### PR TITLE
fix(workflows): remove empty env: block breaking impl-generate dispatch

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -39,13 +39,6 @@ concurrency:
   group: impl-generate-${{ inputs.specification_id || github.event.issue.number }}-${{ inputs.library || github.event.label.name }}
   cancel-in-progress: false
 
-env:
-  # Library dependencies mapping
-  # Per-library deps now come from `pyproject.toml` `lib-{library}` extras —
-  # see [project.optional-dependencies] there. Keeping this list in sync was
-  # painful and silently drifted (this env block lagged the pyproject floors
-  # by a full major version on plotly/altair). Single source of truth wins.
-
 jobs:
   generate:
     # Run on label trigger OR workflow_dispatch


### PR DESCRIPTION
## Summary
- `impl-generate.yml`'s `env:` block has contained only comments since #5453 removed the `DEPS_*` variables. YAML parses a comment-only mapping as `null`, and the GitHub Actions API rejects every `workflow_dispatch` with `HTTP 422 — Unexpected value ''` (Line 42, Col 5).
- This has silently broken **every regen since 2026-04-27 12:05 UTC**. `bulk-generate` reports the dispatch failures internally, but `daily-regen` still finishes as ✅ success, so the outage went unnoticed.
- Fix: drop the empty block.

## Evidence
Bulk-generate runs since the regression:
- `#25108748143` (2026-04-29 12:26) — failure (all 9 dispatches 422)
- `#25104030541` (2026-04-29 10:34) — failure (all 9 dispatches 422)
- `#25114949786` (2026-04-29 14:30) — cancelled, same failure pattern

## Test plan
- [ ] `daily-regen.yml` cron at next slot succeeds with at least one impl-generate dispatched
- [ ] Manual `bulk-generate.yml` for `line-basic / all` dispatches all 9 libraries (smoke test once merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)