### PR TITLE
fix(workflows): safe PR body parsing and idempotent summary comments

### DIFF
--- a/.github/workflows/bot-sync-status.yml
+++ b/.github/workflows/bot-sync-status.yml
@@ -55,7 +55,9 @@ jobs:
 
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             PR_NUM="${{ github.event.pull_request.number }}"
-            PR_BODY="${{ github.event.pull_request.body }}"
+
+            # Safely get PR body using gh CLI to avoid shell escaping issues with newlines
+            PR_BODY=$(gh pr view "$PR_NUM" --json body -q '.body' 2>/dev/null || echo "")
 
             # Extract parent issue from PR body
             PARENT_NUM=$(echo "$PR_BODY" | grep -oP '\*\*Parent Issue:\*\* #\K\d+' | head -1 || echo "")

--- a/.github/workflows/gen-new-plot.yml
+++ b/.github/workflows/gen-new-plot.yml
@@ -318,20 +318,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Check if summary already posted
+        id: check_summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if "Generation Complete" comment already exists (idempotency)
+          EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments \
+            --jq '[.[] | select(.body | startswith("## Generation Complete"))] | length')
+
+          if [ "$EXISTING" -gt "0" ]; then
+            echo "Summary already posted, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Post summary to main issue
+        if: steps.check_summary.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           SPEC_ID="${{ needs.check-conditions.outputs.spec_id }}"
-
-          # Collect results
-          RESULTS=""
-          for LIB in matplotlib seaborn plotly bokeh altair plotnine pygal highcharts; do
-            JOB_NAME="generate-$LIB"
-            # Note: We can't easily get job status in a summary job
-            # The bot-sync-status workflow will update the main issue
-            RESULTS="$RESULTS\n- **$LIB**: Check sub-issue for status"
-          done
 
           # Post summary comment
           gh issue comment ${{ github.event.issue.number }} --body "## Generation Complete


### PR DESCRIPTION
## Summary
- Fix bot-sync-status PR body parsing that caused shell errors with newlines
- Add idempotency check to prevent duplicate 'Generation Complete' comments

## Changes
| File | Fix |
|------|-----|
| bot-sync-status.yml | Safely fetch PR body via gh pr view instead of direct variable interpolation |
| gen-new-plot.yml | Check if summary comment exists before posting (prevents duplicates) |

## Root Cause
- The PR_BODY variable syntax breaks when the body contains newlines
- The approved label was added 3 times to issue #53, causing 3 duplicate comments

## Test plan
- Merge to main
- Create new simple plot request
- Verify sync-status works without errors
- Verify no duplicate comments