### PR TITLE
chore(workflows): switch daily regen pipeline to Sonnet, ~3.5x throughput

### DIFF
--- a/.github/workflows/bulk-generate.yml
+++ b/.github/workflows/bulk-generate.yml
@@ -33,9 +33,9 @@ on:
         type: boolean
         default: false
       pace_seconds:
-        description: "Seconds to wait between dispatches (0 = fire all at once, default 300 = 5 min)"
+        description: "Seconds to wait between dispatches (0 = fire all at once, default 120 = 2 min)"
         required: false
-        default: '300'
+        default: '120'
 
 env:
   ALL_LIBRARIES: "matplotlib seaborn plotly bokeh altair plotnine pygal highcharts letsplot"
@@ -134,7 +134,7 @@ jobs:
           echo "## Bulk Generation Plan"
           echo ""
           echo "**Total items:** $COUNT"
-          echo "**Pacing:** ${{ inputs.pace_seconds || '300' }}s between dispatches (0 = fire all)"
+          echo "**Pacing:** ${{ inputs.pace_seconds || '120' }}s between dispatches (0 = fire all)"
           echo "**Dry run:** $DRY_RUN"
           echo ""
           echo "### Items to generate:"
@@ -145,8 +145,8 @@ jobs:
   #
   # One runner loops through every (spec, library) pair and dispatches
   # impl-generate.yml with a configurable pause between each call. Default
-  # pace is 300 s (5 min) to stay under the Claude Max concurrency budget and
-  # avoid spinning up 9 heavy generation runs at once.
+  # pace is 120 s (2 min) to stay under the Claude Max concurrency budget on
+  # Sonnet and avoid spinning up 9 heavy generation runs at once.
   # ============================================================================
   generate:
     needs: [build-matrix, preview]
@@ -155,7 +155,7 @@ jobs:
     permissions:
       contents: read
       actions: write
-    # Enough headroom: 9 libs × (300 s pace + ~30 s dispatch) ≈ 50 min;
+    # Enough headroom: 9 libs × (120 s pace + ~30 s dispatch) ≈ 23 min;
     # bulk "all for all" could be very long — clamp at 6 h.
     timeout-minutes: 360
 
@@ -167,7 +167,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MATRIX: ${{ needs.build-matrix.outputs.matrix }}
-          PACE_SECONDS: ${{ inputs.pace_seconds || '300' }}
+          PACE_SECONDS: ${{ inputs.pace_seconds || '120' }}
         run: |
           set -u
 

--- a/.github/workflows/daily-regen.yml
+++ b/.github/workflows/daily-regen.yml
@@ -1,32 +1,30 @@
-name: "Scheduled: Regen oldest spec"
-run-name: "Scheduled regen (${{ github.event.inputs.count || '1' }} spec)"
+name: "Scheduled: Regen oldest specs"
+run-name: "Scheduled regen (${{ github.event.inputs.count || '2' }} specs)"
 
-# Picks the spec whose most-recent implementation `updated` timestamp is
-# furthest in the past and re-dispatches `bulk-generate.yml` for it. One
-# spec per Claude-Max 4-hour reset window.
+# Picks the N oldest specs (by most-recent implementation `updated` timestamp)
+# and re-dispatches `bulk-generate.yml` for each. Default N=2 per cron tick.
 #
-# Schedule: every 4h at 00:00/04:00/08:00/12:00 UTC (02:00/06:00/10:00/14:00
-# Berlin CEST). The 16:00 and 20:00 UTC slots are intentionally skipped so
-# runs never start during the user's 18:00-24:00 Berlin window (when the
-# Claude-Max tokens are needed interactively).
+# Schedule: every 2h between 00:00 and 12:00 UTC (02:00–14:00 Berlin CEST).
+# The 14:00–22:00 UTC slots (16:00–24:00 Berlin) are intentionally skipped so
+# runs never start during the user's 18:00–24:00 Berlin interactive window.
 #
-# Worst-case completion of a spec run (3-repair loops × 9 libs × paced
-# dispatch) is ~2.5 h after bulk-generate starts, so the 12:00 UTC firing
-# still finishes well before 16:00 UTC.
+# bulk-generate is serialised via its own concurrency group, so the 2 dispatched
+# specs run sequentially. With Sonnet + reduced bulk-generate pace, a spec
+# completes well within the 2h slot, leaving the user window clean.
 #
 # Triggers:
