### PR TITLE
style(code-view): paper aesthetic in light mode, brand green comments, fix overflow

### DIFF
--- a/app/src/components/CodeHighlighter.tsx
+++ b/app/src/components/CodeHighlighter.tsx
@@ -4,41 +4,43 @@ import { typography } from '../theme';
 
 SyntaxHighlighter.registerLanguage('python', python);
 
-// Custom dark theme using Okabe-Ito palette colors
-const okabeItoDark: Record<string, React.CSSProperties> = {
+// Theme-aware Okabe-Ito syntax theme. All colors come from CSS variables in
+// tokens.css so the block adapts to light (paper) and dark modes. Comments
+// use the brand green as a deliberate editorial accent.
+const okabeItoTheme: Record<string, React.CSSProperties> = {
   'pre[class*="language-"]': {
-    color: '#E8E8E0',
+    color: 'var(--code-text)',
     background: 'var(--code-bg)',
   },
   'code[class*="language-"]': {
-    color: '#E8E8E0',
+    color: 'var(--code-text)',
     background: 'none',
   },
-  comment: { color: '#666', fontStyle: 'italic' },
-  prolog: { color: '#666' },
-  doctype: { color: '#666' },
-  cdata: { color: '#666' },
-  keyword: { color: '#56B4E9' },       // sky blue
-  builtin: { color: '#56B4E9' },
-  operator: { color: '#E8E8E0' },
-  string: { color: '#009E73' },        // green
-  'attr-value': { color: '#009E73' },
-  'template-string': { color: '#009E73' },
-  function: { color: '#E69F00' },      // orange
-  'function-variable': { color: '#E69F00' },
-  'class-name': { color: '#E69F00' },
-  number: { color: '#F0E442' },        // yellow
-  boolean: { color: '#F0E442' },
-  variable: { color: '#CC79A7' },      // purple
-  property: { color: '#CC79A7' },
-  constant: { color: '#D55E00' },      // vermillion
-  decorator: { color: '#D55E00' },
-  punctuation: { color: '#8A8A82' },
-  selector: { color: '#009E73' },
-  tag: { color: '#D55E00' },
-  'attr-name': { color: '#E69F00' },
-  regex: { color: '#009E73' },
-  important: { color: '#D55E00', fontWeight: 'bold' },
+  comment: { color: 'var(--code-comment)', fontStyle: 'italic' },
+  prolog: { color: 'var(--code-comment)', fontStyle: 'italic' },
+  doctype: { color: 'var(--code-comment)' },
+  cdata: { color: 'var(--code-comment)' },
+  keyword: { color: 'var(--code-keyword)' },
+  builtin: { color: 'var(--code-keyword)' },
+  operator: { color: 'var(--code-operator)' },
+  string: { color: 'var(--code-string)' },
+  'attr-value': { color: 'var(--code-string)' },
+  'template-string': { color: 'var(--code-string)' },
+  function: { color: 'var(--code-function)', fontWeight: 600 },
+  'function-variable': { color: 'var(--code-function)', fontWeight: 600 },
+  'class-name': { color: 'var(--code-function)', fontWeight: 600 },
+  number: { color: 'var(--code-number)' },
+  boolean: { color: 'var(--code-number)' },
+  variable: { color: 'var(--code-variable)' },
+  property: { color: 'var(--code-variable)' },
+  constant: { color: 'var(--code-constant)' },
+  decorator: { color: 'var(--code-constant)' },
+  punctuation: { color: 'var(--code-punctuation)' },
+  selector: { color: 'var(--code-string)' },
+  tag: { color: 'var(--code-constant)' },
+  'attr-name': { color: 'var(--code-function)' },
+  regex: { color: 'var(--code-string)' },
+  important: { color: 'var(--code-constant)', fontWeight: 'bold' },
 };
 
 interface CodeHighlighterProps {
@@ -49,15 +51,19 @@ export default function CodeHighlighter({ code }: CodeHighlighterProps) {
   return (
     <SyntaxHighlighter
       language="python"
-      style={okabeItoDark}
+      style={okabeItoTheme}
       customStyle={{
         margin: 0,
-        padding: '28px 32px',
+        padding: '24px 28px',
         fontSize: '0.85rem',
         fontFamily: typography.fontFamily,
         background: 'var(--code-bg)',
-        borderRadius: '12px',
+        color: 'var(--code-text)',
+        border: '1px solid var(--code-border)',
+        borderRadius: '8px',
         lineHeight: 1.7,
+        overflow: 'auto',
+        maxWidth: '100%',
       }}
     >
       {code}

--- a/app/src/components/CodeShowcase.tsx
+++ b/app/src/components/CodeShowcase.tsx
@@ -52,10 +52,11 @@ export function CodeShowcase() {
           </Box>
         </Box>
 
-        {/* Right: code block */}
+        {/* Right: code block — terminal showcase, intentionally dark in both themes
+            so the macOS-style window dots and drop shadow stay coherent. */}
         <Box sx={{
-          background: 'var(--code-bg)',
-          color: 'var(--code-text)',
+          background: '#1A1A17',
+          color: '#E8E8E0',
           p: { xs: 2.5, md: '28px 32px' },
           borderRadius: '12px',
           fontFamily: typography.mono,

--- a/app/src/components/SpecTabs.tsx
+++ b/app/src/components/SpecTabs.tsx
@@ -254,7 +254,7 @@ export function SpecTabs({
   // Lazy-loaded syntax highlighter - only loads when Code tab is opened
   const highlightedCode = code ? (
     <Suspense fallback={
-      <Box sx={{ fontFamily: typography.fontFamily, fontSize: '0.85rem', whiteSpace: 'pre-wrap', color: semanticColors.labelText }}>
+      <Box sx={{ fontFamily: typography.fontFamily, fontSize: '0.85rem', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere', overflowX: 'auto', minWidth: 0, color: semanticColors.labelText }}>
         {code}
       </Box>
     }>

--- a/app/src/components/SpecTabs.tsx
+++ b/app/src/components/SpecTabs.tsx
@@ -328,33 +328,26 @@ export function SpecTabs({
       {/* Code Tab - only in detail mode */}
       {!overviewMode && (
         <TabPanel value={tabIndex} index={0}>
-          <Box sx={{ position: 'relative' }}>
+          <Box sx={{ position: 'relative', minWidth: 0 }}>
             <Tooltip title={copied ? '.copied' : '.copy()'}>
               <IconButton
                 onClick={handleCopy}
                 aria-label="Copy code"
                 sx={{
                   position: 'absolute',
-                  top: 8,
-                  right: 8,
-                  bgcolor: 'rgba(255,255,255,0.9)',
+                  top: 12,
+                  right: 12,
+                  bgcolor: 'var(--bg-elevated)',
+                  border: '1px solid var(--code-border)',
                   zIndex: 1,
-                  '&:hover': { bgcolor: '#fff' },
+                  '&:hover': { bgcolor: 'var(--bg-surface)' },
                 }}
                 size="small"
               >
                 {copied ? <CheckIcon color="success" /> : <ContentCopyIcon fontSize="small" />}
               </IconButton>
             </Tooltip>
-            <Box
-              sx={{
-                bgcolor: 'var(--bg-page)',
-                p: 3,
-                borderRadius: 1,
-              }}
-            >
-              {highlightedCode}
-            </Box>
+            {highlightedCode}
           </Box>
         </TabPanel>
       )}

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -48,7 +48,7 @@
   /* Syntax tokens — tuned for cream paper background.
      Brand green is reserved for comments (italic) so it reads as
      a deliberate accent against neutral ink body text. */
-  --code-comment:     #009E73;  /* brand green, italic */
+  --code-comment:     #007A59;  /* darker brand green, italic — passes AA on cream */
   --code-keyword:     #0072B2;  /* blue */
   --code-string:      #D55E00;  /* vermillion */
   --code-function:    #1A1A17;  /* ink (bold) */

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -38,12 +38,25 @@
   --max-wide: 1600px;     /* (legacy)     — kept for components still referencing it */
   --max-catalog: 2200px;  /* catalog tier — plot grids, library pages, spec pages */
 
-  /* Code blocks — warm near-black, matches --ink so code reads as
-     "inverted body text" against the cream page (editorial feel,
-     softer than pure black). Dark mode goes a step deeper for an
-     inset look against --bg-page. */
-  --code-bg:   #1A1A17;
-  --code-text: #E8E8E0;
+  /* Code blocks — paper aesthetic in light mode (cream surface, ink text)
+     so the syntax-highlighter view sits flush with the editorial palette.
+     Dark mode keeps the warm near-black for an inset look against --bg-page. */
+  --code-bg:     #FFFDF6;
+  --code-text:   #1A1A17;
+  --code-border: rgba(26, 26, 23, 0.10);
+
+  /* Syntax tokens — tuned for cream paper background.
+     Brand green is reserved for comments (italic) so it reads as
+     a deliberate accent against neutral ink body text. */
+  --code-comment:     #009E73;  /* brand green, italic */
+  --code-keyword:     #0072B2;  /* blue */
+  --code-string:      #D55E00;  /* vermillion */
+  --code-function:    #1A1A17;  /* ink (bold) */
+  --code-number:      #B85400;  /* darker vermillion for legibility */
+  --code-variable:    #4A4A44;  /* ink-soft */
+  --code-constant:    #CC79A7;  /* purple */
+  --code-punctuation: #6B6A63;  /* ink-muted */
+  --code-operator:    #1A1A17;  /* ink */
 }
 
 /* MonoLisa script variant (italic ss02) — test */
@@ -80,5 +93,20 @@ html { font-feature-settings: "ss02"; }
   --ink-soft:    #B8B7B0;
   --ink-muted:   #A8A79F;
   --rule:        rgba(240, 239, 232, 0.10);
-  --code-bg:     #0E0E0C;
+
+  /* Code: warm near-black surface, cream text */
+  --code-bg:     #1A1A17;
+  --code-text:   #E8E8E0;
+  --code-border: rgba(240, 239, 232, 0.08);
+
+  /* Syntax tokens — tuned for warm near-black background */
+  --code-comment:     #009E73;  /* brand green, italic */
+  --code-keyword:     #56B4E9;  /* sky */
+  --code-string:      #E69F00;  /* orange */
+  --code-function:    #F0E442;  /* yellow */
+  --code-number:      #F0E442;  /* yellow */
+  --code-variable:    #CC79A7;  /* purple */
+  --code-constant:    #D55E00;  /* vermillion */
+  --code-punctuation: #8A8A82;
+  --code-operator:    #E8E8E0;
 }

--- a/docs/reference/style-guide.md
+++ b/docs/reference/style-guide.md
@@ -429,7 +429,7 @@ Verified with [WebAIM Contrast Checker](https://webaim.org/resources/contrastche
 3. Hero terminal cursor (the blinking `▌` at the end of `make it yours._`)
 4. Active navigation item (green dot prefix + underline on hover)
 5. Code-style action button hover (`.copy()` → green on hover) and CTA hover (filled background swap)
-6. Code block syntax highlighting (strings, specific tokens)
+6. Code block syntax highlighting (comments — italic, signals editorial commentary inside code)
 7. Palette strip and any deliberate palette display
 8. Small status indicators (pulsing dot in plot-card header)
 


### PR DESCRIPTION
The Code tab on spec pages was rendered with a warm near-black background even
in light mode, which clashed with the cream editorial palette and let long
lines bleed past the container. This switches the syntax-highlighter to a
theme-aware paper surface (cream + ink in light, warm near-black + cream in
dark), promotes brand green to the comment color in both modes, and contains
horizontal overflow inside the code block.

- tokens.css: --code-bg/text now adapt per theme; new --code-border and a full
  set of --code-{comment,keyword,string,function,number,variable,constant,
  punctuation,operator} syntax tokens tuned for each surface.
- CodeHighlighter.tsx: drop hardcoded okabeItoDark, drive every token from the
  CSS vars, add border, overflow:auto and maxWidth:100% so long lines scroll
  inside the block instead of escaping the container.
- SpecTabs.tsx: drop the redundant bg-page wrapper around the highlighter,
  add minWidth:0 so it can shrink in the flex parent, and restyle the copy
  button against the new light surface.
- CodeShowcase.tsx: pin the hero "terminal" widget to fixed dark colors so
  the macOS-style window dots and drop shadow stay coherent now that
  --code-bg means paper.