### PR TITLE
fix(workflows): restore Actions Expression interpolation in Claude prompts

### DIFF
--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -154,10 +154,10 @@ jobs:
             Read `prompts/workflow-prompts/ai-quality-review.md` and follow those instructions.
 
             Variables for this run:
-            - LIBRARY: $LIBRARY
-            - SPEC_ID: $SPEC_ID
-            - PR_NUMBER: $PR_NUMBER
-            - ATTEMPT: $ATTEMPT
+            - LIBRARY: ${{ steps.pr.outputs.library }}
+            - SPEC_ID: ${{ steps.pr.outputs.specification_id }}
+            - PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+            - ATTEMPT: ${{ steps.attempts.outputs.display }}
 
       - name: Extract quality score
         id: score

--- a/.github/workflows/report-validate.yml
+++ b/.github/workflows/report-validate.yml
@@ -71,12 +71,12 @@ jobs:
             You are validating a user-submitted issue report for anyplot.
 
             ### Issue Details
-            - **Title:** $ISSUE_TITLE
-            - **Number:** #$ISSUE_NUMBER
-            - **Author:** $ISSUE_USER
+            - **Title:** ${{ github.event.issue.title }}
+            - **Number:** #${{ github.event.issue.number }}
+            - **Author:** ${{ github.event.issue.user.login }}
             - **Body:**
             ```
-            $ISSUE_BODY
+            ${{ github.event.issue.body }}
             ```
 
             ---

--- a/.github/workflows/spec-create.yml
+++ b/.github/workflows/spec-create.yml
@@ -84,12 +84,12 @@ jobs:
             You are creating a new plot specification.
 
             ### Issue Details
-            - **Title:** $ISSUE_TITLE
-            - **Number:** #$ISSUE_NUMBER
-            - **Author:** $ISSUE_USER
+            - **Title:** ${{ github.event.issue.title }}
+            - **Number:** #${{ github.event.issue.number }}
+            - **Author:** ${{ github.event.issue.user.login }}
             - **Body:**
             ```
-            $ISSUE_BODY
+            ${{ github.event.issue.body }}
             ```
 
             ---
@@ -193,12 +193,12 @@ jobs:
             You are creating a new plot specification.
 
             ### Issue Details
-            - **Title:** $ISSUE_TITLE
-            - **Number:** #$ISSUE_NUMBER
-            - **Author:** $ISSUE_USER
+            - **Title:** ${{ github.event.issue.title }}
+            - **Number:** #${{ github.event.issue.number }}
+            - **Author:** ${{ github.event.issue.user.login }}
             - **Body:**
             ```
-            $ISSUE_BODY
+            ${{ github.event.issue.body }}
             ```
 
             ---


### PR DESCRIPTION
## Summary

Three workflows (`impl-review.yml`, `spec-create.yml`, `report-validate.yml`) used shell-style `$VAR` inside `with: prompt: |` blocks of `claude-code-action`. That block is a YAML string handed to a Node/Bun action — **no shell ever runs**, so `$VAR` was sent to Claude as a literal placeholder instead of the actual value. Result: Claude couldn't reliably identify the PR / spec / library to review and silently produced no `quality_score.txt`, which the validate step turns into `ai-review-failed`.

## Symptoms observed today (2026-04-29)

5 stuck implementation PRs from 2026-04-27, all with `ai-review-failed` despite the prior fixes branch (#5410) and the audit branch (#5515) landing in between:

| PR | Branch | Pre-fix labels |
|----|--------|----------------|
| #5476 | seaborn/marimekko-basic | `ai-review-failed`, `quality:78` |
| #5480 | altair/marimekko-basic | `ai-review-failed`, `quality:82` |
| #5481 | letsplot/marimekko-basic | `ai-rejected`, `quality:76` |
| #5483 | plotnine/marimekko-basic | `ai-review-failed` |
| #5486 | plotly/line-basic | `ai-review-failed` |

Re-dispatching review on each confirmed the bug: the run log of `Run AI Quality Review` shows the prompt being passed verbatim:

```
PROMPT: Read prompts/workflow-prompts/ai-quality-review.md and follow those instructions.

Variables for this run:
- LIBRARY: $LIBRARY    # ← literal, never expanded
- SPEC_ID: $SPEC_ID
- PR_NUMBER: $PR_NUMBER
- ATTEMPT: $ATTEMPT
```

Claude's review then either ran for ~20s and exited with no `quality_score.txt` (4 PRs failed), or recovered by inferring values from cwd (1 PR succeeded with `quality:82`). The intermittent pattern is exactly what you'd expect from "the prompt is ambiguous and Claude has to guess from context."

## Root cause

Commit `252977cf3` ("chore: fix critical audit findings", 2026-04-28 22:46) routed several `${{ github.event.* }}` and step-output values through step-level `env:` and rewrote the in-prompt references as `$VAR`. That is the correct mitigation for `run:` shell steps and Python heredocs in the same workflows (and those changes stay in place). Inside `with: prompt: |` it is the wrong tool: the value is consumed by a JS action, not a shell, so there is no injection surface to mitigate and `$VAR` does not interpolate.

`spec-create.yml` and `report-validate.yml` carry the identical anti-pattern in their `prompt:` blocks. They haven't surfaced as failures yet only because no triggering issue has come in since 2026-04-28.

## The fix

Revert **only** the descriptive header lines of each `prompt:` block back to GitHub Actions Expression syntax (`${{ ... }}`), which the runner substitutes into the YAML string before the action receives it. Keep:

- All `env:` blocks (harmless; lets future prompt content reference env vars if useful)
- All `$VAR` references inside **embedded bash code samples** in the prompt (e.g. `gh issue edit $ISSUE_NUMBER`). Those are executed by Claude's Bash tool which inherits the step `env:` and expands them correctly — and rewriting them would re-enable the injection vector the audit was right to close.

```diff
             Variables for this run:
-            - LIBRARY: $LIBRARY
-            - SPEC_ID: $SPEC_ID
-            - PR_NUMBER: $PR_NUMBER
-            - ATTEMPT: $ATTEMPT
+            - LIBRARY: ${{ steps.pr.outputs.library }}
+            - SPEC_ID: ${{ steps.pr.outputs.specification_id }}
+            - PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+            - ATTEMPT: ${{ steps.attempts.outputs.display }}
```

(analogous 8-line revert in `spec-create.yml` × 2 prompt blocks and 4-line revert in `report-validate.yml`).

Diff total: **3 files, 16 ±**.

## Test plan

- [ ] After merge, redispatch `impl-review.yml` for the 4 stuck PRs (`gh workflow run impl-review.yml -f pr_number=<N>` for 5476, 5483, 5486; 5480 already got a 82 in the redispatch and should now stabilize)
- [ ] Verify each run's `Run AI Quality Review` step log shows real values (e.g. `- LIBRARY: plotly`) in the PROMPT echo, not `$LIBRARY`
- [ ] Verify `quality_score.txt` is produced and `ai-review-failed` label is removed
- [ ] On next `spec-request`-labeled issue, verify the spec-create prompt sees the issue title/body
- [ ] On next `report-pending`-labeled issue, verify the report-validate prompt sees the issue title/body

🤖 Generated with [Claude Code](https://claude.com/claude-code)