-#   - schedule: 4× daily (UTC)
+#   - schedule: 7× daily (UTC, every 2h up to 12:00)
 #   - workflow_dispatch: manual, with inputs for count + dry-run
 
 on:
   schedule:
-    - cron: '0 0,4,8,12 * * *'
+    - cron: '0 0,2,4,6,8,10,12 * * *'
   workflow_dispatch:
     inputs:
       count:
-        description: "How many of the oldest specs to regen (default 1)"
+        description: "How many of the oldest specs to regen (default 2)"
         required: false
-        default: '1'
+        default: '2'
       min_age_hours:
         description: "Skip specs regen'd within this many hours (default 20)"
         required: false
@@ -64,7 +62,7 @@ jobs:
       - name: Pick oldest spec(s)
         id: pick
         env:
-          COUNT: ${{ inputs.count || '1' }}
+          COUNT: ${{ inputs.count || '2' }}
           MIN_AGE_HOURS: ${{ inputs.min_age_hours || '20' }}
         run: |
           python3 <<'PY'

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -324,7 +324,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model sonnet"
           # bulk-generate dispatches us from the github-actions bot; explicitly allow it.
           allowed_bots: '*'
           prompt: |
@@ -343,7 +343,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model sonnet"
           # bulk-generate dispatches us from the github-actions bot; explicitly allow it.
           allowed_bots: '*'
           prompt: |
@@ -482,11 +482,11 @@ jobs:
               'specification_id': spec,
               'created': created_ts,
               'updated': ts,
-              # Reflects what claude_args=`--model opus` actually runs: whatever
-              # Claude Code's current "opus" alias resolves to (today Opus 4.7).
+              # Reflects what claude_args=`--model sonnet` actually runs: whatever
+              # Claude Code's current "sonnet" alias resolves to.
               # Use the family name instead of a frozen version string so the
               # metadata doesn't go stale every model release.
-              'generated_by': 'claude-opus',
+              'generated_by': 'claude-sonnet',
               'workflow_run': run_id,
               'issue': issue,
               'python_version': py_ver,

--- a/.github/workflows/impl-repair.yml
+++ b/.github/workflows/impl-repair.yml
@@ -115,7 +115,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model sonnet"
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/impl-repair-claude.md` and follow those instructions.
@@ -134,7 +134,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model sonnet"
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/impl-repair-claude.md` and follow those instructions.


### PR DESCRIPTION
## Summary

- Switch automated regen from Opus to Sonnet (`impl-generate.yml`, `impl-repair.yml`) to free Claude-Max quota.
- Scale `daily-regen.yml` cadence to match: cron every 2h between 00–12 UTC (7 slots), `count` default 1 → 2 → ~14 specs/day.
- Reduce `bulk-generate.yml` `pace_seconds` 300 → 120 since Sonnet is ~5× cheaper per call; comments/timeout headroom adjusted.
- 18–24 Berlin interactive window remains untouched (last cron at 12:00 UTC = 14:00 Berlin, finishes well before 16:00 UTC = 18:00 Berlin).

Quality gate unchanged: `impl-review.yml` (already Sonnet) scores every PR; sub-90 → 3-attempt repair loop (now also Sonnet); sub-50 after 3 attempts → `not-feasible`.

## Test Plan

- [x] All workflow YAML files parse cleanly (`yaml.safe_load`)
- [x] No remaining `--model opus` / `claude-opus` references in changed files
- [x] No remaining `'300'` pace defaults / `'1'` count defaults
- [ ] After merge: trigger `daily-regen.yml` manually with `dry_run=true` to confirm it picks 2 oldest specs
- [ ] After merge: observe first scheduled run, verify `--model sonnet` in `impl-generate` logs and `generated_by: claude-sonnet` in resulting `metadata/{lib}.yaml`
- [ ] After 24h: confirm ~12–14 specs processed, no queue backlog

## Rollback

`git revert` this commit. Or selectively keep `impl-repair.yml` on Opus as a safety net while leaving generation on Sonnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)