### PR TITLE
fix(app): refresh latest release tag every hour in background

### DIFF
--- a/app/src/hooks/useLatestRelease.test.ts
+++ b/app/src/hooks/useLatestRelease.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLatestRelease } from './useLatestRelease';
+
+const CACHE_KEY = 'anyplot:latest-release';
+const ONE_HOUR = 60 * 60 * 1000;
+
+function mockFetchTag(tag: string, ok = true) {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok,
+    json: () => Promise.resolve({ tag_name: tag }),
+  });
+}
+
+describe('useLatestRelease', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the cached tag immediately when cache is fresh', () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: 'v2.1', ts: Date.now() }));
+    const { result } = renderHook(() => useLatestRelease());
+    expect(result.current).toBe('v2.1');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('renders the stale cached tag immediately and refreshes in the background', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: 'v2.0', ts: Date.now() - ONE_HOUR - 1000 }));
+    mockFetchTag('v2.1');
+
+    const { result } = renderHook(() => useLatestRelease());
+    expect(result.current).toBe('v2.0');
+
+    await waitFor(() => expect(result.current).toBe('v2.1'));
+    const stored = JSON.parse(localStorage.getItem(CACHE_KEY)!);
+    expect(stored.tag).toBe('v2.1');
+  });
+
+  it('fetches on mount when no cache exists', async () => {
+    mockFetchTag('v2.1');
+    const { result } = renderHook(() => useLatestRelease());
+    expect(result.current).toBeNull();
+
+    await waitFor(() => expect(result.current).toBe('v2.1'));
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches once per hour while mounted', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockFetchTag('v2.0');
+      const { result } = renderHook(() => useLatestRelease());
+      await waitFor(() => expect(result.current).toBe('v2.0'));
+
+      mockFetchTag('v2.1');
+      await vi.advanceTimersByTimeAsync(ONE_HOUR + 100);
+
+      await waitFor(() => expect(result.current).toBe('v2.1'));
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('refetches when the tab becomes visible after the cache goes stale', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: 'v2.0', ts: Date.now() - ONE_HOUR - 1000 }));
+      mockFetchTag('v2.1');
+
+      const { result } = renderHook(() => useLatestRelease());
+      // Wait for the on-mount refresh to complete first.
+      await waitFor(() => expect(result.current).toBe('v2.1'));
+
+      // Force the cache stale again, advance past the per-attempt throttle, then fire visibilitychange.
+      localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: 'v2.1', ts: Date.now() - ONE_HOUR - 1000 }));
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      mockFetchTag('v2.2');
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      await waitFor(() => expect(result.current).toBe('v2.2'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps the cached value when the API responds with non-ok', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: 'v2.0', ts: Date.now() - ONE_HOUR - 1000 }));
+    mockFetchTag('ignored', false);
+
+    const { result } = renderHook(() => useLatestRelease());
+    expect(result.current).toBe('v2.0');
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(result.current).toBe('v2.0');
+  });
+
+  it('keeps the cached value when fetch rejects', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: 'v2.0', ts: Date.now() - ONE_HOUR - 1000 }));
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('offline'));
+
+    const { result } = renderHook(() => useLatestRelease());
+    expect(result.current).toBe('v2.0');
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(result.current).toBe('v2.0');
+  });
+
+  it('ignores corrupted cache entries', async () => {
+    localStorage.setItem(CACHE_KEY, 'not-json');
+    mockFetchTag('v2.1');
+    const { result } = renderHook(() => useLatestRelease());
+    expect(result.current).toBeNull();
+
+    await waitFor(() => expect(result.current).toBe('v2.1'));
+  });
+
+  it('aborts the in-flight fetch on unmount', () => {
+    const { unmount } = renderHook(() => useLatestRelease());
+    const signal = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.signal as
+      | AbortSignal
+      | undefined;
+    expect(signal).toBeDefined();
+    unmount();
+    expect(signal!.aborted).toBe(true);
+  });
+
+  it('throttles refresh attempts when localStorage throws', async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    try {
+      mockFetchTag('v2.0');
+      renderHook(() => useLatestRelease());
+
+      // Several visibility changes in quick succession should not multiply requests.
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+      for (let i = 0; i < 5; i++) document.dispatchEvent(new Event('visibilitychange'));
+
+      await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
+});

--- a/app/src/hooks/useLatestRelease.ts
+++ b/app/src/hooks/useLatestRelease.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 const API_URL = 'https://api.github.com/repos/MarkusNeusinger/anyplot/releases/latest';
 const CACHE_KEY = 'anyplot:latest-release';
 const TTL_MS = 60 * 60 * 1000;
+const MIN_ATTEMPT_INTERVAL_MS = 60 * 1000;
 
 type Cached = { tag: string; ts: number };
 
