### PR TITLE
fix(app): frontend hook fixes — H27, H28, H29

### DIFF
--- a/app/src/components/SpecTabs.tsx
+++ b/app/src/components/SpecTabs.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, lazy, Suspense } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
@@ -210,13 +211,17 @@ export function SpecTabs({
     return tagCounts[paramName]?.[value] ?? null;
   }, [tagCounts]);
 
-  // Handle tag click - navigate to filtered plots page (full page navigation)
+  const navigate = useNavigate();
+
+  // Handle tag click — in-app navigation (preserves AppDataContext, no full reload).
+  // The previous `window.location.href = …` forced /specs, /libraries, /stats
+  // to be re-fetched on every tag click on a SpecTabs page.
   const handleTagClick = useCallback(
     (paramName: string, value: string) => {
       onTrackEvent?.('tag_click', { param: paramName, value, source: 'spec_detail' });
-      window.location.href = `/?${paramName}=${encodeURIComponent(value)}`;
+      navigate(`/?${paramName}=${encodeURIComponent(value)}`);
     },
-    [onTrackEvent]
+    [navigate, onTrackEvent]
   );
 
   const toggleCategory = (category: string) => {

--- a/app/src/hooks/useFilterFetch.ts
+++ b/app/src/hooks/useFilterFetch.ts
@@ -4,7 +4,7 @@
  * Handles API calls, image shuffling, and pagination state.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 
 import type { PlotImage, ActiveFilters, FilterCounts } from '../types';
 import { API_URL, BATCH_SIZE } from '../constants';
@@ -67,9 +67,15 @@ export function useFilterFetch({
   const skipRef = useRef(skipInitialFetch);
   const initialFiltersRef = useRef(JSON.stringify(activeFilters));
 
+  // Stringify the filters so the effect reruns when CONTENTS change, not when
+  // the parent happens to re-render and hand us a fresh array reference.
+  // Without this memo every parent render re-fired the fetch even when the
+  // filter contents were identical.
+  const filtersKey = useMemo(() => JSON.stringify(activeFilters), [activeFilters]);
+
   useEffect(() => {
     // Skip fetch on first mount if requested and filters match
-    if (skipRef.current && JSON.stringify(activeFilters) === initialFiltersRef.current) {
+    if (skipRef.current && filtersKey === initialFiltersRef.current) {
       skipRef.current = false;
       return;
     }
@@ -81,9 +87,13 @@ export function useFilterFetch({
       setLoading(true);
 
       try {
+        // Parse from the stable string key so the effect doesn't depend on
+        // `activeFilters` directly (whose reference changes per render).
+        const filters: ActiveFilters = JSON.parse(filtersKey);
+
         // Build query string from filters
         const params = new URLSearchParams();
-        activeFilters.forEach(({ category, values }) => {
+        filters.forEach(({ category, values }) => {
           if (values.length > 0) {
             params.append(category, values.join(','));
           }
@@ -125,7 +135,7 @@ export function useFilterFetch({
     fetchFilteredImages();
 
     return () => abortController.abort();
-  }, [activeFilters]);
+  }, [filtersKey]);
 
   return {
     filterCounts,

--- a/app/src/hooks/useFilterState.ts
+++ b/app/src/hooks/useFilterState.ts
@@ -5,7 +5,7 @@
  * Composes useUrlSync and useFilterFetch for cleaner separation of concerns.
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 
 import type { PlotImage, FilterCategory, ActiveFilters, FilterCounts } from '../types';
 import { FILTER_CATEGORIES } from '../types';
@@ -117,22 +117,54 @@ export function useFilterState({
     skipInitialFetch: shouldSkipInitialFetch,
   });
 
-  // Sync state changes back to persistent context
-  useEffect(() => {
-    if (allImages.length > 0 || displayedImages.length > 0) {
-      setHomeState((prev) => ({
-        ...prev,
-        allImages,
-        displayedImages,
+  // Sync state changes back to persistent context.
+  //
+  // Coalesce on a stringified key so the effect only fires when CONTENT
+  // actually changes, not when the parent re-renders and passes new array
+  // references for the same data. Combined with useFilterFetch.ts's
+  // filtersKey memoization, this prevents the sync-back from re-triggering
+  // a fetch when state echoes back through the context.
+  const syncKey = useMemo(
+    () =>
+      JSON.stringify({
+        allImagesLen: allImages.length,
+        displayedLen: displayedImages.length,
         activeFilters,
         filterCounts,
         globalCounts,
         orCounts,
         hasMore,
-        initialized: true,
-      }));
-    }
-  }, [allImages, displayedImages, activeFilters, filterCounts, globalCounts, orCounts, hasMore, setHomeState]);
+      }),
+    [allImages, displayedImages, activeFilters, filterCounts, globalCounts, orCounts, hasMore]
+  );
+  const lastSyncedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (allImages.length === 0 && displayedImages.length === 0) return;
+    if (syncKey === lastSyncedKeyRef.current) return;
+    lastSyncedKeyRef.current = syncKey;
+    setHomeState((prev) => ({
+      ...prev,
+      allImages,
+      displayedImages,
+      activeFilters,
+      filterCounts,
+      globalCounts,
+      orCounts,
+      hasMore,
+      initialized: true,
+    }));
+  }, [
+    syncKey,
+    allImages,
+    displayedImages,
+    activeFilters,
+    filterCounts,
+    globalCounts,
+    orCounts,
+    hasMore,
+    setHomeState,
+  ]);
 
   // Add a new filter group (creates new chip - AND with other groups)
   const handleAddFilter = useCallback((category: FilterCategory, value: string) => {


### PR DESCRIPTION
## Summary

Three related render/perf fixes flagged by the 2026-04-26 audit. All in `app/src/{components,hooks}/`; no API surface changes.

## Fixes

- **H27** `SpecTabs.tsx:217` — replace `window.location.href = …` with `useNavigate()`. Previously every tag click on a SpecTabs page forced a full page reload, dropping AppDataContext and re-fetching `/specs`, `/libraries`, `/stats`.
- **H28** `useFilterFetch.ts:70` — depend on memoized `JSON.stringify(activeFilters)` instead of the array reference. Effect body parses filters from the stable key. Stops re-fetches caused by parent re-renders producing new array references with identical contents.
- **H29** `useFilterState.ts:121` — coalesce the sync-back-to-context effect on a stringified `syncKey` plus a `lastSyncedKeyRef`. Combined with H28, prevents sync-back → fetch loops when state echoes back through `useHomeState`.

## Test plan

- [x] `cd app && yarn tsc --noEmit` — clean
- [x] `cd app && yarn test --run` on SpecTabs / useFilterFetch / useFilterState — 36 tests pass
- [x] `yarn lint` introduces zero new errors (29 pre-existing on main, unrelated)
- [ ] CI checks pass on this PR
- [ ] Manual: smoke test in dev — click a tag chip on a spec page, confirm it navigates without full reload (check Network panel)
- [ ] Manual: rapidly toggle filters on `/plots`, confirm only one fetch fires per content change (not per render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)