### PR TITLE
chore(claude): codify mandatory PR follow-through rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,19 @@ For detailed project documentation (architecture, commands, workflows, etc.), se
 - **Always write in English** - All output text (code comments, commit messages, PR descriptions, issue comments, documentation) must be in English, even if the user writes in another language.
 - **Update documentation when making changes** - When adding new features, events, or modifying behavior, always check if related documentation needs updating (e.g., `docs/reference/plausible.md` for analytics events, `docs/workflows/` for workflow changes, `docs/contributing.md` for user-facing changes).
 
+## PR Follow-Through (mandatory after every `gh pr create`)
+
+After opening a PR, the work is **not** complete. Stay with the PR until both the pipeline is green AND review feedback has been addressed. "PR opened" is a checkpoint, not the finish line.
+
+1. **Watch the pipeline.** Poll `gh pr checks <num>` (and Cloud Build for triggered deploys) until every required check has finished. Use a background bash poll so other work can continue. Default: poll every 20 s, up to ~10 min per check.
+2. **Fix CI failures.** If any check fails, read the relevant log (`gh run view --log-failed`, `gcloud builds log <id>`), push a fix commit to the same branch, then keep watching. Repeat until green.
+3. **Wait for the Copilot PR Reviewer bot** (and any other auto-review bots active on this repo). Typically lands within ~2 min of PR open. Fetch with `gh pr view <num> --comments`, `gh api repos/MarkusNeusinger/anyplot/pulls/<num>/reviews`, and `gh api .../comments`.
+4. **Triage Copilot suggestions and apply only the sensible ones.** Apply when the comment flags a real bug, a deploy-order risk, a security/correctness issue, or a missed edge case. Skip pure style noise or anything that contradicts an explicit decision in the PR body. State briefly in chat which were applied vs skipped, so the user can override.
+5. **Push review-driven fixes to the SAME branch.** Don't open a follow-up PR for review feedback — it belongs on the original PR.
+6. **Only then announce the PR is ready / ask the user to merge.** Premature "done" leaves CI red or feedback unaddressed.
+
+This rule applies to every PR Claude opens, including small fixes and follow-ups.
+
 ## MCP Tools (Serena & Context7)
 
 **Serena** - Prefer for Python/TypeScript code navigation and editing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,10 @@ After opening a PR, the work is **not** complete. Stay with the PR until both th
 
 1. **Watch the pipeline.** Poll `gh pr checks <num>` (and Cloud Build for triggered deploys) until every required check has finished. Use a background bash poll so other work can continue. Default: poll every 20 s, up to ~10 min per check.
 2. **Fix CI failures.** If any check fails, read the relevant log (`gh run view --log-failed`, `gcloud builds log <id>`), push a fix commit to the same branch, then keep watching. Repeat until green.
-3. **Wait for the Copilot PR Reviewer bot** (and any other auto-review bots active on this repo). Typically lands within ~2 min of PR open. Fetch with `gh pr view <num> --comments`, `gh api repos/MarkusNeusinger/anyplot/pulls/<num>/reviews`, and `gh api .../comments`.
+3. **Wait for the Copilot PR Reviewer bot** (and any other auto-review bots active on this repo). Typically lands within ~2 min of PR open. Fetch with `gh pr view <num> --comments`, plus the three GitHub APIs that surface different comment types — `gh api` resolves `{owner}/{repo}` from the current git remote so these are copy/paste-portable:
+   - `gh api repos/{owner}/{repo}/pulls/<num>/reviews` — top-level review summaries (Copilot's overall comment lives here)
+   - `gh api repos/{owner}/{repo}/pulls/<num>/comments` — inline review comments tied to file/line
+   - `gh api repos/{owner}/{repo}/issues/<num>/comments` — generic PR conversation comments (codecov, deployment bots, humans)
 4. **Triage Copilot suggestions and apply only the sensible ones.** Apply when the comment flags a real bug, a deploy-order risk, a security/correctness issue, or a missed edge case. Skip pure style noise or anything that contradicts an explicit decision in the PR body. State briefly in chat which were applied vs skipped, so the user can override.
 5. **Push review-driven fixes to the SAME branch.** Don't open a follow-up PR for review feedback — it belongs on the original PR.
 6. **Only then announce the PR is ready / ask the user to merge.** Premature "done" leaves CI red or feedback unaddressed.


### PR DESCRIPTION
## Why

User-stated rule (2026-04-29): \"das du immer nach erstellen einen pr wartest ob die pipeline durchläuft falls nicht fixen, und wartest auf die copilot commentare wenn sinvoll fixen. das muss immer bei dem erstellten pr gemacht werden\"

Translation: every time Claude opens a PR, it must watch CI through to green, fix failures, wait for Copilot's review, and apply sensible suggestions — without being prompted by the user.

This rule emerged from a sequence of PRs (#5524, #5525, #5551, #5552) where deploy failures and Copilot-flagged issues were caught only because the user prompted me to look. Without that prompt, \"PR opened\" was treated as the finish line.

## What

New section \`PR Follow-Through (mandatory after every \`gh pr create\`)\` in \`CLAUDE.md\` between \"Important Rules\" and \"MCP Tools\". Six numbered steps:

1. Watch the pipeline (poll \`gh pr checks\`)
2. Fix CI failures, push to same branch, repeat until green
3. Wait for Copilot bot review (~2 min after open)
4. Triage suggestions; apply sensible ones; state which skipped
5. Review-driven fixes go on the SAME branch (no follow-up PRs)
6. Only then announce ready / ask the user to merge

Applies to every PR Claude opens, no matter how small.

## Test plan

- [x] \`git diff CLAUDE.md\` shows only the new section, no other edits
- [ ] After merge, future Claude sessions auto-load the rule from \`CLAUDE.md\`
- [ ] Verified live on PR #5552 (this session): I am watching its CI and Copilot review now per the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)