### PR TITLE
Potential fix for code scanning alert no. 80: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bulk-generate.yml
+++ b/.github/workflows/bulk-generate.yml
@@ -158,6 +158,8 @@ jobs:
     needs: [build-matrix, generate]
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Post summary


### PR DESCRIPTION
Potential fix for [https://github.com/MarkusNeusinger/pyplots/security/code-scanning/80](https://github.com/MarkusNeusinger/pyplots/security/code-scanning/80)

To fix the problem, add an explicit `permissions` block that limits GITHUB_TOKEN rights for jobs that don't currently declare them, starting from least privilege. Since the flagged job `summary` only needs to read workflow context and echo data, it does not need any write scopes and can safely be restricted to read-only repository contents or even no permissions at all. However, using `contents: read` is a common minimal baseline and aligns with the provided recommendation pattern.

Concretely, in `.github/workflows/bulk-generate.yml`, under the `summary` job (lines 157–161), insert a `permissions:` section to restrict the GITHUB_TOKEN. This should not affect existing functionality because `summary` only runs `echo` commands and does not perform any authenticated API calls that require write access. No new imports or dependencies are needed; it is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
