### PR TITLE
ci: add automation folder to coverage reporting

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -96,7 +96,7 @@ jobs:
       run: |
         uv run pytest tests/unit tests/integration tests/e2e \
           -v --tb=short \
-          --cov=core --cov=api \
+          --cov=core --cov=api --cov=automation \
           --cov-report=term-missing \
           --cov-report=xml
       # Tests include:


### PR DESCRIPTION
## Summary

- Add `automation/` to pytest coverage measurement in CI pipeline
- Previously only `core/` and `api/` were tracked

### Change

```diff
- --cov=core --cov=api \
+ --cov=core --cov=api --cov=automation \
```

This enables tracking of test coverage for:
- `automation/generators/plot_generator.py`
- `automation/scripts/sync_to_postgres.py`
- `automation/scripts/workflow_utils.py`
- `automation/scripts/label_manager.py`

## Test plan

- [x] CI workflow syntax is valid
- [ ] Coverage report includes automation/ folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)