### PR TITLE
feat(seo): route search bots through prerender + add code-sample JSON-LD

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -75,6 +75,40 @@
     }
     </script>
 
+    <!-- WebSite + SearchAction (sitelinks search box eligibility) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "anyplot.ai",
+      "url": "https://anyplot.ai",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "https://anyplot.ai/plots?q={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
+
+    <!-- Organization (brand entity recognition) -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "anyplot",
+      "url": "https://anyplot.ai",
+      "logo": "https://anyplot.ai/og-image.png",
+      "description": "Open plot catalogue with AI-generated implementations across 9 Python libraries.",
+      "sameAs": [
+        "https://github.com/MarkusNeusinger/anyplot",
+        "https://www.linkedin.com/in/markus-neusinger/"
+      ]
+    }
+    </script>
+
     <!-- Privacy-friendly analytics by Plausible (production only) -->
     <script>
       window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -1,9 +1,23 @@
-# Bot detection for SEO - social media crawlers need pre-rendered meta tags
-# These bots cannot execute JavaScript, so we serve them pre-rendered HTML with og:tags
-# NOTE: Search engines (Googlebot, Bingbot, etc.) are NOT included here — they can
-# render JavaScript since 2019 and should see the full SPA for proper indexing.
+# Bot detection for SEO — these bots get pre-rendered HTML with og:tags from
+# /seo-proxy/, social bots (no JS) and search-engine bots alike. Google
+# explicitly says serving prerendered HTML to crawlers is fine as long as the
+# content matches what humans see; for a content-driven catalogue with ~3000
+# spec/impl pages, having every URL claim the homepage's title/canonical/og:url
+# (the SPA shell) costs weeks of indexing latency on new pages and risks the
+# wrong title/description being indexed when client-side rendering fails.
 map $http_user_agent $is_bot {
     default 0;
+    # Search engines — historically excluded "because they render JS since 2019",
+    # but in practice the prerendered HTML produces faster, more reliable
+    # indexing for a content-driven catalogue. Verify after rollout with
+    # `curl -A "Googlebot" https://anyplot.ai/scatter-basic` — should return
+    # the per-route title/canonical/og:url, not the empty SPA shell.
+    ~*googlebot 1;
+    ~*bingbot 1;
+    ~*duckduckbot 1;
+    ~*yandexbot 1;
+    ~*baiduspider 1;
+    ~*applebot 1;
     # Social Media
     ~*twitterbot 1;
     ~*facebookexternalhit 1;

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -344,6 +344,28 @@ export function SpecPage() {
     })),
   };
 
+  // SoftwareSourceCode schema for impl detail pages — eligibility for Google's
+  // code-sample rich result and SGE/AIO surfaces. anyplot's unique content IS
+  // the LLM-generated source code samples (2696 impl pages), so this is the
+  // single biggest unrealized SEO lever per the 2026-04-26 audit.
+  const softwareSourceJsonLd =
+    mode === 'detail' && urlLanguage && selectedLibrary
+      ? {
+          '@context': 'https://schema.org',
+          '@type': 'SoftwareSourceCode',
+          name: `${specData.title} (${selectedLibrary})`,
+          description: specData.description,
+          programmingLanguage: urlLanguage === 'python' ? 'Python' : urlLanguage,
+          codeSampleType: 'code snippet',
+          codeRepository: 'https://github.com/MarkusNeusinger/anyplot',
+          url: canonical,
+          isBasedOn: `https://anyplot.ai/${specId}`,
+          author: { '@type': 'Organization', name: 'anyplot', url: 'https://anyplot.ai' },
+          license: 'https://opensource.org/licenses/MIT',
+          ...(currentImpl?.preview_url ? { image: currentImpl.preview_url } : {}),
+        }
+      : null;
+
   return (
     <>
       <Helmet>
@@ -355,6 +377,11 @@ export function SpecPage() {
         <meta property="og:url" content={canonical} />
         <link rel="canonical" href={canonical} />
         <script type="application/ld+json">{JSON.stringify(breadcrumbJsonLd).replace(/</g, '\\u003c')}</script>
+        {softwareSourceJsonLd && (
+          <script type="application/ld+json">
+            {JSON.stringify(softwareSourceJsonLd).replace(/</g, '\\u003c')}
+          </script>
+        )}
       </Helmet>
 
       <Box sx={{ pt: 1.5, pb: 4 }}>


### PR DESCRIPTION
## Summary

Two SEO levers from the 2026-04-26 audit that together cover the biggest unrealized search-visibility gap on a content-driven catalogue of ~3000 spec/impl pages.

## H25 — Route Googlebot/Bingbot/etc. through `/seo-proxy/`

`app/nginx.conf` previously routed only social bots through the per-route prerender. Search engines fell back to the SPA shell — every one of the ~3017 sitemap URLs claimed the homepage's title/og:url/canonical, with the actual content materializing only after JS rendered.

Added to the `$is_bot` map: `googlebot`, `bingbot`, `duckduckbot`, `yandexbot`, `baiduspider`, `applebot`.

**Verify after rollout:**
```bash
curl -A "Googlebot" https://anyplot.ai/scatter-basic
# expect per-route <title>, <link rel="canonical">, <meta property="og:url"> —
# NOT the empty SPA shell.
```

## H26 — SoftwareSourceCode + WebSite + Organization JSON-LD

Previously the only JSON-LD blocks were `WebApplication` (site-wide) and `BreadcrumbList` (per page). This PR adds:

- **`WebSite + SearchAction`** (site-wide, `app/index.html`) — sitelinks search box eligibility on brand queries.
- **`Organization`** (site-wide, `app/index.html`) — brand entity recognition; links to GitHub repo + maintainer LinkedIn.
- **`SoftwareSourceCode`** (per impl page, `app/src/pages/SpecPage.tsx`) — eligibility for Google's code-sample rich result and SGE/AIO surfaces. anyplot's unique content IS the LLM-generated source code samples (2696 impl pages); audit flagged this as the single biggest unrealized SEO lever.

The SoftwareSourceCode block fires only on `mode === 'detail'` (language + library present in URL), references the spec hub via `isBasedOn`, includes the preview image when available, and labels the license as MIT.

## Test plan

- [x] `cd app && yarn tsc --noEmit` — clean
- [x] `cd app && yarn test --run src/pages/SpecPage.test.tsx` — 8 tests pass
- [x] All 3 site-level JSON-LD blocks parse cleanly via `JSON.parse`
- [ ] CI checks pass on this PR
- [ ] Manual after deploy: `curl -A "Googlebot" https://anyplot.ai/area-basic` returns per-route title (not the SPA shell)
- [ ] Manual after deploy: validate impl pages at https://validator.schema.org/ for SoftwareSourceCode + Organization
- [ ] Manual after deploy: Search Console → "URL inspection" on a sample impl URL → confirm Google sees the per-route content

🤖 Generated with [Claude Code](https://claude.com/claude-code)