### PR TITLE
feat(analytics): server-side Plausible tracking for og:image requests

### DIFF
--- a/api/analytics.py
+++ b/api/analytics.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 PLAUSIBLE_ENDPOINT = "https://plausible.io/api/event"
 DOMAIN = "pyplots.ai"
 
-# All platforms from nginx.conf bot detection (25 total)
+# All platforms from nginx.conf bot detection (27 total)
 PLATFORM_PATTERNS = {
     # Social Media
     "twitter": "twitterbot",
@@ -118,10 +118,13 @@ def track_og_image(
         url = "https://pyplots.ai/"
     elif page == "catalog":
         url = "https://pyplots.ai/catalog"
-    elif library:
+    elif spec is not None and library:
         url = f"https://pyplots.ai/{spec}/{library}"
-    else:
+    elif spec is not None:
         url = f"https://pyplots.ai/{spec}"
+    else:
+        # Fallback: missing spec for a spec-based page
+        url = "https://pyplots.ai/"
 
     props: dict[str, str] = {"page": page, "platform": platform}
     if spec:

--- a/api/routers/og_images.py
+++ b/api/routers/og_images.py
@@ -24,7 +24,10 @@ def _get_static_og_image() -> bytes:
     global _STATIC_OG_IMAGE
     if _STATIC_OG_IMAGE is None:
         path = Path(__file__).parent.parent.parent / "app" / "public" / "og-image.png"
-        _STATIC_OG_IMAGE = path.read_bytes()
+        try:
+            _STATIC_OG_IMAGE = path.read_bytes()
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=500, detail="Static OG image not found") from exc
     return _STATIC_OG_IMAGE
 
 

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -97,7 +97,8 @@ async def seo_home(request: Request):
     Passes query params (e.g., ?lib=plotly&dom=statistics) to og:image URL for tracking.
     """
     # Pass filter params to og:image URL for tracking shared filtered URLs
-    query_string = str(request.query_params) if request.query_params else ""
+    # Use html.escape to prevent XSS via query params
+    query_string = html.escape(str(request.query_params), quote=True) if request.query_params else ""
     image_url = f"{DEFAULT_HOME_IMAGE}?{query_string}" if query_string else DEFAULT_HOME_IMAGE
     page_url = f"https://pyplots.ai/?{query_string}" if query_string else "https://pyplots.ai/"
 

--- a/docs/architecture/plausible.md
+++ b/docs/architecture/plausible.md
@@ -152,7 +152,7 @@ Bot requests page → nginx detects bot → SEO proxy serves HTML with og:image 
 | `library` | Library ID | Only for detail pages |
 | `filter_*` | Filter value | Dynamic props for filtered URLs (e.g., `filter_lib`, `filter_dom`) |
 
-### Platform Detection (25 platforms)
+### Platform Detection (27 platforms)
 
 **Social Media**: twitter, facebook, linkedin, pinterest, reddit, tumblr, mastodon
 

--- a/tests/unit/api/test_analytics.py
+++ b/tests/unit/api/test_analytics.py
@@ -1,0 +1,193 @@
+"""Tests for server-side Plausible analytics tracking."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.analytics import PLATFORM_PATTERNS, detect_platform, track_og_image
+
+
+class TestDetectPlatform:
+    """Tests for platform detection from User-Agent."""
+
+    def test_detects_twitter(self) -> None:
+        """Should detect Twitter bot."""
+        assert detect_platform("Twitterbot/1.0") == "twitter"
+
+    def test_detects_whatsapp(self) -> None:
+        """Should detect WhatsApp."""
+        assert detect_platform("WhatsApp/2.21.4.22") == "whatsapp"
+
+    def test_detects_facebook(self) -> None:
+        """Should detect Facebook."""
+        assert detect_platform("facebookexternalhit/1.1") == "facebook"
+
+    def test_detects_linkedin(self) -> None:
+        """Should detect LinkedIn."""
+        assert detect_platform("LinkedInBot/1.0") == "linkedin"
+
+    def test_detects_slack(self) -> None:
+        """Should detect Slack."""
+        assert detect_platform("Slackbot-LinkExpanding 1.0") == "slack"
+
+    def test_detects_discord(self) -> None:
+        """Should detect Discord."""
+        assert detect_platform("Mozilla/5.0 (compatible; Discordbot/2.0)") == "discord"
+
+    def test_detects_telegram(self) -> None:
+        """Should detect Telegram."""
+        assert detect_platform("TelegramBot/1.0") == "telegram"
+
+    def test_detects_teams(self) -> None:
+        """Should detect Microsoft Teams."""
+        assert detect_platform("Mozilla/5.0 Microsoft Teams") == "teams"
+
+    def test_detects_google(self) -> None:
+        """Should detect Googlebot."""
+        assert detect_platform("Mozilla/5.0 (compatible; Googlebot/2.1)") == "google"
+
+    def test_returns_unknown_for_regular_browser(self) -> None:
+        """Should return unknown for regular browsers."""
+        assert detect_platform("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/91.0") == "unknown"
+
+    def test_returns_unknown_for_empty_string(self) -> None:
+        """Should return unknown for empty User-Agent."""
+        assert detect_platform("") == "unknown"
+
+    def test_case_insensitive(self) -> None:
+        """Should match case-insensitively."""
+        assert detect_platform("TWITTERBOT/1.0") == "twitter"
+        assert detect_platform("twitterbot/1.0") == "twitter"
+
+    def test_all_platforms_have_patterns(self) -> None:
+        """Should have 27 platform patterns defined."""
+        assert len(PLATFORM_PATTERNS) == 27
+
+
+class TestTrackOgImage:
+    """Tests for og:image tracking function."""
+
+    @pytest.fixture
+    def mock_request(self) -> MagicMock:
+        """Create a mock FastAPI request."""
+        request = MagicMock()
+        request.headers = {"user-agent": "Twitterbot/1.0", "x-forwarded-for": "1.2.3.4"}
+        request.client = MagicMock()
+        request.client.host = "127.0.0.1"
+        return request
+
+    def test_creates_async_task(self, mock_request: MagicMock) -> None:
+        """Should create background task without blocking."""
+        with patch("api.analytics.asyncio.create_task") as mock_create_task:
+            track_og_image(mock_request, page="home")
+            mock_create_task.assert_called_once()
+
+    def test_home_page_url(self, mock_request: MagicMock) -> None:
+        """Should build correct URL for home page."""
+        with patch("api.analytics.asyncio.create_task") as mock_create_task:
+            track_og_image(mock_request, page="home")
+            call_args = mock_create_task.call_args[0][0]
+            # The coroutine should be called with home URL
+            assert call_args is not None
+
+    def test_catalog_page_url(self, mock_request: MagicMock) -> None:
+        """Should build correct URL for catalog page."""
+        with patch("api.analytics._send_plausible_event", new_callable=AsyncMock):
+            with patch("api.analytics.asyncio.create_task") as mock_create_task:
+                track_og_image(mock_request, page="catalog")
+                mock_create_task.assert_called_once()
+
+    def test_spec_overview_url(self, mock_request: MagicMock) -> None:
+        """Should build correct URL for spec overview."""
+        with patch("api.analytics.asyncio.create_task"):
+            # Should not raise even with spec_overview page
+            track_og_image(mock_request, page="spec_overview", spec="scatter-basic")
+
+    def test_spec_detail_url(self, mock_request: MagicMock) -> None:
+        """Should build correct URL for spec detail."""
+        with patch("api.analytics.asyncio.create_task"):
+            track_og_image(mock_request, page="spec_detail", spec="scatter-basic", library="matplotlib")
+
+    def test_fallback_url_when_spec_none(self, mock_request: MagicMock) -> None:
+        """Should fallback to home URL when spec is None for spec-based page."""
+        with patch("api.analytics.asyncio.create_task"):
+            # Should not raise - falls back to home URL
+            track_og_image(mock_request, page="spec_overview", spec=None)
+
+    def test_includes_filter_props(self, mock_request: MagicMock) -> None:
+        """Should include filter parameters in props."""
+        with patch("api.analytics.asyncio.create_task"):
+            track_og_image(mock_request, page="home", filters={"lib": "plotly", "dom": "statistics"})
+
+    def test_uses_x_forwarded_for(self) -> None:
+        """Should use X-Forwarded-For header for client IP."""
+        request = MagicMock()
+        request.headers = {"user-agent": "Twitterbot/1.0", "x-forwarded-for": "5.6.7.8"}
+        request.client = None
+
+        with patch("api.analytics.asyncio.create_task"):
+            track_og_image(request, page="home")
+
+    def test_fallback_to_client_host(self) -> None:
+        """Should fallback to client.host when X-Forwarded-For not present."""
+        request = MagicMock()
+        request.headers = {"user-agent": "Twitterbot/1.0"}
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+
+        with patch("api.analytics.asyncio.create_task"):
+            track_og_image(request, page="home")
+
+    def test_handles_missing_client(self) -> None:
+        """Should handle missing client gracefully."""
+        request = MagicMock()
+        request.headers = {"user-agent": "Twitterbot/1.0"}
+        request.client = None
+
+        with patch("api.analytics.asyncio.create_task"):
+            track_og_image(request, page="home")
+
+
+class TestSendPlausibleEvent:
+    """Tests for Plausible API call."""
+
+    @pytest.mark.asyncio
+    async def test_sends_correct_payload(self) -> None:
+        """Should send correct payload to Plausible."""
+        from api.analytics import _send_plausible_event
+
+        with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await _send_plausible_event(
+                user_agent="Twitterbot/1.0",
+                client_ip="1.2.3.4",
+                name="og_image_view",
+                url="https://pyplots.ai/",
+                props={"page": "home", "platform": "twitter"},
+            )
+
+            mock_client.post.assert_called_once()
+            call_kwargs = mock_client.post.call_args[1]
+            assert call_kwargs["json"]["name"] == "og_image_view"
+            assert call_kwargs["json"]["domain"] == "pyplots.ai"
+
+    @pytest.mark.asyncio
+    async def test_handles_network_error(self) -> None:
+        """Should handle network errors gracefully."""
+        from api.analytics import _send_plausible_event
+
+        with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = Exception("Network error")
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            # Should not raise
+            await _send_plausible_event(
+                user_agent="Twitterbot/1.0",
+                client_ip="1.2.3.4",
+                name="og_image_view",
+                url="https://pyplots.ai/",
+                props={},
+            )


### PR DESCRIPTION
## Summary
- Add server-side Plausible tracking for og:image requests from social media bots
- Bots (Twitter, WhatsApp, Teams, etc.) don't execute JavaScript, so server-side tracking is required
- Fire-and-forget pattern ensures no response delay for image generation

## Changes
- **`api/analytics.py`** (NEW): Server-side Plausible tracking module
  - `track_og_image()` with fire-and-forget pattern
  - `detect_platform()` for 25 platforms (social, messaging, search, link preview)
- **`api/routers/og_images.py`**: Add tracking + new endpoints
  - `/og/home.png` with filter param tracking
  - `/og/catalog.png` for catalog page
  - Tracking added to existing spec/impl endpoints
- **`api/routers/seo.py`**: Route og:images through API
  - `DEFAULT_HOME_IMAGE` → `https://api.pyplots.ai/og/home.png`
  - `DEFAULT_CATALOG_IMAGE` → `https://api.pyplots.ai/og/catalog.png`
- **`docs/architecture/plausible.md`**: Document new event and properties

## New Plausible Event
| Event | Properties |
|-------|------------|
| `og_image_view` | `page`, `platform`, `spec`?, `library`?, `filter_*`? |

## Test plan
- [x] All 752 unit tests pass
- [x] Ruff lint and format checks pass
- [ ] Deploy and verify tracking in Plausible dashboard
- [ ] Register new properties in Plausible: `platform`, `filter_lib`, `filter_dom`, etc.
- [ ] Create goal: `og_image_view`

🤖 Generated with [Claude Code](https://claude.com/claude-code)