### PR TITLE
fix(workflows): add Parent Issue link to implementation PRs

### DIFF
--- a/.github/workflows/bulk-generate.yml
+++ b/.github/workflows/bulk-generate.yml
@@ -155,7 +155,8 @@ jobs:
         run: |
           SPEC_YAML="plots/${{ matrix.specification_id }}/specification.yaml"
           if [ -f "$SPEC_YAML" ]; then
-            ISSUE=$(grep -E "^issue:" "$SPEC_YAML" | awk '{print $2}' | tr -d '\r\n')
+            # Extract issue number using yq for robust YAML parsing
+            ISSUE=$(yq '.issue' "$SPEC_YAML" 2>/dev/null || echo "")
             if [ -n "$ISSUE" ] && [ "$ISSUE" != "null" ]; then
               echo "issue_number=$ISSUE" >> $GITHUB_OUTPUT
               echo "::notice::Found issue #$ISSUE for ${{ matrix.specification_id }}"
@@ -175,15 +176,18 @@ jobs:
         run: |
           echo "Triggering impl-generate.yml for ${{ matrix.specification_id }} / ${{ matrix.library }}"
 
-          # Build workflow run command with optional issue_number
-          CMD="gh workflow run impl-generate.yml --repo ${{ github.repository }}"
-          CMD="$CMD -f specification_id=${{ matrix.specification_id }}"
-          CMD="$CMD -f library=${{ matrix.library }}"
+          # Run workflow with optional issue_number (avoid eval for security)
           if [ -n "$ISSUE" ]; then
-            CMD="$CMD -f issue_number=$ISSUE"
+            gh workflow run impl-generate.yml --repo ${{ github.repository }} \
+              -f specification_id="${{ matrix.specification_id }}" \
+              -f library="${{ matrix.library }}" \
+              -f issue_number="$ISSUE"
+          else
+            gh workflow run impl-generate.yml --repo ${{ github.repository }} \
+              -f specification_id="${{ matrix.specification_id }}" \
+              -f library="${{ matrix.library }}"
           fi
 
-          eval "$CMD"
           echo "::notice::Dispatched impl-generate for ${{ matrix.specification_id }} / ${{ matrix.library }} (issue: ${ISSUE:-none})"
 
   # ============================================================================

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -126,8 +126,8 @@ jobs:
         run: |
           SPEC_YAML="plots/${SPEC_ID}/specification.yaml"
           if [ -f "$SPEC_YAML" ]; then
-            # Extract issue number from specification.yaml
-            ISSUE=$(grep -E "^issue:" "$SPEC_YAML" | awk '{print $2}' | tr -d '\r\n')
+            # Extract issue number using yq for robust YAML parsing
+            ISSUE=$(yq '.issue' "$SPEC_YAML" 2>/dev/null || echo "")
             if [ -n "$ISSUE" ] && [ "$ISSUE" != "null" ]; then
               echo "issue_number=$ISSUE" >> $GITHUB_OUTPUT
               echo "::notice::Found issue #$ISSUE from specification.yaml"


### PR DESCRIPTION
## Summary

Fixes #2841

- Add fallback in `impl-generate.yml` to read issue number from `specification.yaml` when not provided via inputs
- Update `bulk-generate.yml` to read issue number from `specification.yaml` and pass it to `impl-generate.yml`

## Problem

When `impl-generate.yml` creates PRs via `bulk-generate` or `workflow_dispatch` without an `issue_number`, the PR body was missing the `**Parent Issue:** #X` reference. This prevented `impl-merge.yml` from:
- Adding `impl:{library}:done` labels to track progress
- Posting completion comments to the parent issue
- Automatically closing issues when all 9 implementations are complete

## Solution

1. **impl-generate.yml**: Added a new step `Read issue number from specification.yaml (fallback)` that runs when `issue_number` is empty. It reads the `issue:` field from `plots/{spec-id}/specification.yaml`.

2. **bulk-generate.yml**: Now checks out the specification.yaml file (sparse checkout) and reads the issue number before triggering `impl-generate.yml`, passing it as `issue_number` parameter.

## Test plan

- [ ] Manual dispatch of `impl-generate.yml` without `issue_number` should still include Parent Issue in PR body
- [ ] Running `bulk-generate.yml` should pass issue numbers to all triggered workflows
- [ ] PRs should now contain `**Parent Issue:** #X` in their body
- [ ] `impl-merge.yml` should be able to parse the Parent Issue and update labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)