### PR TITLE
feat(theme): tri-state mode (system/light/dark) with live OS sync

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -57,6 +57,7 @@ export default [
         ClipboardEvent: 'readonly',
         Event: 'readonly',
         MessageEvent: 'readonly',
+        MediaQueryListEvent: 'readonly',
         // APIs
         AbortController: 'readonly',
         AbortSignal: 'readonly',

--- a/app/index.html
+++ b/app/index.html
@@ -10,6 +10,20 @@
     <meta name="theme-color" content="#0E0E10" media="(prefers-color-scheme: dark)" />
     <title>any.plot() — any library.</title>
 
+    <!-- Resolve theme before paint to avoid a flash-of-wrong-theme. Mirrors
+         useThemeMode: stored 'light'/'dark' wins, otherwise follow the OS. -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('theme');
+          var dark = stored === 'dark'
+            || (stored !== 'light' && window.matchMedia
+                && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+        } catch (e) { /* private mode etc. — fall through to React-driven default */ }
+      })();
+    </script>
+
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://anyplot.ai/" />

--- a/app/src/components/MastheadRule.test.tsx
+++ b/app/src/components/MastheadRule.test.tsx
@@ -2,14 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, userEvent } from '../test-utils';
 
 const trackEvent = vi.fn();
-const toggle = vi.fn();
+const cycle = vi.fn();
+const setMode = vi.fn();
 
 vi.mock('../hooks', async () => {
   const actual = await vi.importActual<typeof import('../hooks')>('../hooks');
   return {
     ...actual,
     useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
-    useTheme: () => ({ isDark: false, toggle }),
+    useTheme: () => ({ mode: 'system', effective: 'light', isDark: false, setMode, cycle }),
     useLatestRelease: () => 'v1.2.3',
   };
 });
