### PR TITLE
feat(analytics,seo): track new landing-page chrome + tighten SEO

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,7 +112,7 @@ Examples: `scatter-basic`, `scatter-color-mapped`, `bar-grouped-horizontal`, `he
   - **`core/database/types.py`**: Custom SQLAlchemy types (PostgreSQL + SQLite compatibility)
   - **`core/database/repositories.py`**: Data access layer
 - **`api/`**: FastAPI backend (routers, schemas, dependencies, cache, analytics, MCP server)
-- **`app/`**: React frontend (React 19 + TypeScript 6 + Vite 8 + MUI 7)
+- **`app/`**: React frontend (React 19 + TypeScript 6 + Vite 8 + MUI 9)
 - **`agentic/`**: AI workflow layer (composable phases, prompt templates, runtime state)
 - **`automation/`**: CI/CD helper scripts (workflow_cli, label_manager, sync_to_postgres)
 - **`tests/unit/`**: Unit tests with mocked dependencies
@@ -213,7 +213,7 @@ plt.savefig('plot.png', dpi=300, bbox_inches='tight')
 ## Tech Stack
 
 - **Backend**: FastAPI, SQLAlchemy (async), PostgreSQL, Python 3.14+
-- **Frontend**: React 19, TypeScript 6, Vite 8, MUI 7
+- **Frontend**: React 19, TypeScript 6, Vite 8, MUI 9
 - **Package Manager**: uv (Python), yarn (Node.js)
 - **Linting**: Ruff (Python), ESLint (TypeScript)
 

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -8,7 +8,7 @@ matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-pl
 
 ## Tech Stack
 - **Backend**: Python 3.14+, FastAPI, SQLAlchemy async, asyncpg, PostgreSQL
-- **Frontend**: React 19, Vite 8, TypeScript 6, MUI 7, Emotion CSS-in-JS
+- **Frontend**: React 19, Vite 8, TypeScript 6, MUI 9, Emotion CSS-in-JS
 - **Package Managers**: uv (Python), yarn (frontend)
 - **Infrastructure**: Google Cloud Run, Cloud SQL, Cloud Storage (GCS)
 - **AI**: Claude (code generation, quality review, spec creation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ For detailed project documentation (architecture, commands, workflows, etc.), se
 
 ## Important Rules
 
-- **Do NOT commit or push in interactive sessions** - When working with a user interactively, never run `git commit` or `git push` automatically. Always let the user review changes and commit/push manually.
+- **Branch-scoped commit/push policy**:
+  - **On `main`**: NEVER commit or push directly. Always work on a feature branch.
+  - **On a feature branch**: Claude MAY run `git commit`, `git push`, and `gh pr create` when the work warrants it. Still respect the project's automated pipelines (see "CRITICAL: Mandatory Workflow" below) — e.g. don't manually merge spec/impl PRs.
+  - Confirm before destructive or hard-to-reverse operations (force-push, reset --hard, branch deletion) regardless of branch.
 - **GitHub Actions workflows ARE allowed to commit/push** - When running as part of `spec-*.yml` or `impl-*.yml` workflows, creating branches, commits, and PRs is expected and required.
 - **Always write in English** - All output text (code comments, commit messages, PR descriptions, issue comments, documentation) must be in English, even if the user writes in another language.
 - **Update documentation when making changes** - When adding new features, events, or modifying behavior, always check if related documentation needs updating (e.g., `docs/reference/plausible.md` for analytics events, `docs/workflows/` for workflow changes, `docs/contributing.md` for user-facing changes).

--- a/agentic/commands/audit.md
+++ b/agentic/commands/audit.md
@@ -159,7 +159,7 @@ You are the **frontend-auditor** on the audit team. Analyze the `app/src/` direc
 - **Hooks**: Custom hook patterns, missing dependency arrays, stale closures, unnecessary re-renders
 - **Performance**: Missing `memo`/`useMemo`/`useCallback` where needed, large bundles, unnecessary renders
 - **Accessibility**: Missing aria-labels, keyboard navigation, focus management, color contrast
-- **MUI 7 patterns**: Correct theme usage, sx prop vs styled, consistent component usage
+- **MUI 9 patterns**: Correct theme usage, sx prop vs styled, consistent component usage
 - **Dead code**: Unused components, unused imports, unreachable code, commented-out code
 - **Error handling**: Error boundaries, loading states, empty states, fallbacks
 - **Consistency**: Naming conventions, file organization, export patterns

--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -174,7 +174,7 @@ Example: `plots/scatter-basic/` contains everything for the basic scatter plot.
   - **`core/database/types.py`**: Custom SQLAlchemy types (PostgreSQL + SQLite compatibility)
   - **`core/database/repositories.py`**: Data access layer
 - **`api/`**: FastAPI backend (routers, schemas, dependencies, cache, analytics, MCP server)
-- **`app/`**: React frontend (Vite 8 + TypeScript 6 + MUI 7)
+- **`app/`**: React frontend (Vite 8 + TypeScript 6 + MUI 9)
 - **`agentic/`**: AI workflow layer (composable phases, prompt templates, runtime state)
   - **`agentic/workflows/`**: Click CLI scripts (plan, build, test, review + orchestrators)
   - **`agentic/commands/`**: Markdown prompt templates
@@ -327,7 +327,7 @@ gs://anyplot-images/
 ## Tech Stack
 
 - **Backend**: FastAPI, SQLAlchemy (async), PostgreSQL, Python 3.14+
-- **Frontend**: React 19, Vite 8, TypeScript 6, MUI 7
+- **Frontend**: React 19, Vite 8, TypeScript 6, MUI 9
 - **Plotting**: matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot
 - **Package Manager**: uv (fast Python installer)
 - **Infrastructure**: Google Cloud Run, Cloud SQL, Cloud Storage

--- a/app/index.html
+++ b/app/index.html
@@ -57,12 +57,7 @@
         "url": "https://www.linkedin.com/in/markus-neusinger/"
       },
       "keywords": ["python", "plotting", "matplotlib", "seaborn", "plotly", "bokeh", "altair", "plotnine", "pygal", "highcharts", "letsplot", "data visualization", "code examples", "colorblind-safe", "okabe-ito"],
-      "isAccessibleForFree": true,
-      "potentialAction": {
-        "@type": "SearchAction",
-        "target": "https://anyplot.ai/plots?focus=search",
-        "query-input": "required name=search_term_string"
-      }
+      "isAccessibleForFree": true
     }
     </script>
 

--- a/app/index.html
+++ b/app/index.html
@@ -4,22 +4,25 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="library-agnostic, ai-powered python plotting." />
-    <meta name="keywords" content="python, plotting, matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot, data visualization, charts, graphs, ai-generated, code examples" />
-    <title>anyplot.ai</title>
+    <meta name="description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries. browse, copy, adapt — colorblind-safe by default." />
+    <meta name="keywords" content="python, plotting, matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot, data visualization, charts, graphs, ai-generated, code examples, colorblind-safe, okabe-ito" />
+    <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0E0E10" media="(prefers-color-scheme: dark)" />
+    <title>any.plot() — any library.</title>
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://anyplot.ai/" />
-    <meta property="og:title" content="anyplot.ai" />
-    <meta property="og:description" content="library-agnostic, ai-powered python plotting." />
+    <meta property="og:title" content="any.plot() — any library." />
+    <meta property="og:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries." />
     <meta property="og:image" content="https://anyplot.ai/og-image.png" />
     <meta property="og:site_name" content="anyplot.ai" />
+    <meta property="og:locale" content="en_US" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="anyplot.ai" />
-    <meta name="twitter:description" content="library-agnostic, ai-powered python plotting." />
+    <meta name="twitter:title" content="any.plot() — any library." />
+    <meta name="twitter:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries." />
     <meta name="twitter:image" content="https://anyplot.ai/og-image.png" />
     <!-- Preconnect to GCS for font loading -->
     <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
@@ -40,7 +43,7 @@
       "@type": "WebApplication",
       "name": "anyplot.ai",
       "url": "https://anyplot.ai",
-      "description": "library-agnostic, ai-powered python plotting.",
+      "description": "the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Any",
       "offers": {
@@ -53,8 +56,13 @@
         "name": "Markus Neusinger",
         "url": "https://www.linkedin.com/in/markus-neusinger/"
       },
-      "keywords": ["python", "plotting", "matplotlib", "seaborn", "plotly", "bokeh", "altair", "plotnine", "pygal", "highcharts", "letsplot", "data visualization", "code examples"],
-      "isAccessibleForFree": true
+      "keywords": ["python", "plotting", "matplotlib", "seaborn", "plotly", "bokeh", "altair", "plotnine", "pygal", "highcharts", "letsplot", "data visualization", "code examples", "colorblind-safe", "okabe-ito"],
+      "isAccessibleForFree": true,
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://anyplot.ai/plots?focus=search",
+        "query-input": "required name=search_term_string"
+      }
     }
     </script>
 

--- a/app/src/analytics/reportWebVitals.test.ts
+++ b/app/src/analytics/reportWebVitals.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { reportWebVitals } from './reportWebVitals';
+import { setAnalyticsAmbientProps } from '../hooks/useAnalytics';
+
+// Single hoisted mock (vi.mock dedupes by module path — last call wins, so
+// keeping one shared mock avoids cross-test interference).
+vi.mock('web-vitals', () => ({
+  onLCP: (cb: (m: { value: number; rating: string }) => void) => cb({ value: 2500, rating: 'good' }),
+  onCLS: (cb: (m: { value: number; rating: string }) => void) => cb({ value: 0.15, rating: 'needs-improvement' }),
+  onINP: (cb: (m: { value: number; rating: string }) => void) => cb({ value: 200, rating: 'good' }),
+}));
 
 describe('reportWebVitals', () => {
   const originalLocation = window.location;
@@ -11,6 +20,7 @@ describe('reportWebVitals', () => {
       configurable: true,
     });
     delete window.plausible;
+    setAnalyticsAmbientProps({ theme: '' });
   });
 
   it('does nothing in non-production environment', () => {
@@ -44,16 +54,7 @@ describe('reportWebVitals', () => {
     });
     window.plausible = vi.fn();
 
-    // Mock the dynamic import
-    vi.mock('web-vitals', () => ({
-      onLCP: (cb: (m: { value: number; rating: string }) => void) => cb({ value: 2500, rating: 'good' }),
-      onCLS: (cb: (m: { value: number; rating: string }) => void) => cb({ value: 0.15, rating: 'needs-improvement' }),
-      onINP: (cb: (m: { value: number; rating: string }) => void) => cb({ value: 200, rating: 'good' }),
-    }));
-
     reportWebVitals();
-
-    // Wait for dynamic import to resolve
     await vi.dynamicImportSettled();
 
     expect(window.plausible).toHaveBeenCalledWith('LCP', {
@@ -65,7 +66,28 @@ describe('reportWebVitals', () => {
     expect(window.plausible).toHaveBeenCalledWith('INP', {
       props: { value: '200', rating: 'good' },
     });
+  });
 
-    vi.restoreAllMocks();
+  it('merges ambient analytics props (e.g. theme) into CWV events', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, hostname: 'anyplot.ai' },
+      writable: true,
+      configurable: true,
+    });
+    window.plausible = vi.fn();
+    setAnalyticsAmbientProps({ theme: 'dark' });
+
+    reportWebVitals();
+    await vi.dynamicImportSettled();
+
+    expect(window.plausible).toHaveBeenCalledWith('LCP', {
+      props: { theme: 'dark', value: '2500', rating: 'good' },
+    });
+    expect(window.plausible).toHaveBeenCalledWith('CLS', {
+      props: { theme: 'dark', value: '0.15', rating: 'needs-improvement' },
+    });
+    expect(window.plausible).toHaveBeenCalledWith('INP', {
+      props: { theme: 'dark', value: '200', rating: 'good' },
+    });
   });
 });

--- a/app/src/analytics/reportWebVitals.ts
+++ b/app/src/analytics/reportWebVitals.ts
@@ -1,3 +1,5 @@
+import { getAnalyticsAmbientProps } from '../hooks/useAnalytics';
+
 /**
  * Core Web Vitals tracking via web-vitals library.
  * Reports LCP, CLS, and INP to Plausible as custom events.
@@ -15,6 +17,7 @@ export function reportWebVitals() {
     onLCP((metric) => {
       window.plausible?.('LCP', {
         props: {
+          ...getAnalyticsAmbientProps(),
           value: String(Math.round(metric.value / 100) * 100),
           rating: metric.rating,
         },
@@ -24,6 +27,7 @@ export function reportWebVitals() {
     onCLS((metric) => {
       window.plausible?.('CLS', {
         props: {
+          ...getAnalyticsAmbientProps(),
           value: String(Math.round(metric.value * 100) / 100),
           rating: metric.rating,
         },
@@ -33,6 +37,7 @@ export function reportWebVitals() {
     onINP((metric) => {
       window.plausible?.('INP', {
         props: {
+          ...getAnalyticsAmbientProps(),
           value: String(Math.round(metric.value / 50) * 50),
           rating: metric.rating,
         },

--- a/app/src/components/HeroSection.test.tsx
+++ b/app/src/components/HeroSection.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+
+const trackEvent = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
+  };
+});
+
+vi.mock('./PlotOfTheDayTerminal', () => ({
+  PlotOfTheDayTerminal: () => <div data-testid="potd-terminal" />,
+}));
+
+vi.mock('./TypewriterText', () => ({
+  TypewriterText: () => <div data-testid="typewriter" />,
+}));
+
+import { HeroSection } from './HeroSection';
+
+describe('HeroSection', () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it('tracks the primary browse CTA, mcp link and github link', async () => {
+    const user = userEvent.setup();
+    render(<HeroSection potd={null} />);
+
+    await user.click(screen.getByLabelText('Browse plots'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'hero_cta_browse', target: '/plots' });
+
+    await user.click(screen.getByLabelText('Connect via MCP'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'hero_mcp', target: '/mcp' });
+
+    await user.click(screen.getByLabelText('Clone on GitHub'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'hero_github', target: 'github' });
+  });
+});

--- a/app/src/components/HeroSection.tsx
+++ b/app/src/components/HeroSection.tsx
@@ -5,6 +5,7 @@ import { colors, typography } from '../theme';
 import { TypewriterText } from './TypewriterText';
 import { PlotOfTheDayTerminal } from './PlotOfTheDayTerminal';
 import type { PlotOfTheDayData } from '../hooks/usePlotOfTheDay';
+import { useAnalytics } from '../hooks';
 
 interface HeroSectionProps {
   potd?: PlotOfTheDayData | null;
@@ -17,6 +18,7 @@ interface HeroSectionProps {
  * page reads as one continuous grid.
  */
 export function HeroSection({ potd = null }: HeroSectionProps) {
+  const { trackEvent } = useAnalytics();
   return (
     <Box
       sx={{
@@ -165,7 +167,13 @@ export function HeroSection({ potd = null }: HeroSectionProps) {
             animation: 'rise 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0.3s backwards',
           }}
         >
-          <PrimaryCta to="/plots" subject="plots" verb="browse" ariaLabel="Browse plots" />
+          <PrimaryCta
+            to="/plots"
+            subject="plots"
+            verb="browse"
+            ariaLabel="Browse plots"
+            onClick={() => trackEvent('nav_click', { source: 'hero_cta_browse', target: '/plots' })}
+          />
           <Box
             aria-hidden="true"
             sx={{
@@ -178,8 +186,21 @@ export function HeroSection({ potd = null }: HeroSectionProps) {
             |
           </Box>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
-            <SecondaryLink to="/mcp" subject="mcp" verb="connect" ariaLabel="Connect via MCP" />
-            <SecondaryLink href="https://github.com/MarkusNeusinger/anyplot" subject="github" verb="clone" ariaLabel="Clone on GitHub" external />
+            <SecondaryLink
+              to="/mcp"
+              subject="mcp"
+              verb="connect"
+              ariaLabel="Connect via MCP"
+              onClick={() => trackEvent('nav_click', { source: 'hero_mcp', target: '/mcp' })}
+            />
+            <SecondaryLink
+              href="https://github.com/MarkusNeusinger/anyplot"
+              subject="github"
+              verb="clone"
+              ariaLabel="Clone on GitHub"
+              external
+              onClick={() => trackEvent('nav_click', { source: 'hero_github', target: 'github' })}
+            />
           </Box>
         </Box>
 
@@ -194,11 +215,12 @@ export function HeroSection({ potd = null }: HeroSectionProps) {
   );
 }
 
-function PrimaryCta({ to, subject, verb, ariaLabel }: { to: string; subject: string; verb: string; ariaLabel: string }) {
+function PrimaryCta({ to, subject, verb, ariaLabel, onClick }: { to: string; subject: string; verb: string; ariaLabel: string; onClick?: () => void }) {
   return (
     <Box
       component={RouterLink}
       to={to}
+      onClick={onClick}
       aria-label={ariaLabel}
       sx={{
         textDecoration: 'none',
@@ -235,6 +257,7 @@ function SecondaryLink({
   verb,
   ariaLabel,
   external,
+  onClick,
 }: {
   to?: string;
   href?: string;
@@ -242,6 +265,7 @@ function SecondaryLink({
   verb: string;
   ariaLabel: string;
   external?: boolean;
+  onClick?: () => void;
 }) {
   const linkProps = external
     ? { component: 'a' as const, href, target: '_blank', rel: 'noopener noreferrer' }
@@ -250,6 +274,7 @@ function SecondaryLink({
   return (
     <Box
       {...linkProps}
+      onClick={onClick}
       aria-label={ariaLabel}
       sx={{
         textDecoration: 'none',

--- a/app/src/components/MastheadRule.test.tsx
+++ b/app/src/components/MastheadRule.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+
+const trackEvent = vi.fn();
+const toggle = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
+    useTheme: () => ({ isDark: false, toggle }),
+    useLatestRelease: () => 'v1.2.3',
+  };
+});
+
+import { MastheadRule } from './MastheadRule';
+
+describe('MastheadRule', () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+    toggle.mockClear();
+  });
+
+  it('fires theme_toggle event before invoking the underlying toggle', async () => {
+    const user = userEvent.setup();
+    render(<MastheadRule />);
+
+    await user.click(screen.getByLabelText('Switch to dark theme'));
+    expect(trackEvent).toHaveBeenCalledWith('theme_toggle', { to: 'dark' });
+    expect(toggle).toHaveBeenCalled();
+  });
+
+  it('tracks nav_click on the masthead logo, branch, and release links', async () => {
+    const user = userEvent.setup();
+    render(<MastheadRule />);
+
+    await user.click(screen.getByText('~/anyplot.ai'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'masthead_logo', target: '/' });
+
+    await user.click(screen.getByText('main'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'masthead_branch', target: 'github_main' });
+
+    await user.click(screen.getByText('v1.2.3'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'masthead_release', target: 'v1.2.3' });
+  });
+});

--- a/app/src/components/MastheadRule.tsx
+++ b/app/src/components/MastheadRule.tsx
@@ -3,7 +3,7 @@ import { Link as RouterLink, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import { typography, colors } from '../theme';
 import { ThemeToggle } from './ThemeToggle';
-import { useTheme, useLatestRelease } from '../hooks';
+import { useTheme, useLatestRelease, useAnalytics } from '../hooks';
 import { RESERVED_TOP_LEVEL } from '../utils/paths';
 
 // Symmetric block-comment delimiters used when no language context is in the URL.
@@ -102,11 +102,17 @@ function pathSegments(pathname: string): Segment[] {
  */
 export function MastheadRule() {
   const { isDark, toggle } = useTheme();
+  const { trackEvent } = useAnalytics();
   const releaseTag = useLatestRelease();
   const location = useLocation();
   const segments = pathSegments(location.pathname);
   const isLanding = segments.length === 0;
   const version = releaseTag ?? 'v1.0';
+
+  const handleThemeToggle = () => {
+    trackEvent('theme_toggle', { to: isDark ? 'light' : 'dark' });
+    toggle();
+  };
 
   // Pick one random comment style per browser session (stable across client-side nav).
   const [randomIdx] = useState(() => Math.floor(Math.random() * COMMENT_POOL.length));
@@ -156,14 +162,26 @@ export function MastheadRule() {
         textOverflow: 'ellipsis',
       }}>
         {/* Always-visible root marker */}
-        <Box component={RouterLink} to="/" sx={linkSx}>
+        <Box
+          component={RouterLink}
+          to="/"
+          onClick={() => trackEvent('nav_click', { source: 'masthead_logo', target: '/' })}
+          sx={linkSx}
+        >
           ~/anyplot.ai
         </Box>
 
         {isLanding ? (
           <>
             {' · '}
-            <Box component="a" href={`${REPO_URL}/tree/main`} target="_blank" rel="noopener noreferrer" sx={linkSx}>
+            <Box
+              component="a"
+              href={`${REPO_URL}/tree/main`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => trackEvent('nav_click', { source: 'masthead_branch', target: 'github_main' })}
+              sx={linkSx}
+            >
               main
             </Box>
             {' · '}
@@ -172,6 +190,7 @@ export function MastheadRule() {
               href={releaseTag ? `${REPO_URL}/releases/tag/${releaseTag}` : `${REPO_URL}/releases`}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackEvent('nav_click', { source: 'masthead_release', target: version })}
               sx={linkSx}
             >
               {version}
@@ -182,7 +201,12 @@ export function MastheadRule() {
             <Box key={`${seg.label}-${i}`} component="span">
               {' · '}
               {seg.to ? (
-                <Box component={RouterLink} to={seg.to} sx={linkSx}>
+                <Box
+                  component={RouterLink}
+                  to={seg.to}
+                  onClick={() => trackEvent('nav_click', { source: 'breadcrumb', target: seg.to })}
+                  sx={linkSx}
+                >
                   {seg.label}
                 </Box>
               ) : (
@@ -210,7 +234,7 @@ export function MastheadRule() {
         display: 'flex',
         justifyContent: 'flex-end',
       }}>
-        <ThemeToggle isDark={isDark} onToggle={toggle} />
+        <ThemeToggle isDark={isDark} onToggle={handleThemeToggle} />
       </Box>
     </Box>
   );

--- a/app/src/components/NavBar.test.tsx
+++ b/app/src/components/NavBar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+
+const trackEvent = vi.fn();
+const navigate = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
+  };
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+import { NavBar } from './NavBar';
+
+describe('NavBar', () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+    navigate.mockClear();
+  });
+
+  it('tracks nav_click on each menu link', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<NavBar />);
+
+    // The labels render twice (full + short variant, CSS-hidden); we click the
+    // anchor itself via href to avoid the duplicate-text ambiguity.
+    await user.click(container.querySelector('a[href="/plots"]')!);
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'nav_plots', target: '/plots' });
+
+    await user.click(container.querySelector('a[href="/specs"]')!);
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'nav_specs', target: '/specs' });
+  });
+
+  it('tracks nav_click on the logo', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<NavBar />);
+
+    await user.click(container.querySelector('a[href="/"]')!);
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'nav_logo', target: '/' });
+  });
+
+  it('tracks nav_click and navigates on the search button', async () => {
+    const user = userEvent.setup();
+    render(<NavBar />);
+
+    await user.click(screen.getByLabelText('Search plots'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', {
+      source: 'nav_search',
+      target: '/plots?focus=search',
+    });
+    expect(navigate).toHaveBeenCalledWith('/plots?focus=search');
+  });
+});

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -76,6 +76,7 @@ export function NavBar() {
   // Non-triggering clicks fall through to RouterLink's normal `/` navigation.
   const handleLogoClick = useCallback(
     (e: React.MouseEvent) => {
+      trackEvent('nav_click', { source: 'nav_logo', target: '/' });
       if (e.ctrlKey || e.metaKey || e.shiftKey || e.button !== 0) return;
       clickCountRef.current += 1;
       if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
@@ -85,9 +86,7 @@ export function NavBar() {
         clickCountRef.current = 0;
         if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
         navigate('/debug');
-        return;
       }
-      trackEvent('nav_click', { source: 'nav_logo', target: '/' });
     },
     [navigate, trackEvent]
   );

--- a/app/src/components/NavBar.tsx
+++ b/app/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import { colors, typography } from '../theme';
+import { useAnalytics } from '../hooks';
 
 const DEBUG_CLICK_COUNT = 5;
 const DEBUG_CLICK_WINDOW_MS = 800;
@@ -56,6 +57,7 @@ const activeLinkSx = {
 export function NavBar() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { trackEvent } = useAnalytics();
   const clickCountRef = useRef(0);
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -66,6 +68,7 @@ export function NavBar() {
   }, []);
 
   const handleSearch = () => {
+    trackEvent('nav_click', { source: 'nav_search', target: '/plots?focus=search' });
     navigate('/plots?focus=search');
   };
 
@@ -82,9 +85,11 @@ export function NavBar() {
         clickCountRef.current = 0;
         if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
         navigate('/debug');
+        return;
       }
+      trackEvent('nav_click', { source: 'nav_logo', target: '/' });
     },
-    [navigate]
+    [navigate, trackEvent]
   );
 
   return (
@@ -140,6 +145,7 @@ export function NavBar() {
             <Box
               component={RouterLink}
               to={link.to}
+              onClick={() => trackEvent('nav_click', { source: `nav_${link.label}`, target: link.to })}
               sx={location.pathname === link.to ? activeLinkSx : linkSx}
             >
               {/* Full label on ≥md, short label on smaller screens where it saves room */}

--- a/app/src/components/PlotOfTheDay.test.tsx
+++ b/app/src/components/PlotOfTheDay.test.tsx
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '../test-utils';
+
+const trackEvent = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
+  };
+});
+
 import { PlotOfTheDay } from './PlotOfTheDay';
 
 // Mock sessionStorage
@@ -38,6 +49,7 @@ describe('PlotOfTheDay', () => {
     vi.stubGlobal('sessionStorage', sessionStorageStub);
     sessionStorageStub.getItem.mockClear();
     sessionStorageStub.setItem.mockClear();
+    trackEvent.mockClear();
   });
 
   afterEach(() => {
@@ -142,6 +154,29 @@ describe('PlotOfTheDay', () => {
     // After dismiss, component should return null
     expect(container.firstChild).toBeNull();
     expect(sessionStorageStub.setItem).toHaveBeenCalledWith('potd_dismissed', 'true');
+    expect(trackEvent).toHaveBeenCalledWith('potd_dismiss', expect.objectContaining({ spec: 'scatter-basic', library: 'matplotlib' }));
+  });
+
+  it('tracks nav_click when the image, title and source link are clicked', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const { userEvent } = await import('../test-utils');
+    const user = userEvent.setup();
+
+    render(<PlotOfTheDay />);
+
+    await waitFor(() => {
+      expect(screen.getByText('plot of the day')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Basic Scatter Plot'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_title' }));
+
+    await user.click(screen.getByText(/python plots\/scatter-basic\/matplotlib\.py/));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_source_link' }));
   });
 
   it('hides library version when it is "unknown"', async () => {

--- a/app/src/components/PlotOfTheDay.tsx
+++ b/app/src/components/PlotOfTheDay.tsx
@@ -12,6 +12,7 @@ import { colors, typography, fontSize, semanticColors } from '../theme';
 import { buildSrcSet, getFallbackSrc } from '../utils/responsiveImage';
 import { selectPreviewUrl } from '../utils/themedPreview';
 import { useTheme } from '../hooks/useLayoutContext';
+import { useAnalytics } from '../hooks';
 import { specPath } from '../utils/paths';
 
 interface PlotOfTheDayData {
@@ -38,6 +39,7 @@ export function PlotOfTheDay() {
   const [loading, setLoading] = useState(true);
   const [dismissed, setDismissed] = useState(() => window.sessionStorage.getItem('potd_dismissed') === 'true');
   const { isDark } = useTheme();
+  const { trackEvent } = useAnalytics();
   const previewUrl = selectPreviewUrl(data, isDark);
 
   useEffect(() => {
@@ -51,9 +53,10 @@ export function PlotOfTheDay() {
 
   const handleDismiss = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
+    trackEvent('potd_dismiss', { spec: data?.spec_id, library: data?.library_id });
     setDismissed(true);
     window.sessionStorage.setItem('potd_dismissed', 'true');
-  }, []);
+  }, [trackEvent, data]);
 
   // Already dismissed — no space needed (user saw page before)
   if (dismissed) return null;
@@ -102,7 +105,10 @@ export function PlotOfTheDay() {
             href={`${GITHUB_URL}/blob/main/plots/${data.spec_id}/implementations/${data.library_id}.py`}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={(e: React.MouseEvent) => e.stopPropagation()}
+            onClick={(e: React.MouseEvent) => {
+              e.stopPropagation();
+              trackEvent('nav_click', { source: 'potd_source_link', target: 'github', spec: data.spec_id, library: data.library_id });
+            }}
             sx={{
               fontFamily: mono, fontSize: fontSize.xxs, color: semanticColors.mutedText,
               flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
@@ -134,6 +140,7 @@ export function PlotOfTheDay() {
           <Link
             component={RouterLink}
             to={specPath(data.spec_id, data.language, data.library_id)}
+            onClick={() => trackEvent('nav_click', { source: 'potd_image', target: 'spec_detail', spec: data.spec_id, library: data.library_id })}
             sx={{
               display: 'block',
               textDecoration: 'none',
@@ -190,6 +197,7 @@ export function PlotOfTheDay() {
             <Link
               component={RouterLink}
               to={specPath(data.spec_id, data.language, data.library_id)}
+              onClick={() => trackEvent('nav_click', { source: 'potd_title', target: 'spec_detail', spec: data.spec_id, library: data.library_id })}
               sx={{
                 textDecoration: 'none',
                 color: 'var(--ink)',

--- a/app/src/components/PlotOfTheDayTerminal.test.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+
+const trackEvent = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
+  };
+});
+
+vi.mock('../hooks/useLayoutContext', async () => {
+  const actual = await vi.importActual<typeof import('../hooks/useLayoutContext')>('../hooks/useLayoutContext');
+  return { ...actual, useTheme: () => ({ isDark: false, toggle: vi.fn() }) };
+});
+
+import { PlotOfTheDayTerminal } from './PlotOfTheDayTerminal';
+
+const potd = {
+  spec_id: 'scatter-basic',
+  spec_title: 'Basic Scatter',
+  description: null,
+  library_id: 'matplotlib',
+  library_name: 'Matplotlib',
+  language: 'python',
+  quality_score: 9,
+  preview_url: 'https://cdn.example.com/plot.png',
+  preview_url_light: null,
+  preview_url_dark: null,
+  image_description: null,
+  library_version: '3.8.0',
+  python_version: '3.12',
+  date: '2026-04-25',
+};
+
+describe('PlotOfTheDayTerminal', () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it('renders nothing without potd data', () => {
+    const { container } = render(<PlotOfTheDayTerminal potd={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('tracks nav_click on filename, github link and image', async () => {
+    const user = userEvent.setup();
+    render(<PlotOfTheDayTerminal potd={potd} />);
+
+    await user.click(screen.getByText(/plots\/scatter-basic\/matplotlib\.py/));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_terminal_filename' }));
+
+    await user.click(screen.getByLabelText('Open source on GitHub'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_terminal_github' }));
+
+    await user.click(screen.getByLabelText(/Open Basic Scatter implementation/));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_terminal_image' }));
+  });
+});

--- a/app/src/components/PlotOfTheDayTerminal.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.tsx
@@ -6,6 +6,7 @@ import { colors, typography } from '../theme';
 import { buildSrcSet, getFallbackSrc } from '../utils/responsiveImage';
 import { selectPreviewUrl } from '../utils/themedPreview';
 import { useTheme } from '../hooks/useLayoutContext';
+import { useAnalytics } from '../hooks';
 import { specPath } from '../utils/paths';
 import type { PlotOfTheDayData } from '../hooks/usePlotOfTheDay';
 
@@ -37,6 +38,7 @@ export function PlotOfTheDayTerminal({
   maxPlotHeight = '55vh',
 }: PlotOfTheDayTerminalProps) {
   const { isDark } = useTheme();
+  const { trackEvent } = useAnalytics();
   const previewUrl = selectPreviewUrl(potd, isDark);
   if (!potd || !previewUrl) return null;
 
@@ -89,6 +91,7 @@ export function PlotOfTheDayTerminal({
           href={githubFileUrl}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() => trackEvent('nav_click', { source: 'potd_terminal_filename', target: 'github', spec: potd.spec_id, library: potd.library_id })}
           sx={{
             flex: 1,
             minWidth: 0,
@@ -112,6 +115,7 @@ export function PlotOfTheDayTerminal({
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Open source on GitHub"
+          onClick={() => trackEvent('nav_click', { source: 'potd_terminal_github', target: 'github', spec: potd.spec_id, library: potd.library_id })}
           sx={{
             color: 'inherit',
             textDecoration: 'none',
@@ -131,6 +135,7 @@ export function PlotOfTheDayTerminal({
         component={RouterLink}
         to={implPath}
         aria-label={`Open ${potd.spec_title} implementation for ${potd.library_name}`}
+        onClick={() => trackEvent('nav_click', { source: 'potd_terminal_image', target: 'spec_detail', spec: potd.spec_id, library: potd.library_id })}
         sx={{
           display: 'block',
           mx: 'auto',

--- a/app/src/components/RootLayout.test.tsx
+++ b/app/src/components/RootLayout.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '../test-utils';
+import { Routes, Route } from 'react-router-dom';
+
+const { setAmbient } = vi.hoisted(() => ({ setAmbient: vi.fn() }));
+
+vi.mock('../hooks/useAnalytics', async () => {
+  const actual = await vi.importActual<typeof import('../hooks/useAnalytics')>('../hooks/useAnalytics');
+  return {
+    ...actual,
+    setAnalyticsAmbientProps: setAmbient,
+  };
+});
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent: vi.fn(), trackPageview: vi.fn() }),
+    useLatestRelease: () => null,
+  };
+});
+
+vi.mock('../hooks/useLayoutContext', async () => {
+  const actual = await vi.importActual<typeof import('../hooks/useLayoutContext')>('../hooks/useLayoutContext');
+  return { ...actual, useTheme: () => ({ isDark: true, toggle: vi.fn() }) };
+});
+
+vi.mock('./MastheadRule', () => ({
+  MastheadRule: () => <div data-testid="masthead" />,
+}));
+vi.mock('./NavBar', () => ({ NavBar: () => <div data-testid="nav" /> }));
+vi.mock('./Footer', () => ({ Footer: () => <div data-testid="footer" /> }));
+
+import { RootLayout } from './RootLayout';
+
+describe('RootLayout', () => {
+  beforeEach(() => {
+    setAmbient.mockClear();
+  });
+
+  it('synchronously sets the theme ambient prop on render', () => {
+    render(
+      <Routes>
+        <Route element={<RootLayout />}>
+          <Route index element={<div>home</div>} />
+        </Route>
+      </Routes>
+    );
+
+    expect(setAmbient).toHaveBeenCalledWith({ theme: 'dark' });
+  });
+});

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -1,8 +1,11 @@
+import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 
 import { useAnalytics } from '../hooks';
+import { setAnalyticsAmbientProps } from '../hooks/useAnalytics';
+import { useTheme } from '../hooks/useLayoutContext';
 import { MastheadRule } from './MastheadRule';
 import { NavBar } from './NavBar';
 import { Footer } from './Footer';
@@ -23,7 +26,12 @@ const containerSx = {
 export function RootLayout() {
   const { trackEvent } = useAnalytics();
   const { pathname } = useLocation();
+  const { isDark } = useTheme();
   const mastheadSticks = pathname !== '/plots';
+
+  useEffect(() => {
+    setAnalyticsAmbientProps({ theme: isDark ? 'dark' : 'light' });
+  }, [isDark]);
 
   return (
     <Box sx={{

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
@@ -29,9 +28,10 @@ export function RootLayout() {
   const { isDark } = useTheme();
   const mastheadSticks = pathname !== '/plots';
 
-  useEffect(() => {
-    setAnalyticsAmbientProps({ theme: isDark ? 'dark' : 'light' });
-  }, [isDark]);
+  // Set synchronously during render so the first pageview from a child page's
+  // useEffect (which runs before the parent's useEffect) carries the theme prop.
+  // setAnalyticsAmbientProps merges into module state, so re-renders are safe.
+  setAnalyticsAmbientProps({ theme: isDark ? 'dark' : 'light' });
 
   return (
     <Box sx={{

--- a/app/src/components/SectionHeader.test.tsx
+++ b/app/src/components/SectionHeader.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+
+const trackEvent = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
+  };
+});
+
+import { SectionHeader } from './SectionHeader';
+
+describe('SectionHeader', () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+  });
+
+  it('renders the title and prompt', () => {
+    render(<SectionHeader prompt="❯" title="libraries" />);
+    expect(screen.getByText('❯')).toBeInTheDocument();
+    expect(screen.getByText('libraries')).toBeInTheDocument();
+  });
+
+  it('tracks nav_click when the action link is clicked', async () => {
+    const user = userEvent.setup();
+    render(<SectionHeader prompt="❯" title="specs" linkText="specs.all()" linkTo="/specs" />);
+
+    await user.click(screen.getByText('specs.all()'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'section_header', target: '/specs' });
+  });
+});

--- a/app/src/components/SectionHeader.tsx
+++ b/app/src/components/SectionHeader.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box';
 import { Link } from 'react-router-dom';
 import { colors, typography } from '../theme';
+import { useAnalytics } from '../hooks';
 
 interface SectionHeaderProps {
   /** Prefix symbol — e.g. `§`, `❯`, `$`. Rendered at the same size as the title. */
@@ -13,6 +14,7 @@ interface SectionHeaderProps {
 const titleFontSize = { xs: '1.5rem', sm: '1.875rem', md: 'clamp(1.875rem, 3.5vw, 2.5rem)' };
 
 export function SectionHeader({ prompt, title, linkText, linkTo }: SectionHeaderProps) {
+  const { trackEvent } = useAnalytics();
   return (
     <Box sx={{
       display: 'grid',
@@ -55,6 +57,7 @@ export function SectionHeader({ prompt, title, linkText, linkTo }: SectionHeader
         <Box
           component={Link}
           to={linkTo}
+          onClick={() => trackEvent('nav_click', { source: 'section_header', target: linkTo })}
           sx={{
             fontFamily: typography.mono,
             fontSize: '12px',

--- a/app/src/hooks/useAnalytics.test.ts
+++ b/app/src/hooks/useAnalytics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useAnalytics } from './useAnalytics';
+import { useAnalytics, setAnalyticsAmbientProps } from './useAnalytics';
 
 describe('useAnalytics', () => {
   const originalLocation = window.location;
@@ -8,6 +8,8 @@ describe('useAnalytics', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     window.plausible = vi.fn();
+    // Reset module-level ambient props between tests so each starts clean.
+    setAnalyticsAmbientProps({ theme: '' });
   });
 
   afterEach(() => {
@@ -166,6 +168,101 @@ describe('useAnalytics', () => {
 
       // The call should have gone through with buildPlausibleUrl(), not the invalid URL
       expect(window.plausible).toHaveBeenCalled();
+    });
+  });
+
+  describe('ambient props', () => {
+    function setHostname(hostname: string) {
+      Object.defineProperty(window, 'location', {
+        value: { ...originalLocation, hostname, search: '' },
+        writable: true,
+        configurable: true,
+      });
+    }
+
+    it('attaches ambient props to custom events', () => {
+      setHostname('anyplot.ai');
+      setAnalyticsAmbientProps({ theme: 'dark' });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackEvent('nav_click', { source: 'nav_logo' });
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('nav_click', {
+        props: { theme: 'dark', source: 'nav_logo' },
+      });
+    });
+
+    it('attaches ambient props to events fired without explicit props', () => {
+      setHostname('anyplot.ai');
+      setAnalyticsAmbientProps({ theme: 'light' });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackEvent('suggest_spec');
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('suggest_spec', {
+        props: { theme: 'light' },
+      });
+    });
+
+    it('attaches ambient props to pageviews', () => {
+      setHostname('anyplot.ai');
+      setAnalyticsAmbientProps({ theme: 'dark' });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackPageview('/specs');
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('pageview', {
+        url: 'https://anyplot.ai/specs',
+        props: { theme: 'dark' },
+      });
+    });
+
+    it('omits the props key when no ambient props are set', () => {
+      setHostname('anyplot.ai');
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackPageview('/about');
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('pageview', {
+        url: 'https://anyplot.ai/about',
+      });
+    });
+
+    it('event-level props override ambient values for the same key', () => {
+      setHostname('anyplot.ai');
+      setAnalyticsAmbientProps({ theme: 'dark' });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackEvent('theme_toggle', { theme: 'light' });
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('theme_toggle', {
+        props: { theme: 'light' },
+      });
+    });
+
+    it('clears a key when set to empty string', () => {
+      setHostname('anyplot.ai');
+      setAnalyticsAmbientProps({ theme: 'dark' });
+      setAnalyticsAmbientProps({ theme: '' });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackEvent('search_no_results');
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('search_no_results', undefined);
     });
   });
 });

--- a/app/src/hooks/useAnalytics.ts
+++ b/app/src/hooks/useAnalytics.ts
@@ -7,11 +7,16 @@ interface EventProps {
 
 // Module-level ambient props attached to every pageview and custom event.
 // Set by the layout once theme/locale-style values are known so we don't have
-// to thread them through every component that fires an event.
+// to thread them through every component that fires an event. Empty-string
+// values clear the key (so callers can effectively reset a prop).
 let ambientProps: Record<string, string> = {};
 
 export function setAnalyticsAmbientProps(props: Record<string, string>): void {
-  ambientProps = { ...ambientProps, ...props };
+  const merged: Record<string, string> = { ...ambientProps, ...props };
+  for (const key of Object.keys(merged)) {
+    if (!merged[key]) delete merged[key];
+  }
+  ambientProps = merged;
 }
 
 function debounce<T extends (...args: never[]) => void>(

--- a/app/src/hooks/useAnalytics.ts
+++ b/app/src/hooks/useAnalytics.ts
@@ -5,6 +5,15 @@ interface EventProps {
   [key: string]: string | undefined;
 }
 
+// Module-level ambient props attached to every pageview and custom event.
+// Set by the layout once theme/locale-style values are known so we don't have
+// to thread them through every component that fires an event.
+let ambientProps: Record<string, string> = {};
+
+export function setAnalyticsAmbientProps(props: Record<string, string>): void {
+  ambientProps = { ...ambientProps, ...props };
+}
+
 function debounce<T extends (...args: never[]) => void>(
   fn: T,
   delay: number,
@@ -90,7 +99,8 @@ export function useAnalytics() {
       if (url === lastPageviewRef.current) return;
       lastPageviewRef.current = url;
 
-      window.plausible?.("pageview", { url });
+      const props = Object.keys(ambientProps).length > 0 ? { ...ambientProps } : undefined;
+      window.plausible?.("pageview", props ? { url, props } : { url });
     },
     [isProduction],
   );
@@ -107,12 +117,11 @@ export function useAnalytics() {
         ? Object.fromEntries(
             Object.entries(props).filter(([, v]) => v !== undefined),
           )
-        : undefined;
+        : {};
+      const merged = { ...ambientProps, ...cleanProps } as Record<string, string>;
       window.plausible?.(
         name,
-        cleanProps
-          ? { props: cleanProps as Record<string, string> }
-          : undefined,
+        Object.keys(merged).length > 0 ? { props: merged } : undefined,
       );
     },
     [isProduction],

--- a/app/src/hooks/useAnalytics.ts
+++ b/app/src/hooks/useAnalytics.ts
@@ -19,6 +19,12 @@ export function setAnalyticsAmbientProps(props: Record<string, string>): void {
   ambientProps = merged;
 }
 
+// Snapshot of current ambient props for callers that fire `window.plausible`
+// directly (e.g. reportWebVitals.ts, which runs outside React).
+export function getAnalyticsAmbientProps(): Record<string, string> {
+  return { ...ambientProps };
+}
+
 function debounce<T extends (...args: never[]) => void>(
   fn: T,
   delay: number,

--- a/app/src/pages/LandingPage.test.tsx
+++ b/app/src/pages/LandingPage.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+
+const trackEvent = vi.fn();
+const trackPageview = vi.fn();
+const navigate = vi.fn();
+
+vi.mock('../hooks', async () => {
+  const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
+  return {
+    ...actual,
+    useAnalytics: () => ({ trackEvent, trackPageview }),
+    useAppData: () => ({
+      specsData: [],
+      librariesData: [{ id: 'matplotlib', name: 'matplotlib' }],
+      stats: { specs: 100, plots: 900, libraries: 9, lines_of_code: 50000 },
+    }),
+  };
+});
+
+vi.mock('../hooks/useFeaturedSpecs', () => ({
+  useFeaturedSpecs: () => [
+    {
+      spec_id: 'scatter-basic',
+      spec_title: 'Basic Scatter',
+      spec_description: 'A scatter plot',
+      library_id: 'matplotlib',
+      preview_url: 'https://cdn.example.com/scatter.png',
+      preview_url_light: null,
+      preview_url_dark: null,
+    },
+  ],
+}));
+
+vi.mock('../hooks/usePlotOfTheDay', () => ({
+  usePlotOfTheDay: () => null,
+}));
+
+vi.mock('../hooks/useLayoutContext', async () => {
+  const actual = await vi.importActual<typeof import('../hooks/useLayoutContext')>('../hooks/useLayoutContext');
+  return { ...actual, useTheme: () => ({ isDark: false, toggle: vi.fn() }) };
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock('../components/HeroSection', () => ({
+  HeroSection: () => <div data-testid="hero" />,
+}));
+
+vi.mock('../components/NumbersStrip', () => ({
+  NumbersStrip: () => <div data-testid="numbers" />,
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => <div data-testid="helmet">{children}</div>,
+}));
+
+import { LandingPage } from './LandingPage';
+
+describe('LandingPage', () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+    trackPageview.mockClear();
+    navigate.mockClear();
+  });
+
+  it('fires a pageview for / on mount', () => {
+    render(<LandingPage />);
+    expect(trackPageview).toHaveBeenCalledWith('/');
+  });
+
+  it('tracks library card clicks and navigates', async () => {
+    const user = userEvent.setup();
+    render(<LandingPage />);
+
+    await user.click(screen.getByText('matplotlib'));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', {
+      source: 'library_card',
+      target: '/plots',
+      value: 'matplotlib',
+    });
+    expect(navigate).toHaveBeenCalledWith('/plots?lib=matplotlib');
+  });
+
+  it('tracks featured thumb clicks', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<LandingPage />);
+
+    const thumb = container.querySelector('a[href="/scatter-basic"]');
+    expect(thumb).toBeTruthy();
+    await user.click(thumb!);
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'featured_thumb', target: 'spec_hub', spec: 'scatter-basic' }));
+  });
+
+  it('tracks the "more in catalogue" link', async () => {
+    const user = userEvent.setup();
+    render(<LandingPage />);
+
+    const more = screen.getByText(/more in the catalogue/);
+    await user.click(more);
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'specs_more_link', target: '/specs' });
+  });
+
+  it('tracks the suggest_spec link and the okabe-ito reference', async () => {
+    const user = userEvent.setup();
+    render(<LandingPage />);
+
+    await user.click(screen.getByText(/suggest/));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'suggest_spec_link' }));
+
+    await user.click(screen.getByText(/Okabe/));
+    expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'palette_okabe_ito' }));
+  });
+});

--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -6,7 +6,7 @@ import { HeroSection } from '../components/HeroSection';
 import { NumbersStrip } from '../components/NumbersStrip';
 import { LibrariesSection } from '../components/LibrariesSection';
 import { SectionHeader } from '../components/SectionHeader';
-import { useAppData } from '../hooks';
+import { useAppData, useAnalytics } from '../hooks';
 import { usePlotOfTheDay } from '../hooks/usePlotOfTheDay';
 import { useFeaturedSpecs, type FeaturedImpl } from '../hooks/useFeaturedSpecs';
 import { useTheme } from '../hooks/useLayoutContext';
@@ -21,6 +21,12 @@ export function LandingPage() {
   const potd = usePlotOfTheDay();
   const featured = useFeaturedSpecs(5);
   const navigate = useNavigate();
+  const { trackEvent } = useAnalytics();
+
+  const handleLibraryClick = (lib: string) => {
+    trackEvent('nav_click', { source: 'library_card', target: '/plots', value: lib });
+    navigate(`/plots?lib=${encodeURIComponent(lib)}`);
+  };
 
   return (
     <>
@@ -52,7 +58,7 @@ export function LandingPage() {
 
       <LibrariesSection
         libraries={librariesData}
-        onLibraryClick={(lib) => navigate(`/plots?lib=${encodeURIComponent(lib)}`)}
+        onLibraryClick={handleLibraryClick}
         widthTier="catalog"
       />
 
@@ -66,6 +72,7 @@ export function LandingPage() {
  * the left, labelled palette strip on the right.
  */
 function PaletteSection() {
+  const { trackEvent } = useAnalytics();
   return (
     <Box sx={{ py: { xs: 2, md: 3 } }}>
       <SectionHeader prompt="❯" title={<em>palette</em>} linkText="palette.explore()" linkTo="/palette" />
@@ -95,6 +102,7 @@ function PaletteSection() {
               href="https://jfly.uni-koeln.de/color/"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackEvent('nav_click', { source: 'palette_okabe_ito', target: 'jfly_uni_koeln' })}
               sx={{
                 color: 'var(--ink)',
                 textDecoration: 'none',
@@ -202,6 +210,7 @@ function LabelledPaletteStrip() {
  * specs become.
  */
 function SpecsSection({ specCount, featured }: { specCount?: number; featured: FeaturedImpl[] | null }) {
+  const { trackEvent } = useAnalytics();
   return (
     <Box sx={{ py: { xs: 2, md: 3 } }}>
       <SectionHeader prompt="❯" title={<em>specifications</em>} linkText="specs.all()" linkTo="/specs" />
@@ -232,6 +241,7 @@ function SpecsSection({ specCount, featured }: { specCount?: number; featured: F
             subject="spec"
             verb="suggest"
             external
+            source="suggest_spec_link"
           />
         </Box>
       </Box>
@@ -241,6 +251,7 @@ function SpecsSection({ specCount, featured }: { specCount?: number; featured: F
         <Box
           component={RouterLink}
           to="/specs"
+          onClick={() => trackEvent('nav_click', { source: 'specs_more_link', target: '/specs' })}
           sx={{
             display: 'inline-block',
             mt: 2.5,
@@ -291,6 +302,7 @@ interface MethodLinkProps {
   subject: string;
   verb: string;
   external?: boolean;
+  source?: string;
 }
 
 /**
@@ -298,7 +310,11 @@ interface MethodLinkProps {
  * rendered muted (opacity 0.7), `.verb()` at the link's current colour.
  * Whole element turns primary-green on hover; subject brightens to full.
  */
-function MethodLink({ to, href, subject, verb, external }: MethodLinkProps) {
+function MethodLink({ to, href, subject, verb, external, source }: MethodLinkProps) {
+  const { trackEvent } = useAnalytics();
+  const handleClick = source
+    ? () => trackEvent('nav_click', { source, target: href ?? to ?? '' })
+    : undefined;
   const sx = {
     fontFamily: typography.mono,
     fontSize: '13px',
@@ -327,6 +343,7 @@ function MethodLink({ to, href, subject, verb, external }: MethodLinkProps) {
         href={href}
         target={external ? '_blank' : undefined}
         rel={external ? 'noopener noreferrer' : undefined}
+        onClick={handleClick}
         sx={sx}
       >
         {content}
@@ -334,7 +351,7 @@ function MethodLink({ to, href, subject, verb, external }: MethodLinkProps) {
     );
   }
   return (
-    <Box component={RouterLink} to={to ?? '#'} sx={sx}>
+    <Box component={RouterLink} to={to ?? '#'} onClick={handleClick} sx={sx}>
       {content}
     </Box>
   );
@@ -348,6 +365,7 @@ function MethodLink({ to, href, subject, verb, external }: MethodLinkProps) {
  */
 function FeaturedThumb({ item }: { item: FeaturedImpl | null }) {
   const { isDark } = useTheme();
+  const { trackEvent } = useAnalytics();
   const previewUrl = selectPreviewUrl(item, isDark);
   const cardSx = {
     display: 'flex',
@@ -430,7 +448,12 @@ function FeaturedThumb({ item }: { item: FeaturedImpl | null }) {
   }
 
   return (
-    <Box component={RouterLink} to={specPath(item.spec_id)} sx={cardSx}>
+    <Box
+      component={RouterLink}
+      to={specPath(item.spec_id)}
+      onClick={() => trackEvent('nav_click', { source: 'featured_thumb', target: 'spec_hub', spec: item.spec_id, library: item.library_id })}
+      sx={cardSx}
+    >
       <Box sx={imageSx}>
         <Box component="picture" key={previewUrl} sx={{ display: 'block', width: '100%', height: '100%' }}>
           <source type="image/webp" srcSet={buildSrcSet(previewUrl, 'webp')} sizes="(max-width: 599px) 50vw, 25vw" />

--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import Box from '@mui/material/Box';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
@@ -21,7 +22,11 @@ export function LandingPage() {
   const potd = usePlotOfTheDay();
   const featured = useFeaturedSpecs(5);
   const navigate = useNavigate();
-  const { trackEvent } = useAnalytics();
+  const { trackEvent, trackPageview } = useAnalytics();
+
+  useEffect(() => {
+    trackPageview('/');
+  }, [trackPageview]);
 
   const handleLibraryClick = (lib: string) => {
     trackEvent('nav_click', { source: 'library_card', target: '/plots', value: lib });

--- a/app/src/pages/LegalPage.tsx
+++ b/app/src/pages/LegalPage.tsx
@@ -126,9 +126,11 @@ export function LegalPage() {
               </Link>
               , a privacy-focused analytics tool. it collects no personal data, uses no cookies, and does
               not track you across websites. we track: page views, navigation patterns, code copies, image
-              downloads, search queries, filter usage, and UI interactions. when you share a link, we detect
-              which platform requests the preview (e.g., LinkedIn, WhatsApp). all data is aggregated and
-              anonymous.
+              downloads, search queries, filter usage, UI interactions (tab toggles, theme preference,
+              banner dismissals), and anonymized performance metrics (Core Web Vitals: LCP, CLS, INP) to
+              keep the site fast. when you share a link, we read the requesting bot&apos;s user-agent to
+              detect the platform (e.g., LinkedIn, WhatsApp) — no data about the eventual viewer is
+              collected at that step. all data is aggregated and anonymous.
             </Typography>
             <Typography sx={textStyle}>
               <strong>public dashboard.</strong> our analytics are{' '}

--- a/app/src/pages/PalettePage.tsx
+++ b/app/src/pages/PalettePage.tsx
@@ -32,6 +32,7 @@ export function PalettePage() {
       <Helmet>
         <title>palette | anyplot.ai</title>
         <meta name="description" content="the Okabe-Ito colorblind-safe palette used across all anyplot.ai visualizations. 8 colors, validated for deuteranopia, protanopia, and tritanopia." />
+        <link rel="canonical" href="https://anyplot.ai/palette" />
       </Helmet>
 
       <Box sx={{ pb: 4 }}>

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -354,7 +354,7 @@ export function SpecPage() {
         {currentImpl?.preview_url && <meta property="og:image" content={currentImpl.preview_url} />}
         <meta property="og:url" content={canonical} />
         <link rel="canonical" href={canonical} />
-        <script type="application/ld+json">{JSON.stringify(breadcrumbJsonLd)}</script>
+        <script type="application/ld+json">{JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')}</script>
       </Helmet>
 
       <Box sx={{ pt: 1.5, pb: 4 }}>

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -324,6 +324,26 @@ export function SpecPage() {
       ? specData.implementations.filter((i) => i.language === languageFilter)
       : specData.implementations;
 
+  const breadcrumbItems: { name: string; item: string }[] = [
+    { name: 'anyplot', item: 'https://anyplot.ai/' },
+    { name: 'specs', item: 'https://anyplot.ai/specs' },
+    { name: specData.title, item: `https://anyplot.ai/${specId}` },
+  ];
+  if (mode === 'detail' && urlLanguage && selectedLibrary) {
+    breadcrumbItems.push({ name: urlLanguage, item: `https://anyplot.ai/${specId}/${urlLanguage}` });
+    breadcrumbItems.push({ name: selectedLibrary, item: canonical });
+  }
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbItems.map((b, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: b.name,
+      item: b.item,
+    })),
+  };
+
   return (
     <>
       <Helmet>
@@ -334,6 +354,7 @@ export function SpecPage() {
         {currentImpl?.preview_url && <meta property="og:image" content={currentImpl.preview_url} />}
         <meta property="og:url" content={canonical} />
         <link rel="canonical" href={canonical} />
+        <script type="application/ld+json">{JSON.stringify(breadcrumbJsonLd)}</script>
       </Helmet>
 
       <Box sx={{ pt: 1.5, pb: 4 }}>

--- a/app/src/pages/StatsPage.tsx
+++ b/app/src/pages/StatsPage.tsx
@@ -126,6 +126,7 @@ export function StatsPage() {
       <Helmet>
         <title>stats | anyplot.ai</title>
         <meta name="description" content="Platform statistics for anyplot.ai — plot counts, quality scores, library coverage, and more." />
+        <link rel="canonical" href="https://anyplot.ai/stats" />
       </Helmet>
 
       <Box sx={{ pt: { xs: 2, md: 3 }, pb: 4 }}>

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -431,7 +431,7 @@ User lands on anyplot.ai
 | `tag_click` | `param`, `value`, `source` | SpecTabs.tsx |
 | `plot_rotate` | `spec` | SpecsListPage.tsx |
 | `open_interactive` | `spec`, `library` | SpecOverview.tsx, SpecDetailView.tsx |
-| `suggest_spec` | - | CatalogPage.tsx |
+| `suggest_spec` | - | SpecsListPage.tsx (LandingPage mirror attributed via `nav_click` with `source: suggest_spec_link`) |
 | `report_issue` | `spec`, `library`? | SpecPage.tsx |
 | `external_link` | `destination`, `spec`?, `library`? | Footer.tsx, LegalPage.tsx |
 | `internal_link` | `destination`, `spec`, `library` | Footer.tsx |

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -127,7 +127,7 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `tab_toggle` | `action`, `tab`, `library` | SpecTabs.tsx | User opens or closes a tab |
 | `plot_rotate` | `spec` | SpecsListPage.tsx | User clicks image on specs page to rotate library |
 | `open_interactive` | `spec`, `library` | SpecOverview.tsx, SpecDetailView.tsx | User opens interactive HTML view |
-| `suggest_spec` | - | LandingPage.tsx (legacy) | User clicks "suggest spec" link — superseded by `nav_click` with `source: suggest_spec_link` |
+| `suggest_spec` | - | SpecsListPage.tsx | User clicks the `spec.suggest()` link on the specs list page. The mirror link on the landing page emits `nav_click` with `source: suggest_spec_link` instead. |
 | `report_issue` | `spec`, `library`? | SpecPage.tsx | User clicks "report issue" link |
 | `tag_click` | `param`, `value`, `source` | SpecTabs.tsx | User clicks a tag chip to filter |
 | `theme_toggle` | `to` | MastheadRule.tsx | User toggles dark/light mode (`to` ∈ `dark`, `light`) |

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -127,9 +127,36 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `tab_toggle` | `action`, `tab`, `library` | SpecTabs.tsx | User opens or closes a tab |
 | `plot_rotate` | `spec` | SpecsListPage.tsx | User clicks image on specs page to rotate library |
 | `open_interactive` | `spec`, `library` | SpecOverview.tsx, SpecDetailView.tsx | User opens interactive HTML view |
-| `suggest_spec` | - | CatalogPage.tsx | User clicks "suggest spec" link |
+| `suggest_spec` | - | LandingPage.tsx (legacy) | User clicks "suggest spec" link — superseded by `nav_click` with `source: suggest_spec_link` |
 | `report_issue` | `spec`, `library`? | SpecPage.tsx | User clicks "report issue" link |
 | `tag_click` | `param`, `value`, `source` | SpecTabs.tsx | User clicks a tag chip to filter |
+| `theme_toggle` | `to` | MastheadRule.tsx | User toggles dark/light mode (`to` ∈ `dark`, `light`) |
+| `potd_dismiss` | `spec`, `library` | PlotOfTheDay.tsx | User dismisses the plot-of-the-day banner |
+
+### Landing Page Navigation (`nav_click`)
+
+A single event captures every clickable surface on the chrome and the new
+editorial landing page so we can answer "where do users go from `/` and via
+which UI element". One event, one event-property pair: `source` (which UI
+element was clicked) + `target` (where it leads). Some sources additionally
+carry `spec`, `library`, or `value` for richer breakdowns.
+
+| `source` value | Where | Target |
+|----------------|-------|--------|
+| `nav_specs` / `nav_plots` / `nav_libraries` / `nav_stats` / `nav_palette` / `nav_mcp` | NavBar.tsx | top-level menu bar |
+| `nav_logo` | NavBar.tsx | logo → `/` |
+| `nav_search` | NavBar.tsx | `plots.search()` button → `/plots?focus=search` |
+| `masthead_logo` / `masthead_branch` / `masthead_release` | MastheadRule.tsx | masthead `~/anyplot.ai · main · v1.x.x` |
+| `breadcrumb` | MastheadRule.tsx | breadcrumb segments on non-landing routes |
+| `hero_cta_browse` / `hero_mcp` / `hero_github` | HeroSection.tsx | hero call-to-action + secondary links |
+| `potd_image` / `potd_title` / `potd_source_link` | PlotOfTheDay.tsx | dismissible plot-of-the-day banner |
+| `potd_terminal_image` / `potd_terminal_filename` / `potd_terminal_github` | PlotOfTheDayTerminal.tsx | hero terminal-framed POTD |
+| `featured_thumb` | LandingPage.tsx | featured plot grid |
+| `library_card` | LandingPage.tsx | library cards (carries `value=<library_id>`) |
+| `section_header` | SectionHeader.tsx | `specs.all()` / `libraries.all()` / `palette.explore()` headers |
+| `specs_more_link` | LandingPage.tsx | `+ N more in the catalogue →` |
+| `suggest_spec_link` | LandingPage.tsx | `spec.suggest()` GitHub-issue link |
+| `palette_okabe_ito` | LandingPage.tsx | external Okabe & Ito reference |
 
 **Random methods**:
 - `click`: Shuffle icon clicked
@@ -278,7 +305,10 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | `action` | Toggle action (open, close) | `tab_toggle` |
 | `size` | Grid size (normal, compact) | `grid_resize` |
 | `param` | URL parameter name for tag | `tag_click` |
-| `source` | Source page context | `tag_click` |
+| `source` | Source UI element / page context | `tag_click`, `nav_click` |
+| `target` | Click destination (route or external label) | `nav_click` |
+| `to` | New mode after toggle (`dark` / `light`) | `theme_toggle` |
+| `theme` | Ambient theme prop attached to **every** pageview & event (`dark` / `light`) | all events (set in RootLayout via `setAnalyticsAmbientProps`) |
 | `rating` | CWV rating (good, needs-improvement, poor) | `LCP`, `CLS`, `INP` |
 | `filter_lib` | Library filter value (for og:image) | `og_image_view` |
 | `filter_spec` | Specification filter value (for og:image) | `og_image_view` |
@@ -315,6 +345,9 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | `report_issue` | Custom Event | Track issue report clicks |
 | `tag_click` | Custom Event | Track tag filter clicks |
 | `plot_rotate` | Custom Event | Track plot image rotation on specs page |
+| `nav_click` | Custom Event | Track which UI element on landing/chrome leads users off the root |
+| `theme_toggle` | Custom Event | Track dark/light theme switches |
+| `potd_dismiss` | Custom Event | Track plot-of-the-day banner dismissals |
 | `og_image_view` | Custom Event | Track og:image requests from social media bots |
 | `LCP` | Custom Event | Largest Contentful Paint (Core Web Vital) |
 | `CLS` | Custom Event | Cumulative Layout Shift (Core Web Vital) |
@@ -402,12 +435,20 @@ User lands on anyplot.ai
 | `report_issue` | `spec`, `library`? | SpecPage.tsx |
 | `external_link` | `destination`, `spec`?, `library`? | Footer.tsx, LegalPage.tsx |
 | `internal_link` | `destination`, `spec`, `library` | Footer.tsx |
+| `nav_click` | `source`, `target`, `spec`?, `library`?, `value`? | NavBar, MastheadRule, HeroSection, SectionHeader, PlotOfTheDay, PlotOfTheDayTerminal, LandingPage |
+| `theme_toggle` | `to` | MastheadRule.tsx |
+| `potd_dismiss` | `spec`, `library` | PlotOfTheDay.tsx |
 | `LCP` | `value`, `rating` | reportWebVitals.ts |
 | `CLS` | `value`, `rating` | reportWebVitals.ts |
 | `INP` | `value`, `rating` | reportWebVitals.ts |
 | `og_image_view` | `page`, `platform`, `spec`?, `language`?, `library`?, `filter_*`? | api/analytics.py (server-side) |
 
-**Total: 19 client-side + 1 server-side = 20 events**
+**Total: 22 client-side + 1 server-side = 23 events**
+
+> Every pageview and event additionally carries a `theme` ambient prop (`dark` /
+> `light`). Set in `RootLayout` via `setAnalyticsAmbientProps` whenever the user
+> toggles the theme — register `theme` as a custom property to see the
+> dark-vs-light split per URL.
 
 ---
 
@@ -554,6 +595,9 @@ window.plausible = function(...args) { console.log('Plausible:', args); };
 - [x] Plot rotation (`plot_rotate`)
 - [x] Core Web Vitals tracking (`LCP`, `CLS`, `INP`)
 - [x] Server-side og:image tracking (`og_image_view`) with platform detection
+- [x] Landing-page navigation tracking (`nav_click`)
+- [x] Theme tracking (`theme_toggle` event + `theme` ambient pageview prop)
+- [x] Plot-of-the-day dismissal (`potd_dismiss`)
 
 ### Plausible Dashboard Checklist
 
@@ -564,5 +608,5 @@ window.plausible = function(...args) { console.log('Plausible:', args); };
 
 ---
 
-**Last Updated**: 2026-03-10
-**Status**: Production-ready with full journey tracking, Core Web Vitals, and server-side og:image analytics
+**Last Updated**: 2026-04-25
+**Status**: Production-ready with full journey tracking, Core Web Vitals, server-side og:image analytics, landing-page nav tracking, and theme analytics


### PR DESCRIPTION
Tracking gaps after the editorial-design switch left the entire landing
chrome (NavBar, MastheadRule, HeroSection, PlotOfTheDay, featured grid,
library cards, palette section) ungtracked. Adds a single `nav_click`
event keyed by `source` + `target` so we can answer "where do users go
from `/` and via which UI element". Adds `theme_toggle` event and a
`theme` ambient prop attached to every pageview/event so dark-vs-light
usage is finally measurable. Adds `potd_dismiss` for plot-of-the-day.

SEO: refresh index.html title/description/og to match the new editorial
positioning, add `theme-color` per color-scheme, `og:locale`, a
SearchAction in the JSON-LD, BreadcrumbList JSON-LD on spec pages, and
canonicals on /stats and /palette.

plausible.md is updated to reflect the new event surface and the
ambient `theme` prop registration requirement.