### PR TITLE
ci: skip GCP-secret steps on Dependabot PRs

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,15 +90,19 @@ jobs:
       if: steps.check.outputs.should_test == 'true'
       run: uv sync --extra test
 
+    # Dependabot PRs run from forks and cannot access repository secrets,
+    # so skip GCP auth + Cloud SQL Proxy + Codecov upload. Only unit and
+    # integration tests run for Dependabot (no e2e — those need real Postgres).
+
     - name: Authenticate to GCP
-      if: steps.check.outputs.should_test == 'true'
+      if: steps.check.outputs.should_test == 'true' && github.actor != 'dependabot[bot]'
       uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
       with:
         project_id: anyplot
         workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
     - name: Start Cloud SQL Proxy
-      if: steps.check.outputs.should_test == 'true'
+      if: steps.check.outputs.should_test == 'true' && github.actor != 'dependabot[bot]'
       run: |
         # Download Cloud SQL Proxy
         curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.14.3/cloud-sql-proxy.linux.amd64
@@ -114,7 +118,7 @@ jobs:
         echo "DATABASE_URL=postgresql+asyncpg://${{ secrets.DB_USER }}:${{ secrets.DB_PASS }}@localhost:5432/${{ secrets.DB_NAME }}" >> $GITHUB_ENV
 
     - name: Run all tests with coverage
-      if: steps.check.outputs.should_test == 'true'
+      if: steps.check.outputs.should_test == 'true' && github.actor != 'dependabot[bot]'
       run: |
         uv run pytest tests/unit tests/integration tests/e2e \
           -v --tb=short \
@@ -126,8 +130,13 @@ jobs:
       # - Integration tests: SQLite in-memory for repository layer
       # - E2E tests: Real PostgreSQL with separate 'test' database
 
+    - name: Run unit + integration tests (Dependabot)
+      if: steps.check.outputs.should_test == 'true' && github.actor == 'dependabot[bot]'
+      run: |
+        uv run pytest tests/unit tests/integration -v --tb=short
+
     - name: Upload coverage to GitHub Artifacts
-      if: steps.check.outputs.should_test == 'true' && always()
+      if: steps.check.outputs.should_test == 'true' && github.actor != 'dependabot[bot]' && always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
       with:
         name: coverage-report
@@ -135,7 +144,7 @@ jobs:
         retention-days: 30
 
     - name: Upload coverage to Codecov
-      if: steps.check.outputs.should_test == 'true'
+      if: steps.check.outputs.should_test == 'true' && github.actor != 'dependabot[bot]'
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Dependabot PRs run from a fork and can't access repository secrets, so the `google-github-actions/auth` step fails with `workload_identity_provider missing` and the whole `Run Tests` job is marked red — even when the actual dependency update is fine
- This causes false negatives across all Python deps PRs (5510-5514) and hides real regressions
- Skip GCP auth, Cloud SQL Proxy, and Codecov upload when `github.actor == 'dependabot[bot]'`
- Run only `tests/unit` + `tests/integration` for Dependabot (use SQLite in-memory, no secrets needed). E2E tests still restricted to non-Dependabot runs

## Validation
Locally merged all 8 open Dependabot branches into a test branch and ran:
- `uv sync --all-extras` — clean
- `uv run ruff check .` + `ruff format --check` — pass
- `uv run pytest tests/unit tests/integration` — **1370 passed**
- `yarn tsc --noEmit` + `yarn build` — pass

So the deps themselves are fine; only the workflow needed the fix.

## Test plan
- [ ] Merge → next Dependabot PR (or rebase an existing one) should show a green `Run Tests` job
- [ ] Confirm a normal (non-Dependabot) PR still runs the full suite incl. e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)