@@ -27,10 +28,20 @@ export function useLatestRelease(): string | null {
 
   useEffect(() => {
     let cancelled = false;
+    let inFlight = false;
+    let lastAttempt = 0;
+    const controller = new AbortController();
 
     const refresh = () => {
+      if (cancelled || inFlight) return;
       if (isFresh(readCache())) return;
-      fetch(API_URL)
+      // Guard against repeated calls when localStorage is unavailable —
+      // without this, visibilitychange could spam the API.
+      const now = Date.now();
+      if (now - lastAttempt < MIN_ATTEMPT_INTERVAL_MS) return;
+      lastAttempt = now;
+      inFlight = true;
+      fetch(API_URL, { signal: controller.signal })
         .then((r) => (r.ok ? r.json() : null))
         .then((data) => {
           if (cancelled) return;
@@ -44,7 +55,10 @@ export function useLatestRelease(): string | null {
           }
         })
         .catch(() => {
-          /* offline / rate-limited — fallback stays */
+          /* offline / rate-limited / aborted — fallback stays */
+        })
+        .finally(() => {
+          inFlight = false;
         });
     };
 
@@ -57,6 +71,7 @@ export function useLatestRelease(): string | null {
 
     return () => {
       cancelled = true;
+      controller.abort();
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisible);
     };

--- a/app/src/hooks/useLatestRelease.ts
+++ b/app/src/hooks/useLatestRelease.ts
@@ -2,46 +2,63 @@ import { useEffect, useState } from 'react';
 
 const API_URL = 'https://api.github.com/repos/MarkusNeusinger/anyplot/releases/latest';
 const CACHE_KEY = 'anyplot:latest-release';
-const TTL_MS = 24 * 60 * 60 * 1000;
+const TTL_MS = 60 * 60 * 1000;
 
 type Cached = { tag: string; ts: number };
 
-function readCache(): string | null {
+function readCache(): Cached | null {
   try {
     const raw = localStorage.getItem(CACHE_KEY);
     if (!raw) return null;
     const parsed: Cached = JSON.parse(raw);
-    if (parsed?.tag && Date.now() - parsed.ts < TTL_MS) return parsed.tag;
+    if (parsed?.tag && typeof parsed.ts === 'number') return parsed;
   } catch {
     /* ignore */
   }
   return null;
 }
 
+function isFresh(entry: Cached | null): boolean {
+  return !!entry && Date.now() - entry.ts < TTL_MS;
+}
+
 export function useLatestRelease(): string | null {
-  const [tag, setTag] = useState<string | null>(readCache);
+  const [tag, setTag] = useState<string | null>(() => readCache()?.tag ?? null);
 
   useEffect(() => {
-    if (readCache()) return;
     let cancelled = false;
-    fetch(API_URL)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (cancelled) return;
-        const name: string | undefined = data?.tag_name;
-        if (!name) return;
-        setTag(name);
-        try {
-          localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: name, ts: Date.now() } satisfies Cached));
-        } catch {
-          /* ignore */
-        }
-      })
-      .catch(() => {
-        /* offline / rate-limited — fallback stays */
-      });
+
+    const refresh = () => {
+      if (isFresh(readCache())) return;
+      fetch(API_URL)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (cancelled) return;
+          const name: string | undefined = data?.tag_name;
+          if (!name) return;
+          setTag(name);
+          try {
+            localStorage.setItem(CACHE_KEY, JSON.stringify({ tag: name, ts: Date.now() } satisfies Cached));
+          } catch {
+            /* ignore */
+          }
+        })
+        .catch(() => {
+          /* offline / rate-limited — fallback stays */
+        });
+    };
+
+    refresh();
+    const interval = window.setInterval(refresh, TTL_MS);
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
     return () => {
       cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
     };
   }, []);
 


### PR DESCRIPTION
## Why

The version shown in the masthead (e.g. `v2.0`) was sticky: users reported still seeing `v2.0` after 12+ hours even though `v2.1` had been released.

The bug is in `app/src/hooks/useLatestRelease.ts`:

- TTL was **24 hours**, not 1 hour.
- The hook only fetched on mount when no valid cache existed. If a cache entry was present (within 24h), the effect returned early and never re-fetched — there was no background refresh at all.
- No stale-while-revalidate, no interval, no visibility-change refresh.

So a release published shortly after the user first opened the app would not appear until the 24h cache expired *and* the page was reloaded.

## What changed

`app/src/hooks/useLatestRelease.ts`:

- TTL reduced from 24h → 1h.
- Always render the cached value immediately (even if stale), so the UI never blinks.
- Refresh on mount when the cache is stale, then every hour via `setInterval`, and again whenever the tab becomes visible — covering long-lived tabs and laptop sleep/wake.
- Cache writes are unchanged in shape (`{ tag, ts }`), so existing entries remain readable.

## Test plan

- [x] `yarn type-check` passes
- [x] `yarn test MastheadRule` passes (2/2)
- [ ] Manual: open app, confirm the cached tag still renders instantly on reload
- [ ] Manual: with devtools, set `localStorage['anyplot:latest-release']` to a value with `ts` older than 1h and confirm a fresh `GET /releases/latest` fires on next mount
- [ ] Manual: leave the tab open >1h and confirm the interval fires another fetch


---
_Generated by [Claude Code](https://claude.ai/code/session_0169gs6qP7iNCrbvEgBDKMsC)_