### PR TITLE
feat(router): add route-level error boundary with chunk-reload recovery

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -31,6 +31,7 @@ export default [
         URL: 'readonly',
         URLSearchParams: 'readonly',
         localStorage: 'readonly',
+        sessionStorage: 'readonly',
         history: 'readonly',
         location: 'readonly',
         requestAnimationFrame: 'readonly',

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -32,6 +32,7 @@ export default [
         URLSearchParams: 'readonly',
         localStorage: 'readonly',
         sessionStorage: 'readonly',
+        Storage: 'readonly',
         history: 'readonly',
         location: 'readonly',
         requestAnimationFrame: 'readonly',

--- a/app/src/components/RouteErrorBoundary.test.tsx
+++ b/app/src/components/RouteErrorBoundary.test.tsx
@@ -125,10 +125,32 @@ describe('RouteErrorBoundary', () => {
     expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
   });
 
-  it('falls back to "Unknown error" when JSON.stringify throws (circular refs)', async () => {
+  it('handles JSON.stringify failures (circular refs) without crashing', async () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     renderWithRouter(circular);
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('renders useful diagnostics for non-404 Response errors', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          errorElement: <RouteErrorBoundary />,
+          loader: () => {
+            throw new Response('Bad', { status: 500, statusText: 'Internal Server Error' });
+          },
+          element: <div>never</div>,
+        },
+      ],
+      { initialEntries: ['/'] }
+    );
+    render(
+      <ThemeProvider theme={theme}>
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    );
     expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
   });
 

--- a/app/src/components/RouteErrorBoundary.test.tsx
+++ b/app/src/components/RouteErrorBoundary.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { RouteErrorBoundary } from './RouteErrorBoundary';
@@ -99,5 +100,49 @@ describe('RouteErrorBoundary', () => {
   it('treats ChunkLoadError messages as chunk errors', async () => {
     renderWithRouter(new Error('ChunkLoadError: Loading chunk 42 failed'));
     await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1));
+  });
+
+  it('reloads the page when the Reload Page button is clicked', async () => {
+    renderWithRouter(new Error('boom'));
+    await screen.findByText('Something went wrong');
+    await userEvent.click(screen.getByRole('button', { name: /reload page/i }));
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles string errors thrown from loaders', async () => {
+    renderWithRouter('plain string error');
+    // Plain strings are not chunk errors; render generic UI.
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+    // In dev mode the raw message is rendered — when present, it shows the string.
+    const devMessage = screen.queryByText('plain string error');
+    if (devMessage) {
+      expect(devMessage).toBeInTheDocument();
+    }
+  });
+
+  it('handles non-Error object values thrown from loaders', async () => {
+    renderWithRouter({ some: 'object' });
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('falls back to "Unknown error" when JSON.stringify throws (circular refs)', async () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    renderWithRouter(circular);
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('detects chunk errors from non-Error objects with a message property', async () => {
+    renderWithRouter({ message: 'Importing a module script failed' });
+    await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1));
+  });
+
+  it('skips the reload-loop guard when sessionStorage throws', async () => {
+    const getSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('sessionStorage unavailable');
+    });
+    renderWithRouter(new Error('Failed to fetch dynamically imported module: /x.js'));
+    await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1));
+    getSpy.mockRestore();
   });
 });

--- a/app/src/components/RouteErrorBoundary.test.tsx
+++ b/app/src/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { RouteErrorBoundary } from './RouteErrorBoundary';
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const theme = createTheme();
+
+function renderWithRouter(thrown: unknown) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        errorElement: <RouteErrorBoundary />,
+        loader: () => {
+          throw thrown;
+        },
+        element: <div>never rendered</div>,
+      },
+    ],
+    { initialEntries: ['/'] }
+  );
+  return render(
+    <ThemeProvider theme={theme}>
+      <RouterProvider router={router} />
+    </ThemeProvider>
+  );
+}
+
+describe('RouteErrorBoundary', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    // Replace window.location so we can spy on reload without jsdom errors.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: vi.fn() },
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('renders generic error UI for unknown errors', async () => {
+    renderWithRouter(new Error('boom'));
+    expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload page/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go home/i })).toBeInTheDocument();
+  });
+
+  it('renders 404 page for route 404 responses', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/',
+          errorElement: <RouteErrorBoundary />,
+          loader: () => {
+            throw new Response('Not Found', { status: 404 });
+          },
+          element: <div>never</div>,
+        },
+      ],
+      { initialEntries: ['/'] }
+    );
+    render(
+      <ThemeProvider theme={theme}>
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    );
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(screen.getByText('page not found')).toBeInTheDocument();
+  });
+
+  it('auto-reloads once on chunk load errors', async () => {
+    renderWithRouter(new Error('Failed to fetch dynamically imported module: https://example.com/x.js'));
+    await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1));
+    expect(sessionStorage.getItem('anyplot:chunk-reload-attempt')).not.toBeNull();
+  });
+
+  it('does not reload loop — shows recovery UI after a prior attempt', async () => {
+    sessionStorage.setItem('anyplot:chunk-reload-attempt', String(Date.now()));
+    renderWithRouter(new Error('Failed to fetch dynamically imported module: https://example.com/x.js'));
+    expect(await screen.findByText('A new version is available')).toBeInTheDocument();
+    expect(window.location.reload).not.toHaveBeenCalled();
+  });
+
+  it('treats ChunkLoadError messages as chunk errors', async () => {
+    renderWithRouter(new Error('ChunkLoadError: Loading chunk 42 failed'));
+    await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1));
+  });
+});

