### PR TITLE
fix(impl-merge): use ADMIN_TOKEN PAT so --admin can bypass main ruleset

### DIFF
--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -178,10 +178,20 @@ jobs:
       - name: Merge PR to main (with retry)
         if: steps.check.outputs.should_run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # ADMIN_TOKEN: PAT with admin scope from a repo-admin user, used so
+          # that `gh pr merge --admin` can bypass the main-branch ruleset
+          # (required-status-checks). Falls back to GITHUB_TOKEN if not set so
+          # the workflow still runs and fails with a clear ruleset error
+          # instead of an opaque auth error.
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.check.outputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
+          HAS_ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN != '' }}
         run: |
+          if [ "$HAS_ADMIN_TOKEN" != "true" ]; then
+            echo "::warning::ADMIN_TOKEN secret is not set — merge will fail if main ruleset enforces required status checks. Add a fine-grained PAT with Contents:Write + Pull requests:Write + Administration:Read+Write as repo secret ADMIN_TOKEN."
+          fi
+
           MAX_ATTEMPTS=5
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
@@ -197,6 +207,9 @@ jobs:
             # downstream CI workflows (Run Linting / Run Tests / Run Frontend
             # Tests), so impl PRs never get those checks. The pipeline already
             # gates merge behind the AI quality review threshold.
+            #
+            # Bypass only works if the token has admin role. GITHUB_TOKEN is
+            # only `write`, so a repo-admin PAT is required (ADMIN_TOKEN).
             if gh pr merge "$PR_NUM" \
               --repo "$REPOSITORY" \
               --squash \


### PR DESCRIPTION
## Summary

Follow-up to #5521 (which added `--admin` to `gh pr merge`). That change alone wasn't enough — verified just now: 3 dispatched merges (#5476, #5480, #5481) all failed identically with:

```
GraphQL: Repository rule violations found
3 of 3 required status checks are expected.
(mergePullRequest)
```

## Why --admin alone didn't work

The `main` ruleset's bypass list contains only `RepositoryRole admin` (mode: `pull_request`). Default `GITHUB_TOKEN` runs as `github-actions[bot]` with `write` role — not admin — so the API rejects the bypass.

```bash
gh api repos/MarkusNeusinger/anyplot/rulesets/10578859 --jq '.bypass_actors'
# [{"actor_id":5,"actor_type":"RepositoryRole","bypass_mode":"pull_request"}]
```

## The fix

Route **only the merge step** through a repo-admin PAT (`ADMIN_TOKEN`). All other steps in `impl-merge.yml` and the rest of the impl-* workflows keep using `GITHUB_TOKEN`. Bypass scope is therefore exactly one step, not the whole pipeline.

```diff
       - name: Merge PR to main (with retry)
         if: steps.check.outputs.should_run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.check.outputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
+          HAS_ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN != '' }}
         run: |
+          if [ "$HAS_ADMIN_TOKEN" != "true" ]; then
+            echo "::warning::ADMIN_TOKEN secret is not set..."
+          fi
```

The fallback `secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN` and the warning preserve the previous behavior if `ADMIN_TOKEN` isn't set yet — workflow still runs, fails with the same ruleset error as before, but the log says clearly what's missing instead of an opaque auth error.

## Required after merge

1. **Create PAT**: Settings → Developer settings → Personal access tokens → Fine-grained
   - Repository: `anyplot`
   - Permissions:
     - Contents: Read+Write
     - Pull requests: Read+Write
     - Administration: Read+Write
     - Metadata: Read
2. **Set secret**: Settings → Secrets and variables → Actions → New repository secret
   - Name: `ADMIN_TOKEN`
   - Value: the PAT

## Considered alternatives

| Option | Verdict |
|--------|---------|
| Add `github-actions[bot]` as bypass actor on ruleset | broader blast radius — *every* workflow run could bypass main |
| Remove the 3 required checks from ruleset | weakens protection for human PRs too |
| Push from impl-generate via PAT so CI triggers naturally | cleanest semantically but needs PAT in 3 workflows + same maintenance overhead |
| **Scope PAT to merge step only (this PR)** | smallest blast radius, matches the actual permission gap |

## Test plan

- [ ] Merge this PR
- [ ] Create the fine-grained PAT and add as `ADMIN_TOKEN` repo secret
- [ ] Re-dispatch `impl-merge.yml` for the 3 stuck approved PRs (#5476 seaborn, #5480 altair, #5481 letsplot)
- [ ] Verify each merges successfully on attempt 1 (no ruleset error in run log)
- [ ] Verify metadata file created, GCS staging→production promotion done, parent issue gets `impl:{library}:done` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)