### PR TITLE
fix(config): use NoDecode so ADMIN_ALLOWED_EMAILS comma form works at startup

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -5,10 +5,10 @@ All environment variables are defined here with type validation,
 defaults, and documentation.
 """
 
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 from pydantic import field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -167,11 +167,13 @@ class Settings(BaseSettings):
     """Cloudflare Access Application AUD tag (UUID from the Zero Trust
     dashboard). Validated as the JWT `aud` claim."""
 
-    admin_allowed_emails: list[str] = []
+    admin_allowed_emails: Annotated[list[str], NoDecode] = []
     """Email addresses allowed to authenticate via Cloudflare Access for
     /debug/* endpoints. Defaults to an empty list — must be set explicitly
     in production. Accepts either a JSON array (`["a@b.com","c@d.com"]`)
-    or a comma-separated string (`a@b.com,c@d.com`) when set via env var."""
+    or a comma-separated string (`a@b.com,c@d.com`) when set via env var.
+    `NoDecode` keeps pydantic-settings from JSON-parsing the env value
+    before our field_validator runs (so a comma-separated string is OK)."""
 
     @field_validator("admin_allowed_emails", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary

After PR #5524 was merged, the API container failed to start with:

\`\`\`
pydantic_settings.exceptions.SettingsError: error parsing value
for field \"admin_allowed_emails\" from source \"EnvSettingsSource\"
\`\`\`

PR #5522 added a \`field_validator(mode=\"before\")\` to accept both JSON-array and comma-separated env values, but pydantic-settings runs its **own** JSON pre-decode for any \`list\`-typed field **before** field validators run. Since \`meakeiok@gmail.com\` is not valid JSON, pre-decode raised \`SettingsError\` before our validator was reached.

## Fix

\`Annotated[list[str], NoDecode]\` opts the field out of pydantic-settings' JSON pre-decode, so the existing validator handles both forms.

## Verified locally (against latest main + this fix)

| Env value | Parsed |
|-----------|--------|
| \`meakeiok@gmail.com\` (the failing case) | \`['meakeiok@gmail.com']\` |
| \`[\"a@b.com\",\"c@d.com\"]\` (JSON form) | \`['a@b.com', 'c@d.com']\` |
| \`a@b.com,c@d.com\` (multi-email comma) | \`['a@b.com', 'c@d.com']\` |
| (unset) | \`[]\` |

Existing test suite: \`34 passed\` in \`tests/unit/api/test_debug.py\`.

## Test plan
- [x] Local reproduction of pre-fix SettingsError
- [x] All four input shapes parse correctly post-fix
- [x] \`uv run ruff check core/config.py\` clean
- [x] \`pytest tests/unit/api/test_debug.py\` 34/34 pass
- [ ] Cloud Build deploys without the SettingsError after merge
- [ ] Container starts and \`/debug/ping\` is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)