--- a/app/src/components/RouteErrorBoundary.tsx
+++ b/app/src/components/RouteErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Link as RouterLink, isRouteErrorResponse, useRouteError } from 'react-router-dom';
 import { Alert, Box, Button, CircularProgress, Typography } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
@@ -7,16 +7,19 @@ import { NotFoundPage } from '../pages/NotFoundPage';
 
 const RELOAD_ATTEMPT_KEY = 'anyplot:chunk-reload-attempt';
 
+function extractMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    const maybe = (error as { message?: unknown }).message;
+    if (typeof maybe === 'string') return maybe;
+  }
+  return '';
+}
+
 function isChunkLoadError(error: unknown): boolean {
   if (!error) return false;
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === 'string'
-        ? error
-        : typeof (error as { message?: unknown }).message === 'string'
-          ? (error as { message: string }).message
-          : '';
+  const message = extractMessage(error);
   return (
     /Failed to fetch dynamically imported module/i.test(message) ||
     /Importing a module script failed/i.test(message) ||
@@ -28,10 +31,36 @@ function isChunkLoadError(error: unknown): boolean {
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === 'string') return error;
+  // Both raw Response objects and react-router's ErrorResponse wrapper expose
+  // status/statusText — JSON.stringify alone would yield "{}" for a raw Response.
+  if (error instanceof Response || isRouteErrorResponse(error)) {
+    const statusText = (error as { statusText?: string }).statusText;
+    return `${error.status} ${statusText || 'Response'}`.trim();
+  }
+  const fromMessage = extractMessage(error);
+  if (fromMessage) return fromMessage;
   try {
-    return JSON.stringify(error);
+    const json = JSON.stringify(error);
+    if (json && json !== '{}') return json;
   } catch {
-    return 'Unknown error';
+    // fall through to String(error)
+  }
+  return String(error);
+}
+
+function hasAttemptedReload(): boolean {
+  try {
+    return Boolean(sessionStorage.getItem(RELOAD_ATTEMPT_KEY));
+  } catch {
+    return false;
+  }
+}
+
+function markReloadAttempted(): void {
+  try {
+    sessionStorage.setItem(RELOAD_ATTEMPT_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage can throw in private mode; skip the loop guard.
   }
 }
 
@@ -47,29 +76,22 @@ export function RouteErrorBoundary() {
   const error = useRouteError();
   const chunkError = isChunkLoadError(error);
 
-  // Decide once at mount whether to auto-reload. Using a lazy initializer
-  // avoids setState-in-effect and guarantees the reload decision and the
-  // sessionStorage write happen together.
-  const [isReloading] = useState(() => {
-    if (!chunkError) return false;
-    try {
-      if (sessionStorage.getItem(RELOAD_ATTEMPT_KEY)) return false;
-      sessionStorage.setItem(RELOAD_ATTEMPT_KEY, String(Date.now()));
-    } catch {
-      // sessionStorage can throw in private mode; skip the loop guard.
-    }
-    return true;
-  });
+  // Decide whether to auto-reload from pure reads only — the render phase
+  // stays side-effect free. The sessionStorage write and the actual reload
+  // happen in an effect.
+  const shouldAttemptReload = chunkError && !hasAttemptedReload();
 
   useEffect(() => {
-    if (isReloading) window.location.reload();
-  }, [isReloading]);
+    if (!shouldAttemptReload) return;
+    markReloadAttempted();
+    window.location.reload();
+  }, [shouldAttemptReload]);
 
   if (isRouteErrorResponse(error) && error.status === 404) {
     return <NotFoundPage />;
   }
 
-  if (chunkError && isReloading) {
+  if (shouldAttemptReload) {
     return (
       <Box
         sx={{

--- a/app/src/components/RouteErrorBoundary.tsx
+++ b/app/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import { Link as RouterLink, isRouteErrorResponse, useRouteError } from 'react-router-dom';
+import { Alert, Box, Button, CircularProgress, Typography } from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import HomeIcon from '@mui/icons-material/Home';
+import { NotFoundPage } from '../pages/NotFoundPage';
+
+const RELOAD_ATTEMPT_KEY = 'anyplot:chunk-reload-attempt';
+
+function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false;
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : typeof (error as { message?: unknown }).message === 'string'
+          ? (error as { message: string }).message
+          : '';
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /ChunkLoadError/i.test(message)
+  );
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+/**
+ * Route-level error boundary for the React Router data router. Catches errors
+ * thrown from route loaders, actions, lazy imports, and child components.
+ *
+ * Chunk load failures after a deploy are transient — the user's HTML references
+ * old hashed bundles that no longer exist. We reload once automatically to pick
+ * up the fresh bundle, and guard against reload loops with sessionStorage.
+ */
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  const chunkError = isChunkLoadError(error);
+
+  // Decide once at mount whether to auto-reload. Using a lazy initializer
+  // avoids setState-in-effect and guarantees the reload decision and the
+  // sessionStorage write happen together.
+  const [isReloading] = useState(() => {
+    if (!chunkError) return false;
+    try {
+      if (sessionStorage.getItem(RELOAD_ATTEMPT_KEY)) return false;
+      sessionStorage.setItem(RELOAD_ATTEMPT_KEY, String(Date.now()));
+    } catch {
+      // sessionStorage can throw in private mode; skip the loop guard.
+    }
+    return true;
+  });
+
+  useEffect(() => {
+    if (isReloading) window.location.reload();
+  }, [isReloading]);
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <NotFoundPage />;
+  }
+
+  if (chunkError && isReloading) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: '50vh',
+          gap: 2,
+        }}
+      >
+        <CircularProgress size={32} />
+        <Typography variant="body2" color="text.secondary">
+          Loading the latest version…
+        </Typography>
+      </Box>
+    );
+  }
+
+  const title = chunkError ? 'A new version is available' : 'Something went wrong';
+  const body = chunkError
+    ? 'The page could not be loaded because the app has been updated. Reload to get the latest version.'
+    : 'An unexpected error occurred while loading this page.';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '50vh',
+        padding: 4,
+        textAlign: 'center',
+      }}
+    >
+      <Alert severity={chunkError ? 'info' : 'error'} sx={{ maxWidth: 500, width: '100%', mb: 3 }}>
+        <Typography variant="h6" component="div" sx={{ fontWeight: 600, mb: 1 }}>
+          {title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {body}
+        </Typography>
+        {import.meta.env.DEV && (
+          <Typography
+            variant="caption"
+            component="pre"
+            sx={{
+              mt: 2,
+              p: 1,
+              bgcolor: 'grey.100',
+              borderRadius: 1,
+              overflow: 'auto',
+              maxHeight: 120,
+              textAlign: 'left',
+              fontFamily: 'monospace',
+            }}
+          >
+            {errorMessage(error)}
+          </Typography>
+        )}
+      </Alert>
+
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Button
+          variant="contained"
+          startIcon={<RefreshIcon />}
+          onClick={() => window.location.reload()}
+          sx={{ textTransform: 'none' }}
+        >
+          Reload Page
+        </Button>
+        <Button
+          component={RouterLink}
+          to="/"
+          variant="outlined"
+          startIcon={<HomeIcon />}
+          sx={{ textTransform: 'none' }}
+        >
+          Go Home
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -6,6 +6,7 @@ import { AppDataProvider } from './components/Layout';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RootLayout } from './components/RootLayout';
 import { BareLayout } from './components/BareLayout';
