### PR TITLE
fix(app): preserve prior scrollRestoration value across mount/unmount

### DIFF
--- a/app/src/components/RootLayout.test.tsx
+++ b/app/src/components/RootLayout.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter, Routes, Route, Link } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { RootLayout } from './RootLayout';
+
+vi.mock('../hooks', () => ({
+  useAnalytics: () => ({ trackEvent: vi.fn(), trackPageview: vi.fn() }),
+}));
+
+vi.mock('./MastheadRule', () => ({
+  MastheadRule: () => <div data-testid="masthead" />,
+}));
+
+vi.mock('./NavBar', () => ({
+  NavBar: () => <div data-testid="navbar" />,
+}));
+
+vi.mock('./Footer', () => ({
+  Footer: () => <div data-testid="footer" />,
+}));
+
+const theme = createTheme();
+
+function renderAt(initialPath: string) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route element={<RootLayout />}>
+            <Route
+              path="/"
+              element={
+                <div>
+                  <Link to="/legal">go-legal</Link>
+                  <Link to="/about#section">go-about-hash</Link>
+                </div>
+              }
+            />
+            <Route path="/legal" element={<div>legal-page</div>} />
+            <Route path="/about" element={<div>about-page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('RootLayout', () => {
+  let scrollSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    scrollSpy.mockRestore();
+  });
+
+  it('scrolls to top when navigating to a new path (PUSH)', async () => {
+    const user = userEvent.setup();
+    renderAt('/');
+    scrollSpy.mockClear();
+
+    await user.click(document.querySelector('a[href="/legal"]') as HTMLElement);
+
+    expect(scrollSpy).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('does not scroll to top when the destination has a hash anchor', async () => {
+    const user = userEvent.setup();
+    renderAt('/');
+    scrollSpy.mockClear();
+
+    await user.click(document.querySelector('a[href="/about#section"]') as HTMLElement);
+
+    expect(scrollSpy).not.toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -27,12 +27,12 @@ export function RootLayout() {
   const navigationType = useNavigationType();
   const mastheadSticks = pathname !== '/plots';
 
-  // Reset scroll on forward navigation (PUSH/REPLACE). Without this, short
-  // pages like /legal inherit the previous page's scroll position because
-  // PlotsPage sets scrollRestoration='manual'. Skip on POP so browser
-  // back/forward keeps native scroll restoration; skip when a hash anchor
-  // is present so in-page anchors still work. PlotsPage runs its own
-  // saved-scroll restore in a later effect, so it still overrides this.
+  // Reset scroll on forward navigation (PUSH/REPLACE). In SPA route changes,
+  // the next page can otherwise keep the previous page's scroll position,
+  // which is especially noticeable on short pages like /legal. Skip on POP
+  // so browser back/forward keeps native scroll restoration; skip when a
+  // hash anchor is present so in-page anchors still work. Pages with their
+  // own saved-scroll restore in a later effect can still override this.
   useEffect(() => {
     if (hash) return;
     if (navigationType === 'POP') return;

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
@@ -22,8 +23,18 @@ const containerSx = {
  */
 export function RootLayout() {
   const { trackEvent } = useAnalytics();
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
   const mastheadSticks = pathname !== '/plots';
+
+  // Reset scroll on route change. PlotsPage sets scrollRestoration='manual',
+  // so without this the browser keeps the previous scroll position when
+  // navigating to short pages (e.g. /legal from the footer). Pages that
+  // restore a saved scroll position (PlotsPage) do so in a later effect, so
+  // they still override this on back-navigation.
+  useEffect(() => {
+    if (hash) return;
+    window.scrollTo(0, 0);
+  }, [pathname, hash]);
 
   return (
     <Box sx={{

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigationType } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 
@@ -24,17 +24,20 @@ const containerSx = {
 export function RootLayout() {
   const { trackEvent } = useAnalytics();
   const { pathname, hash } = useLocation();
+  const navigationType = useNavigationType();
   const mastheadSticks = pathname !== '/plots';
 
-  // Reset scroll on route change. PlotsPage sets scrollRestoration='manual',
-  // so without this the browser keeps the previous scroll position when
-  // navigating to short pages (e.g. /legal from the footer). Pages that
-  // restore a saved scroll position (PlotsPage) do so in a later effect, so
-  // they still override this on back-navigation.
+  // Reset scroll on forward navigation (PUSH/REPLACE). Without this, short
+  // pages like /legal inherit the previous page's scroll position because
+  // PlotsPage sets scrollRestoration='manual'. Skip on POP so browser
+  // back/forward keeps native scroll restoration; skip when a hash anchor
+  // is present so in-page anchors still work. PlotsPage runs its own
+  // saved-scroll restore in a later effect, so it still overrides this.
   useEffect(() => {
     if (hash) return;
+    if (navigationType === 'POP') return;
     window.scrollTo(0, 0);
-  }, [pathname, hash]);
+  }, [pathname, hash, navigationType]);
 
   return (
     <Box sx={{

--- a/app/src/pages/HomePage.test.tsx
+++ b/app/src/pages/HomePage.test.tsx
@@ -124,12 +124,20 @@ describe('HomePage', () => {
       history.scrollRestoration = original;
     });
 
-    it("sets scrollRestoration to 'manual' on mount and restores 'auto' on unmount", () => {
+    it("sets scrollRestoration to 'manual' on mount and restores the previous value on unmount", () => {
       history.scrollRestoration = 'auto';
       const { unmount } = render(<HomePage />);
       expect(history.scrollRestoration).toBe('manual');
       unmount();
       expect(history.scrollRestoration).toBe('auto');
+    });
+
+    it('restores a non-default previous value on unmount instead of forcing auto', () => {
+      history.scrollRestoration = 'manual';
+      const { unmount } = render(<HomePage />);
+      expect(history.scrollRestoration).toBe('manual');
+      unmount();
+      expect(history.scrollRestoration).toBe('manual');
     });
   });
 });

--- a/app/src/pages/HomePage.test.tsx
+++ b/app/src/pages/HomePage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '../test-utils';
 
 // Mock hooks
@@ -115,5 +115,21 @@ describe('HomePage', () => {
   it('renders Helmet for SEO', () => {
     render(<HomePage />);
     expect(screen.getByTestId('helmet')).toBeInTheDocument();
+  });
+
+  describe('scrollRestoration', () => {
+    const original = history.scrollRestoration;
+
+    afterEach(() => {
+      history.scrollRestoration = original;
+    });
+
+    it("sets scrollRestoration to 'manual' on mount and restores 'auto' on unmount", () => {
+      history.scrollRestoration = 'auto';
+      const { unmount } = render(<HomePage />);
+      expect(history.scrollRestoration).toBe('manual');
+      unmount();
+      expect(history.scrollRestoration).toBe('auto');
+    });
   });
 });

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -28,11 +28,15 @@ export function HomePage() {
   const { specsData, librariesData, stats } = useAppData();
   const { homeStateRef, saveScrollPosition } = useHomeState();
 
-  // Disable browser's automatic scroll restoration
+  // Disable browser's automatic scroll restoration so we can restore from
+  // our persisted state (homeStateRef.scrollY) instead. Restore on unmount
+  // so other routes get native back/forward behavior.
   useEffect(() => {
-    if ('scrollRestoration' in history) {
-      history.scrollRestoration = 'manual';
-    }
+    if (!('scrollRestoration' in history)) return;
+    history.scrollRestoration = 'manual';
+    return () => {
+      history.scrollRestoration = 'auto';
+    };
   }, []);
 
   // Custom hooks

--- a/app/src/pages/HomePage.tsx
+++ b/app/src/pages/HomePage.tsx
@@ -29,13 +29,15 @@ export function HomePage() {
   const { homeStateRef, saveScrollPosition } = useHomeState();
 
   // Disable browser's automatic scroll restoration so we can restore from
-  // our persisted state (homeStateRef.scrollY) instead. Restore on unmount
-  // so other routes get native back/forward behavior.
+  // our persisted state (homeStateRef.scrollY) instead. Capture the prior
+  // mode and restore it on unmount, so we don't clobber any non-default
+  // value set elsewhere and other routes get back native behavior.
   useEffect(() => {
     if (!('scrollRestoration' in history)) return;
+    const previous = history.scrollRestoration;
     history.scrollRestoration = 'manual';
     return () => {
-      history.scrollRestoration = 'auto';
+      history.scrollRestoration = previous;
     };
   }, []);
 

--- a/app/src/pages/PlotsPage.test.tsx
+++ b/app/src/pages/PlotsPage.test.tsx
@@ -76,12 +76,20 @@ describe('PlotsPage', () => {
       history.scrollRestoration = original;
     });
 
-    it("sets scrollRestoration to 'manual' on mount and restores 'auto' on unmount", () => {
+    it("sets scrollRestoration to 'manual' on mount and restores the previous value on unmount", () => {
       history.scrollRestoration = 'auto';
       const { unmount } = render(<PlotsPage />);
       expect(history.scrollRestoration).toBe('manual');
       unmount();
       expect(history.scrollRestoration).toBe('auto');
+    });
+
+    it('restores a non-default previous value on unmount instead of forcing auto', () => {
+      history.scrollRestoration = 'manual';
+      const { unmount } = render(<PlotsPage />);
+      expect(history.scrollRestoration).toBe('manual');
+      unmount();
+      expect(history.scrollRestoration).toBe('manual');
     });
   });
 });

--- a/app/src/pages/PlotsPage.test.tsx
+++ b/app/src/pages/PlotsPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '../test-utils';
 
 vi.mock('../hooks', () => ({
@@ -67,5 +67,21 @@ describe('PlotsPage', () => {
   it('renders Helmet for SEO', () => {
     render(<PlotsPage />);
     expect(screen.getByTestId('helmet')).toBeInTheDocument();
+  });
+
+  describe('scrollRestoration', () => {
+    const original = history.scrollRestoration;
+
+    afterEach(() => {
+      history.scrollRestoration = original;
+    });
+
+    it("sets scrollRestoration to 'manual' on mount and restores 'auto' on unmount", () => {
+      history.scrollRestoration = 'auto';
+      const { unmount } = render(<PlotsPage />);
+      expect(history.scrollRestoration).toBe('manual');
+      unmount();
+      expect(history.scrollRestoration).toBe('auto');
+    });
   });
 });

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -21,11 +21,15 @@ export function PlotsPage() {
   const { specsData, librariesData } = useAppData();
   const { homeStateRef, saveScrollPosition } = useHomeState();
 
-  // Disable browser's automatic scroll restoration
+  // Disable browser's automatic scroll restoration so we can restore from
+  // our persisted state (homeStateRef.scrollY) instead. Restore on unmount
+  // so other routes get native back/forward behavior.
   useEffect(() => {
-    if ('scrollRestoration' in history) {
-      history.scrollRestoration = 'manual';
-    }
+    if (!('scrollRestoration' in history)) return;
+    history.scrollRestoration = 'manual';
+    return () => {
+      history.scrollRestoration = 'auto';
+    };
   }, []);
 
   const { trackPageview, trackEvent } = useAnalytics();

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -22,13 +22,15 @@ export function PlotsPage() {
   const { homeStateRef, saveScrollPosition } = useHomeState();
 
   // Disable browser's automatic scroll restoration so we can restore from
-  // our persisted state (homeStateRef.scrollY) instead. Restore on unmount
-  // so other routes get native back/forward behavior.
+  // our persisted state (homeStateRef.scrollY) instead. Capture the prior
+  // mode and restore it on unmount, so we don't clobber any non-default
+  // value set elsewhere and other routes get back native behavior.
   useEffect(() => {
     if (!('scrollRestoration' in history)) return;
+    const previous = history.scrollRestoration;
     history.scrollRestoration = 'manual';
     return () => {
-      history.scrollRestoration = 'auto';
+      history.scrollRestoration = previous;
     };
   }, []);
 


### PR DESCRIPTION
Follow-up to #5403 addressing review feedback that arrived after the original PR was squash-merged.

Because #5403 was squash-merged, this branch's individual commits show as new against `main`. The diff therefore covers both the feedback fix and the original commits — the description below reflects the full diff.

## Summary
- **Preserve prior `history.scrollRestoration`** in `HomePage` and `PlotsPage` (the new bit). Capture the value on mount and restore it on unmount, instead of hard-setting `'auto'` — avoids clobbering a non-default value set elsewhere.
- **Scroll-to-top on forward navigation** in `RootLayout` (carried over from the squash-merged #5403). Skips POP navigation so browser back/forward keeps native scroll restoration; skips when a hash anchor is present so in-page anchors still work. Comment in the source updated to accurately describe the SPA-PUSH cause (per review feedback).
- **Scoped `scrollRestoration='manual'`** in `HomePage`/`PlotsPage` to those pages with cleanup on unmount, so other routes get native browser back/forward behavior.
- **Tests:** new `RootLayout.test.tsx` (PUSH scrolls, hash skips); extended `HomePage.test.tsx` and `PlotsPage.test.tsx` covering mount/unmount restoration for both `'auto'` and `'manual'` prior values.

## User-facing behavior
- Clicking a footer link like `/legal` from a long page now lands at the top.
- Browser back/forward to a route without custom scroll handling restores the previous position.
- Pages that manage their own saved scroll (`HomePage`, `PlotsPage`) still restore from their persisted state.

## Test plan
- [ ] `cd app && yarn test` — all suites pass
- [ ] Navigate `/plots` → footer `/legal` lands at top
- [ ] Browser back from `/legal` to `/plots` restores prior scroll
- [ ] In-page hash anchor (e.g. `/about#section`) still scrolls to anchor