@@ -19,16 +20,18 @@ import { MastheadRule } from './MastheadRule';
 describe('MastheadRule', () => {
   beforeEach(() => {
     trackEvent.mockClear();
-    toggle.mockClear();
+    cycle.mockClear();
+    setMode.mockClear();
   });
 
-  it('fires theme_toggle event before invoking the underlying toggle', async () => {
+  it('fires theme_toggle event with the next mode and cycles', async () => {
     const user = userEvent.setup();
     render(<MastheadRule />);
 
-    await user.click(screen.getByLabelText('Switch to dark theme'));
-    expect(trackEvent).toHaveBeenCalledWith('theme_toggle', { to: 'dark' });
-    expect(toggle).toHaveBeenCalled();
+    // mode='system' → next is 'light'
+    await user.click(screen.getByLabelText('Switch to light theme'));
+    expect(trackEvent).toHaveBeenCalledWith('theme_toggle', { to: 'light' });
+    expect(cycle).toHaveBeenCalled();
   });
 
   it('tracks nav_click on the masthead logo, branch, and release links', async () => {

--- a/app/src/components/MastheadRule.tsx
+++ b/app/src/components/MastheadRule.tsx
@@ -101,7 +101,7 @@ function pathSegments(pathname: string): Segment[] {
  * and the catchphrase is suppressed so the line stays uncluttered.
  */
 export function MastheadRule() {
-  const { isDark, toggle } = useTheme();
+  const { mode, cycle } = useTheme();
   const { trackEvent } = useAnalytics();
   const releaseTag = useLatestRelease();
   const location = useLocation();
@@ -109,9 +109,10 @@ export function MastheadRule() {
   const isLanding = segments.length === 0;
   const version = releaseTag ?? 'v1.0';
 
+  const NEXT_MODE = { system: 'light', light: 'dark', dark: 'system' } as const;
   const handleThemeToggle = () => {
-    trackEvent('theme_toggle', { to: isDark ? 'light' : 'dark' });
-    toggle();
+    trackEvent('theme_toggle', { to: NEXT_MODE[mode] });
+    cycle();
   };
 
   // Pick one random comment style per browser session (stable across client-side nav).
@@ -234,7 +235,7 @@ export function MastheadRule() {
         display: 'flex',
         justifyContent: 'flex-end',
       }}>
-        <ThemeToggle isDark={isDark} onToggle={handleThemeToggle} />
+        <ThemeToggle mode={mode} onCycle={handleThemeToggle} />
       </Box>
     </Box>
   );

--- a/app/src/components/RootLayout.test.tsx
+++ b/app/src/components/RootLayout.test.tsx
@@ -22,7 +22,16 @@ vi.mock('../hooks', async () => {
 
 vi.mock('../hooks/useLayoutContext', async () => {
   const actual = await vi.importActual<typeof import('../hooks/useLayoutContext')>('../hooks/useLayoutContext');
-  return { ...actual, useTheme: () => ({ isDark: true, toggle: vi.fn() }) };
+  return {
+    ...actual,
+    useTheme: () => ({
+      mode: 'dark' as const,
+      effective: 'dark' as const,
+      isDark: true,
+      setMode: vi.fn(),
+      cycle: vi.fn(),
+    }),
+  };
 });
 
 vi.mock('./MastheadRule', () => ({ MastheadRule: () => <div data-testid="masthead" /> }));

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -27,13 +27,15 @@ export function RootLayout() {
   const { trackEvent } = useAnalytics();
   const { pathname, hash } = useLocation();
   const navigationType = useNavigationType();
-  const { isDark } = useTheme();
+  const { effective } = useTheme();
   const mastheadSticks = pathname !== '/plots';
 
   // Set synchronously during render so the first pageview from a child page's
   // useEffect (which runs before the parent's useEffect) carries the theme prop.
   // setAnalyticsAmbientProps merges into module state, so re-renders are safe.
-  setAnalyticsAmbientProps({ theme: isDark ? 'dark' : 'light' });
+  // The ambient prop tracks the *effective* theme so existing Plausible
+  // dark/light breakdowns keep working regardless of mode (system/light/dark).
+  setAnalyticsAmbientProps({ theme: effective });
 
   // Reset scroll on forward navigation (PUSH/REPLACE). In SPA route changes,
   // the next page can otherwise keep the previous page's scroll position,

--- a/app/src/components/ThemeToggle.tsx
+++ b/app/src/components/ThemeToggle.tsx
@@ -1,19 +1,32 @@
 import Box from '@mui/material/Box';
 import { colors, typography } from '../theme';
+import type { ThemeMode } from '../hooks/useLayoutContext';
 
 interface ThemeToggleProps {
-  isDark: boolean;
-  onToggle: () => void;
+  mode: ThemeMode;
+  onCycle: () => void;
 }
 
-export function ThemeToggle({ isDark, onToggle }: ThemeToggleProps) {
-  const icon = isDark ? '☀' : '◐';
-  const label = isDark ? 'light' : 'dark';
+const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system',
+};
+
+const ICON: Record<ThemeMode, string> = {
+  system: '◑',
+  light: '☀',
+  dark: '☾',
+};
+
+export function ThemeToggle({ mode, onCycle }: ThemeToggleProps) {
+  const next = NEXT_MODE[mode];
   return (
     <Box
       component="button"
-      onClick={onToggle}
-      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      onClick={onCycle}
+      aria-label={`Switch to ${next} theme`}
+      title={`theme: ${mode}`}
       sx={{
         background: 'none',
         border: '1px solid var(--rule)',
@@ -32,9 +45,9 @@ export function ThemeToggle({ isDark, onToggle }: ThemeToggleProps) {
         },
       }}
     >
-      {icon}
+      {ICON[mode]}
       <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' }, ml: 0.5 }}>
-        {label}
+        {mode}
       </Box>
     </Box>
   );

--- a/app/src/hooks/useLayoutContext.ts
+++ b/app/src/hooks/useLayoutContext.ts
@@ -39,14 +39,26 @@ export const initialHomeState: HomeState = {
   initialized: false,
 };
 
+export type ThemeMode = 'system' | 'light' | 'dark';
+export type EffectiveTheme = 'light' | 'dark';
+
 export interface ThemeContextValue {
+  mode: ThemeMode;
+  effective: EffectiveTheme;
   isDark: boolean;
-  toggle: () => void;
+  setMode: (mode: ThemeMode) => void;
+  cycle: () => void;
 }
 
 export const AppDataContext = createContext<AppData | null>(null);
 export const HomeStateContext = createContext<HomeStateContextValue | null>(null);
-export const ThemeContext = createContext<ThemeContextValue>({ isDark: false, toggle: () => {} });
+export const ThemeContext = createContext<ThemeContextValue>({
+  mode: 'system',
+  effective: 'light',
+  isDark: false,
+  setMode: () => {},
+  cycle: () => {},
+});
 
 export function useAppData() {
   const context = useContext(AppDataContext);

--- a/app/src/hooks/useThemeMode.test.ts
+++ b/app/src/hooks/useThemeMode.test.ts
@@ -1,50 +1,142 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useThemeMode } from './useThemeMode';
 
+type MQListener = (e: MediaQueryListEvent) => void;
+
+interface MockMediaQuery {
+  matches: boolean;
+  media: string;
+  addEventListener: (type: 'change', listener: MQListener) => void;
+  removeEventListener: (type: 'change', listener: MQListener) => void;
+  // Test-only helpers
+  _emit: (matches: boolean) => void;
+}
+
+function installMatchMedia(initialDark: boolean) {
+  let matches = initialDark;
+  const listeners = new Set<MQListener>();
+  const mq: MockMediaQuery = {
+    get matches() { return matches; },
+    set matches(v: boolean) { matches = v; },
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (_type, listener) => { listeners.add(listener); },
+    removeEventListener: (_type, listener) => { listeners.delete(listener); },
+    _emit(next: boolean) {
+      matches = next;
+      const event = { matches: next, media: mq.media } as MediaQueryListEvent;
+      listeners.forEach(l => l(event));
+    },
+  };
+  vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mq));
+  return mq;
+}
+
 describe('useThemeMode', () => {
+  let mq: MockMediaQuery;
+
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
+    mq = installMatchMedia(false);
   });
 
-  it('defaults to light mode when no stored preference', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('first-ever visit defaults to system mode and persists nothing', () => {
     const { result } = renderHook(() => useThemeMode());
+    expect(result.current.mode).toBe('system');
+    expect(result.current.effective).toBe('light');
     expect(result.current.isDark).toBe(false);
-  });
-
-  it('sets data-theme attribute on html element', () => {
-    renderHook(() => useThemeMode());
+    expect(localStorage.getItem('theme')).toBeNull();
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
-  it('toggles to dark mode', () => {
+  it('system mode follows the OS preference at mount', () => {
+    mq._emit(true); // OS prefers dark before mount
     const { result } = renderHook(() => useThemeMode());
-
-    act(() => {
-      result.current.toggle();
-    });
-
-    expect(result.current.isDark).toBe(true);
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
-    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(result.current.mode).toBe('system');
+    expect(result.current.effective).toBe('dark');
+    expect(localStorage.getItem('theme')).toBeNull();
   });
 
-  it('restores dark mode from localStorage', () => {
-    localStorage.setItem('theme', 'dark');
-    const { result } = renderHook(() => useThemeMode());
-    expect(result.current.isDark).toBe(true);
-  });
-
-  it('toggles back to light mode', () => {
-    localStorage.setItem('theme', 'dark');
+  it('system → light transition persists the choice', () => {
     const { result } = renderHook(() => useThemeMode());
 
-    act(() => {
-      result.current.toggle();
-    });
+    act(() => { result.current.cycle(); });
 
-    expect(result.current.isDark).toBe(false);
+    expect(result.current.mode).toBe('light');
+    expect(result.current.effective).toBe('light');
     expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('light → dark transition persists the new choice', () => {
+    localStorage.setItem('theme', 'light');
+    const { result } = renderHook(() => useThemeMode());
+
+    act(() => { result.current.cycle(); });
+
+    expect(result.current.mode).toBe('dark');
+    expect(result.current.effective).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('dark → system transition clears localStorage and re-follows the OS', () => {
+    localStorage.setItem('theme', 'dark');
+    mq._emit(false); // OS prefers light
+    const { result } = renderHook(() => useThemeMode());
+    expect(result.current.mode).toBe('dark');
+
+    act(() => { result.current.cycle(); });
+
+    expect(result.current.mode).toBe('system');
+    expect(result.current.effective).toBe('light');
+    expect(localStorage.getItem('theme')).toBeNull();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('live OS change flips the theme while in system mode', () => {
+    const { result } = renderHook(() => useThemeMode());
+    expect(result.current.effective).toBe('light');
+
+    act(() => { mq._emit(true); });
+
+    expect(result.current.effective).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBeNull();
+  });
+
+  it('explicit light/dark mode ignores OS-level changes', () => {
+    localStorage.setItem('theme', 'light');
+    const { result } = renderHook(() => useThemeMode());
+
+    act(() => { mq._emit(true); }); // OS flips to dark — should be ignored
+
+    expect(result.current.mode).toBe('light');
+    expect(result.current.effective).toBe('light');
+  });
+
+  it('setMode jumps directly to a target mode', () => {
+    const { result } = renderHook(() => useThemeMode());
+
+    act(() => { result.current.setMode('dark'); });
+    expect(result.current.mode).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+
+    act(() => { result.current.setMode('system'); });
+    expect(result.current.mode).toBe('system');
+    expect(localStorage.getItem('theme')).toBeNull();
+  });
+
+  it('restores explicit dark mode from localStorage on remount', () => {
+    localStorage.setItem('theme', 'dark');
+    const { result } = renderHook(() => useThemeMode());
+    expect(result.current.mode).toBe('dark');
+    expect(result.current.effective).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 });

--- a/app/src/hooks/useThemeMode.ts
+++ b/app/src/hooks/useThemeMode.ts
@@ -2,40 +2,80 @@ import { useState, useEffect, useCallback } from 'react';
 
 const STORAGE_KEY = 'theme';
 
+export type ThemeMode = 'system' | 'light' | 'dark';
+export type EffectiveTheme = 'light' | 'dark';
+
+const CYCLE: ThemeMode[] = ['system', 'light', 'dark'];
+
+function readStoredMode(): ThemeMode {
+  if (typeof window === 'undefined') return 'system';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === 'dark' || stored === 'light' ? stored : 'system';
+}
+
+function systemPrefersDark(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function persistMode(mode: ThemeMode): void {
+  if (mode === 'system') localStorage.removeItem(STORAGE_KEY);
+  else localStorage.setItem(STORAGE_KEY, mode);
+}
+
 /**
- * Manages dark/light theme via data-theme attribute on <html>.
- * Persists to localStorage, respects prefers-color-scheme on first visit.
+ * Tri-state theme hook (system/light/dark).
+ *
+ * - `system` (default): follows `prefers-color-scheme` live and writes nothing
+ *   to localStorage, so a fresh visit on a new device or browser keeps tracking
+ *   the OS until the user opts in.
+ * - `light` / `dark`: explicit user choice, persisted in localStorage and
+ *   immune to OS-level changes during the session.
+ * - Returning to `system` clears the storage key, so the next visit again
+ *   defaults to OS-following.
  */
 export function useThemeMode() {
-  const [isDark, setIsDark] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) return stored === 'dark';
-    return typeof window.matchMedia === 'function'
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : false;
-  });
+  const [mode, setModeState] = useState<ThemeMode>(readStoredMode);
+  const [systemDark, setSystemDark] = useState<boolean>(systemPrefersDark);
 
-  // Sync attribute + localStorage whenever isDark changes
+  const effective: EffectiveTheme = mode === 'system'
+    ? (systemDark ? 'dark' : 'light')
+    : mode;
+
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-    localStorage.setItem(STORAGE_KEY, isDark ? 'dark' : 'light');
-  }, [isDark]);
+    document.documentElement.setAttribute('data-theme', effective);
+  }, [effective]);
 
-  // Listen for system preference changes (only when no explicit choice stored)
+  // Track OS preference unconditionally — the value only feeds `effective` while
+  // mode === 'system', but keeping the listener mounted means re-entering
+  // system mode picks up the current OS state without a stale reading.
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return;
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = (e: MediaQueryListEvent) => {
-      if (!localStorage.getItem(STORAGE_KEY)) {
-        setIsDark(e.matches);
-      }
-    };
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
   }, []);
 
-  const toggle = useCallback(() => setIsDark(prev => !prev), []);
+  const setMode = useCallback((next: ThemeMode) => {
+    persistMode(next);
+    setModeState(next);
+  }, []);
 
-  return { isDark, toggle } as const;
+  const cycle = useCallback(() => {
+    setModeState(prev => {
+      const next = CYCLE[(CYCLE.indexOf(prev) + 1) % CYCLE.length];
+      persistMode(next);
+      return next;
+    });
+  }, []);
+
+  return {
+    mode,
+    effective,
+    isDark: effective === 'dark',
+    setMode,
+    cycle,
+  } as const;
 }

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -130,7 +130,7 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `suggest_spec` | - | SpecsListPage.tsx | User clicks the `spec.suggest()` link on the specs list page. The mirror link on the landing page emits `nav_click` with `source: suggest_spec_link` instead. |
 | `report_issue` | `spec`, `library`? | SpecPage.tsx | User clicks "report issue" link |
 | `tag_click` | `param`, `value`, `source` | SpecTabs.tsx | User clicks a tag chip to filter |
-| `theme_toggle` | `to` | MastheadRule.tsx | User toggles dark/light mode (`to` ∈ `dark`, `light`) |
+| `theme_toggle` | `to` | MastheadRule.tsx | User cycles tri-state theme mode (`to` ∈ `system`, `light`, `dark`). The cycle order is `system → light → dark → system`. |
 | `potd_dismiss` | `spec`, `library` | PlotOfTheDay.tsx | User dismisses the plot-of-the-day banner |
 
 ### Landing Page Navigation (`nav_click`)
@@ -307,8 +307,8 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | `param` | URL parameter name for tag | `tag_click` |
 | `source` | Source UI element / page context | `tag_click`, `nav_click` |
 | `target` | Click destination (route or external label) | `nav_click` |
-| `to` | New mode after toggle (`dark` / `light`) | `theme_toggle` |
-| `theme` | Ambient theme prop attached to **every** pageview & event (`dark` / `light`) | all events (set in RootLayout via `setAnalyticsAmbientProps`) |
+| `to` | New mode after toggle (`system` / `light` / `dark`) | `theme_toggle` |
+| `theme` | Ambient *effective* theme attached to **every** pageview & event (`dark` / `light`) — resolved from the tri-state mode so OS-followers still split cleanly | all events (set in RootLayout via `setAnalyticsAmbientProps`) |
 | `rating` | CWV rating (good, needs-improvement, poor) | `LCP`, `CLS`, `INP` |
 | `filter_lib` | Library filter value (for og:image) | `og_image_view` |
 | `filter_spec` | Specification filter value (for og:image) | `og_image_view` |


### PR DESCRIPTION
Closes #5406.

## Summary

- Rewrites `useThemeMode` to a tri-state hook returning `{ mode, effective, isDark, setMode, cycle }` with `mode: 'system' | 'light' | 'dark'`.
- `system` is the new default and writes nothing to `localStorage`, so a fresh visit follows `prefers-color-scheme` and live-flips when the OS theme changes (e.g. iOS sunset auto-dark) — fixing the dead `matchMedia` listener.
- Explicit `light` / `dark` persists in `localStorage`; cycling back to `system` clears the key so the next visit again defaults to OS-following.
- `ThemeToggle` becomes a tri-state cycle: `◑ system → ☀ light → ☾ dark → system`.
- Inline pre-paint script in `index.html` resolves the theme before React hydrates to avoid a flash-of-wrong-theme.

## Analytics

- `theme_toggle.to` now reports the new **mode** (`system` / `light` / `dark`) so we can see how often users opt back into system tracking.
- The ambient `theme` pageview prop still reports the **effective** theme (`dark` / `light`), so existing Plausible breakdowns keep working.
- `docs/reference/plausible.md` updated.

## Tests

`useThemeMode.test.ts` rewritten to cover:

- First-ever visit defaults to `system` and persists nothing
- `system → light → dark → system` transitions (storage written / cleared correctly)
- Live OS change while in `system` flips effective theme
- OS change while in explicit `light` / `dark` is ignored
- `setMode` direct path
- Restore explicit dark from `localStorage` on remount

## Acceptance criteria checklist

- [x] First-ever visit follows OS preference and persists nothing
- [x] User toggle persists `light` / `dark` in `localStorage`
- [x] User can return to `system` mode and `localStorage` is cleared
- [x] When mode is `system`, OS-level theme changes during the session flip the page live
- [x] When mode is `light` / `dark`, OS changes are ignored
- [x] `theme` ambient analytics prop reflects the **effective** theme
- [x] `theme_toggle` event captures the new **mode**
- [x] Hook return shape stays ergonomic (`{ mode, effective, setMode, cycle }`)
- [x] No flash-of-wrong-theme — inline pre-paint script in `index.html`
- [x] Tests cover all four transitions

## Test plan

- [x] `yarn type-check` clean
- [x] `yarn test` — 374/374 pass
- [x] `yarn build` succeeds
- [ ] Manual: load with `localStorage.theme` cleared and verify OS preference is honored, that toggling iOS/macOS dark/light mode flips the tab live, and that the cycle button takes you back to `system` (clearing storage)
- [ ] Manual: load with `localStorage.theme = 'dark'` set and verify OS changes are ignored
- [ ] Manual: hard-refresh on a slow connection and confirm there is no FOWT

https://claude.ai/code/session_01W3JkYodBsG9p5vB6y7LDPG

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3JkYodBsG9p5vB6y7LDPG)_