### PR TITLE
fix(debug): hard-reload on TypeError to fire CF Access page-gate

### DIFF
--- a/app/src/pages/DebugPage.test.tsx
+++ b/app/src/pages/DebugPage.test.tsx
@@ -187,4 +187,44 @@ describe('DebugPage', () => {
     expect(screen.getByPlaceholderText('Admin token (fallback)')).toBeInTheDocument();
   });
 
+  // The SPA-routed entry into /debug bypasses Cloudflare Access's page-level
+  // intercept (no server roundtrip = no 302 to login). The first API fetch
+  // then hits CF Access and 302s cross-origin to *.cloudflareaccess.com,
+  // which fetch can't follow without CORS, surfacing as TypeError. The page
+  // bootstraps the gate by triggering one top-level navigation.
+  it('forces a top-level navigation on TypeError and sets the reload guard', async () => {
+    sessionStorage.clear();
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))));
+    const replaceSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, replace: replaceSpy, href: 'https://anyplot.ai/debug' },
+    });
+
+    render(<DebugPage />);
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(replaceSpy).toHaveBeenCalledWith('https://anyplot.ai/debug');
+    expect(sessionStorage.getItem('anyplot.debugAuthReloaded')).toBe('1');
+  });
+
+  it('does not loop: second TypeError after the guard is set surfaces the error', async () => {
+    sessionStorage.setItem('anyplot.debugAuthReloaded', '1');
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))));
+    const replaceSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, replace: replaceSpy, href: 'https://anyplot.ai/debug' },
+    });
+
+    render(<DebugPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to fetch/i)).toBeInTheDocument();
+    });
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
 });

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -169,6 +169,8 @@ function pingColor(ms: number): string {
 //     in sessionStorage so it survives reloads of the same tab without
 //     persisting across browser sessions.
 const ADMIN_TOKEN_KEY = 'anyplot.adminToken';
+// One-shot guard for the SPA-routed → CF Access page-gate bootstrap.
+const RELOAD_GUARD_KEY = 'anyplot.debugAuthReloaded';
 const readAdminToken = (): string => {
   try { return sessionStorage.getItem(ADMIN_TOKEN_KEY) ?? ''; } catch { return ''; }
 };
@@ -208,10 +210,11 @@ export function DebugPage() {
     setError(null);
     adminFetch(`${DEBUG_API_URL}/debug/status`, adminToken)
       .then(async r => {
-        // Reaching the .then path means the fetch resolved cleanly — clear
-        // the one-shot reload guard so a future cross-origin redirect can
+        // Reaching here means the fetch promise resolved (the response may
+        // still be 401/403/503 — those are handled below). Clear the one-shot
+        // reload guard so a future cross-origin CF Access redirect can
         // re-trigger the bootstrap.
-        try { sessionStorage.removeItem('anyplot.debugAuthReloaded'); } catch {}
+        try { sessionStorage.removeItem(RELOAD_GUARD_KEY); } catch {}
         // 403 is the Cloudflare Access JWT path's denial: a signed-in Google
         // account that isn't on the admin_allowed_emails allow-list. Surface
         // it on the auth-required screen with the server's message so the
@@ -239,10 +242,13 @@ export function DebugPage() {
         // the second load ALSO fails (e.g. wrong allow-list).
         if (e instanceof TypeError) {
           let alreadyTried = false;
-          try { alreadyTried = !!sessionStorage.getItem('anyplot.debugAuthReloaded'); } catch {}
+          try { alreadyTried = !!sessionStorage.getItem(RELOAD_GUARD_KEY); } catch {}
           if (!alreadyTried) {
-            try { sessionStorage.setItem('anyplot.debugAuthReloaded', '1'); } catch {}
-            window.location.assign(window.location.href);
+            try { sessionStorage.setItem(RELOAD_GUARD_KEY, '1'); } catch {}
+            // replace() not assign() — assign would push the broken pre-auth
+            // /debug onto the back-stack, so the user could navigate back
+            // into the same loop after logging in.
+            window.location.replace(window.location.href);
             return;
           }
         }

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -208,6 +208,10 @@ export function DebugPage() {
     setError(null);
     adminFetch(`${DEBUG_API_URL}/debug/status`, adminToken)
       .then(async r => {
+        // Reaching the .then path means the fetch resolved cleanly — clear
+        // the one-shot reload guard so a future cross-origin redirect can
+        // re-trigger the bootstrap.
+        try { sessionStorage.removeItem('anyplot.debugAuthReloaded'); } catch {}
         // 403 is the Cloudflare Access JWT path's denial: a signed-in Google
         // account that isn't on the admin_allowed_emails allow-list. Surface
         // it on the auth-required screen with the server's message so the
@@ -225,7 +229,25 @@ export function DebugPage() {
         return r.json();
       })
       .then(setData)
-      .catch(e => setError(e.message || 'failed to load'))
+      .catch(e => {
+        // SPA-routed entry to /debug bypasses the Cloudflare Access page-
+        // level intercept. The first API fetch then 302s cross-origin to
+        // *.cloudflareaccess.com, which fetch can't follow without CORS,
+        // surfacing as TypeError("Failed to fetch"). Force one top-level
+        // navigation so CF Access can intercept the page request and bounce
+        // to Google login. sessionStorage guard keeps this from looping if
+        // the second load ALSO fails (e.g. wrong allow-list).
+        if (e instanceof TypeError) {
+          let alreadyTried = false;
+          try { alreadyTried = !!sessionStorage.getItem('anyplot.debugAuthReloaded'); } catch {}
+          if (!alreadyTried) {
+            try { sessionStorage.setItem('anyplot.debugAuthReloaded', '1'); } catch {}
+            window.location.assign(window.location.href);
+            return;
+          }
+        }
+        setError(e.message || 'failed to load');
+      })
       .finally(() => setLoading(false));
   }, [adminToken, reloadCounter]);
 


### PR DESCRIPTION
## Why

User-reported (incognito, clicking through SPA to /debug):
1. SPA shows \`failed to load: Failed to fetch\`
2. F5 → Google login appears, after sign-in /debug renders fine

Console shows:
\`\`\`
Access to fetch at 'https://anyplot.cloudflareaccess.com/cdn-cgi/access/login/anyplot.ai?…'
(redirected from 'https://anyplot.ai/api/debug/status') from origin
'https://anyplot.ai' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
\`\`\`

## Diagnosis

When the user reaches /debug via SPA client-side routing (no full page
navigation), the Cloudflare Access page-gate on \`anyplot.ai/debug\` never
fires — there's no HTTP request for that URL. The SPA mounts and fires
\`fetch('/api/debug/status', { credentials: 'include' })\`, which CF Access
on \`/api/debug/*\` 302s to a cross-origin login URL. fetch follows the
redirect but the target lacks CORS headers, so the promise rejects with
\`TypeError: Failed to fetch\`.

## Fix

Catch the TypeError once and force a top-level
\`window.location.assign(window.location.href)\`. The reload IS a real
navigation, so CF Access intercepts and bounces to Google login. After
sign-in, the user lands back on /debug with the cookie set, fetch
succeeds, page renders.

\`sessionStorage\` guard \`anyplot.debugAuthReloaded\` prevents an infinite
reload loop if the second attempt also fails (allow-list misconfig,
backend down, etc.) — in that case we surface the original error.

## Test plan

- [x] \`yarn tsc --noEmit\` clean
- [ ] After merge: open https://anyplot.ai/ in incognito, click into
  /debug via SPA navigation → page should briefly mount, immediately
  reload, then bounce to Google login
- [ ] After login → page renders with data, no \"Failed to fetch\"
- [ ] Bookmark/direct hit to /debug still triggers Google login on first
  visit (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)