### PR TITLE
Potential fix for code scanning alert no. 79: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bulk-generate.yml
+++ b/.github/workflows/bulk-generate.yml
@@ -107,6 +107,8 @@ jobs:
   preview:
     needs: build-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Preview generation plan


### PR DESCRIPTION
Potential fix for [https://github.com/MarkusNeusinger/pyplots/security/code-scanning/79](https://github.com/MarkusNeusinger/pyplots/security/code-scanning/79)

To fix the problem, explicitly restrict the GITHUB_TOKEN permissions for the `preview` job (and optionally at the workflow root, but the reported issue is on this job). Since `preview` just reads workflow outputs and prints them, it only needs read access to repository contents, and in many cases can even work with `permissions: {}`; however, using `contents: read` is a clear, minimal, and conventional choice.

Concretely, in `.github/workflows/bulk-generate.yml`, within the `preview` job definition starting at line 107 (`preview:`), add a `permissions:` block directly under the existing `needs`/`runs-on` lines, e.g.:

```yaml
preview:
  needs: build-matrix
  runs-on: ubuntu-latest
  permissions:
    contents: read
```

No additional imports, steps, or other definitions are needed; this change merely constrains the default permissions for that job without altering its behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
