### PR TITLE
fix(workflows): fix sync-status, idempotency, and artifact versions

### DIFF
--- a/.github/workflows/bot-ai-review.yml
+++ b/.github/workflows/bot-ai-review.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Download plot metadata
         if: steps.check.outputs.should_run == 'true'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           name: plot-metadata
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/bot-sync-status.yml
+++ b/.github/workflows/bot-sync-status.yml
@@ -55,7 +55,9 @@ jobs:
 
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             PR_NUM="${{ github.event.pull_request.number }}"
-            PR_BODY="${{ github.event.pull_request.body }}"
+
+            # Safely get PR body using gh CLI to avoid shell escaping issues
+            PR_BODY=$(gh pr view "$PR_NUM" --json body -q '.body' 2>/dev/null || echo "")
 
             # Extract parent issue from PR body
             PARENT_NUM=$(echo "$PR_BODY" | grep -oP '\*\*Parent Issue:\*\* #\K\d+' | head -1 || echo "")

--- a/.github/workflows/ci-plottest.yml
+++ b/.github/workflows/ci-plottest.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.python-version }}
           path: test-results/

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -37,7 +37,7 @@ jobs:
         uv run pytest tests/unit -v --tb=short --cov=core --cov=api --cov-report=term-missing --cov-report=xml
 
     - name: Upload coverage to GitHub Artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage.xml

--- a/.github/workflows/gen-new-plot.yml
+++ b/.github/workflows/gen-new-plot.yml
@@ -318,20 +318,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Check if summary already posted
+        id: check_summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if "Generation Complete" comment already exists (idempotency)
+          EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            --jq '[.[] | select(.body | startswith("## Generation Complete"))] | length')
+
+          if [ "$EXISTING" -gt "0" ]; then
+            echo "Summary already posted, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Post summary to main issue
+        if: steps.check_summary.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SPEC_ID="${{ needs.check-conditions.outputs.spec_id }}"
-
-          # Collect results
-          RESULTS=""
-          for LIB in matplotlib seaborn plotly bokeh altair plotnine pygal highcharts; do
-            JOB_NAME="generate-$LIB"
-            # Note: We can't easily get job status in a summary job
-            # The bot-sync-status workflow will update the main issue
-            RESULTS="$RESULTS\n- **$LIB**: Check sub-issue for status"
-          done
 
           # Post summary comment
           gh issue comment ${{ github.event.issue.number }} --body "## Generation Complete

--- a/.github/workflows/gen-preview.yml
+++ b/.github/workflows/gen-preview.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Download test results
         if: steps.check.outputs.should_run == 'true'
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           pattern: test-results-*
           path: all-test-results
@@ -350,7 +350,7 @@ jobs:
 
       - name: Upload metadata artifact
         if: steps.check.outputs.should_run == 'true' && steps.changed_plots.outputs.has_plots == 'true'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v4
         with:
           name: plot-metadata
           path: |


### PR DESCRIPTION
## Summary
- Fix bot-sync-status PR body parsing that caused shell errors
- Add idempotency check to prevent duplicate 'Generation Complete' comments  
- Standardize artifact action versions to v4 for compatibility

## Changes
| File | Fix |
|------|-----|
| `bot-sync-status.yml` | Safely fetch PR body via `gh pr view` instead of direct variable |
| `gen-new-plot.yml` | Check if summary comment exists before posting |
| `bot-ai-review.yml` | download-artifact v6 → v4 |
| `ci-plottest.yml` | upload-artifact v5 → v4 |
| `ci-unittest.yml` | upload-artifact v5 → v4 |
| `gen-preview.yml` | download/upload v5/v6 → v4 |

## Test plan
- [ ] Merge to main
- [ ] Create new simple plot request
- [ ] Verify no duplicate comments
- [ ] Verify status table updates correctly