### PR TITLE
fix(workflows): add id-token permission for validate-request workflow

### DIFF
--- a/.github/workflows/bot-validate-request.yml
+++ b/.github/workflows/bot-validate-request.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Check conditions


### PR DESCRIPTION
## Summary
- Add missing `id-token: write` permission to `bot-validate-request.yml`
- Required for Claude Code action's OIDC authentication

## Test
- Rerun validation on Issue #75 after merge