+import { RouteErrorBoundary } from './components/RouteErrorBoundary';
 import { NotFoundPage } from './pages/NotFoundPage';
 
 const LazyFallback = () => (
@@ -22,29 +23,42 @@ function SpecLanguageRedirect() {
   return <Navigate to={{ pathname: `/${specId}`, search: `?language=${encodeURIComponent(language)}` }} replace />;
 }
 
+// A pathless child route with errorElement lets us keep the layout chrome
+// (masthead/navbar/footer) when a child page fails to load. Errors in the
+// layout itself still surface via the outer ErrorBoundary wrapping the router.
 const router = createBrowserRouter([
   {
     element: <RootLayout />,
     children: [
-      { index: true, lazy: () => import('./pages/LandingPage').then(m => ({ Component: m.LandingPage })) },
-      { path: 'plots', lazy: () => import('./pages/PlotsPage').then(m => ({ Component: m.PlotsPage })) },
-      { path: 'specs', lazy: () => import('./pages/SpecsListPage').then(m => ({ Component: m.SpecsListPage })) },
-      { path: 'libraries', lazy: () => import('./pages/LibrariesPage').then(m => ({ Component: m.LibrariesPage })) },
-      { path: 'palette', lazy: () => import('./pages/PalettePage').then(m => ({ Component: m.PalettePage })) },
-      { path: 'about', lazy: () => import('./pages/AboutPage').then(m => ({ Component: m.AboutPage })) },
-      { path: 'legal', lazy: () => import('./pages/LegalPage').then(m => ({ Component: m.LegalPage })) },
-      { path: 'mcp', lazy: () => import('./pages/McpPage').then(m => ({ Component: m.McpPage })) },
-      { path: 'stats', lazy: () => import('./pages/StatsPage').then(m => ({ Component: m.StatsPage })) },
-      { path: ':specId', lazy: lazySpec },
-      { path: ':specId/:language', element: <SpecLanguageRedirect /> },
-      { path: ':specId/:language/:library', lazy: lazySpec },
-      { path: '*', element: <NotFoundPage /> },
+      {
+        errorElement: <RouteErrorBoundary />,
+        children: [
+          { index: true, lazy: () => import('./pages/LandingPage').then(m => ({ Component: m.LandingPage })) },
+          { path: 'plots', lazy: () => import('./pages/PlotsPage').then(m => ({ Component: m.PlotsPage })) },
+          { path: 'specs', lazy: () => import('./pages/SpecsListPage').then(m => ({ Component: m.SpecsListPage })) },
+          { path: 'libraries', lazy: () => import('./pages/LibrariesPage').then(m => ({ Component: m.LibrariesPage })) },
+          { path: 'palette', lazy: () => import('./pages/PalettePage').then(m => ({ Component: m.PalettePage })) },
+          { path: 'about', lazy: () => import('./pages/AboutPage').then(m => ({ Component: m.AboutPage })) },
+          { path: 'legal', lazy: () => import('./pages/LegalPage').then(m => ({ Component: m.LegalPage })) },
+          { path: 'mcp', lazy: () => import('./pages/McpPage').then(m => ({ Component: m.McpPage })) },
+          { path: 'stats', lazy: () => import('./pages/StatsPage').then(m => ({ Component: m.StatsPage })) },
+          { path: ':specId', lazy: lazySpec },
+          { path: ':specId/:language', element: <SpecLanguageRedirect /> },
+          { path: ':specId/:language/:library', lazy: lazySpec },
+          { path: '*', element: <NotFoundPage /> },
+        ],
+      },
     ],
   },
   {
     element: <BareLayout />,
     children: [
-      { path: 'debug', lazy: () => import('./pages/DebugPage').then(m => ({ Component: m.DebugPage })) },
+      {
+        errorElement: <RouteErrorBoundary />,
+        children: [
+          { path: 'debug', lazy: () => import('./pages/DebugPage').then(m => ({ Component: m.DebugPage })) },
+        ],
+      },
     ],
   },
 ]);


### PR DESCRIPTION
React Router v7 data routers handle thrown errors internally and fall back to
their default 'Unexpected Application Error!' screen when routes have no
errorElement. The existing <ErrorBoundary> wrapping <RouterProvider> can't
catch those errors, so users who hit a stale hashed chunk after a deploy (e.g.
PlotsPage-BMpApnHc.js 404ing) got a raw error page with no recovery path.

- New RouteErrorBoundary: detects 'Failed to fetch dynamically imported
  module' / ChunkLoadError messages, reloads once (session-scoped guard
  against reload loops), and otherwise shows a friendly error with Reload /
  Go Home. 404 Responses render NotFoundPage.
- Wired as errorElement on pathless child routes under RootLayout and
  BareLayout so the layout chrome is preserved when a child page fails.
- Added sessionStorage to ESLint globals alongside localStorage.