### PR TITLE
fix(workflows): add id-token permission for gen-library-impl workflow

### DIFF
--- a/.github/workflows/gen-library-impl.yml
+++ b/.github/workflows/gen-library-impl.yml
@@ -54,6 +54,7 @@ jobs:
       pull-requests: write
       issues: write
       actions: read
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Add missing `id-token: write` permission to `gen-library-impl.yml`
- Required for Claude Code action's OIDC authentication

## Test
- Rerun generation on Issue #75 after merge