### PR TITLE
chore(audit): post-merge CI fix — ruff format + DebugPage auth tests

### DIFF
--- a/app/src/pages/DebugPage.test.tsx
+++ b/app/src/pages/DebugPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 import { render, screen, waitFor } from '../test-utils';
 
 import { DebugPage } from './DebugPage';
@@ -81,6 +82,84 @@ describe('DebugPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
     });
+  });
+
+  // /debug routes are gated by `require_admin` (api/routers/debug.py). The
+  // browser handles the gate via an X-Admin-Token sessionStorage UX; these
+  // tests cover the 401/503 branch + submit/clear flow that the existing
+  // tests miss (and the codecov/patch gate flagged at 65% diff coverage).
+  it('renders the admin-token form on 401', async () => {
+    sessionStorage.clear();
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 401 })));
+
+    render(<DebugPage />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('X-Admin-Token')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /unlock/i })).toBeInTheDocument();
+    expect(screen.getByText(/admin token required/i)).toBeInTheDocument();
+  });
+
+  it('renders the admin-token form on 503 with the not-configured hint', async () => {
+    sessionStorage.clear();
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 503 })));
+
+    render(<DebugPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/admin auth not configured/i)).toBeInTheDocument();
+    });
+  });
+
+  it('submits the token, sends X-Admin-Token, and persists to sessionStorage', async () => {
+    sessionStorage.clear();
+    let callIndex = 0;
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      callIndex += 1;
+      // First /debug/status → 401 (no token yet); subsequent calls → ok.
+      if (url.includes('/debug/ping')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ database_connected: true, response_time_ms: 10, timestamp: '2026-04-27T00:00:00Z' }),
+        });
+      }
+      if (callIndex === 1) {
+        return Promise.resolve({ ok: false, status: 401 });
+      }
+      // Verify the header is sent on the retry.
+      const hdr = (init?.headers as Record<string, string> | undefined)?.['X-Admin-Token'];
+      if (hdr !== 'secret-xyz') return Promise.resolve({ ok: false, status: 401 });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockDebugData) });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DebugPage />);
+
+    const input = await screen.findByPlaceholderText('X-Admin-Token');
+    fireEvent.change(input, { target: { value: 'secret-xyz' } });
+    fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText('scatter-basic').length).toBeGreaterThan(0);
+    });
+    expect(sessionStorage.getItem('anyplot.adminToken')).toBe('secret-xyz');
+  });
+
+  it('clears the stored token and re-prompts', async () => {
+    sessionStorage.setItem('anyplot.adminToken', 'stored-token');
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 401 })));
+
+    render(<DebugPage />);
+
+    const clearBtn = await screen.findByRole('button', { name: /clear stored token/i });
+    fireEvent.click(clearBtn);
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem('anyplot.adminToken')).toBeNull();
+    });
+    // Form is still on screen because fetch still returns 401.
+    expect(screen.getByPlaceholderText('X-Admin-Token')).toBeInTheDocument();
   });
 
 });

--- a/core/database/repositories.py
+++ b/core/database/repositories.py
@@ -161,9 +161,7 @@ class SpecRepository(BaseRepository[Spec]):
         session must use `get_all_with_code()` to avoid MissingGreenlet.
         """
         impls_loader = selectinload(Spec.impls)
-        result = await self.session.execute(
-            select(Spec).options(impls_loader.selectinload(Impl.library))
-        )
+        result = await self.session.execute(select(Spec).options(impls_loader.selectinload(Impl.library)))
         return list(result.scalars().all())
 
     async def get_all_with_code(self) -> list[Spec]:


### PR DESCRIPTION
## Summary

Post-merge follow-up to #5453. Two checks were red on that PR (codecov-patch + Run Linting); the PR was merged anyway, so main is currently lint-broken.

- **ruff format** wanted `core/database/repositories.py:161-165` collapsed onto one line (the multi-line call fit within line-length after the `get_all()` simplification in 4d3e5d3c).
- **codecov/patch/frontend** flagged 65.38% diff coverage (target 80%) — the admin-token branch in `DebugPage.tsx` (401/503 → token form, submit flow, sessionStorage persistence, clear) had no tests. Added 4 cases.

## Test plan

- [x] `uv run ruff format --check .` — clean
- [x] `cd app && yarn tsc --noEmit` — clean
- [x] `cd app && yarn test --run` — 396 tests pass (was 392, +4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)