### PR TITLE
chore(release): bump version to 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # pyproject.toml
 [project]
 name = "anyplot"
-version = "2.0.0"
+version = "2.2.0"
 description = "AI-powered plotting examples"
 authors = [{ name = "Markus Neusinger", email = "admin@anyplot.ai" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "anyplot"
-version = "2.0.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version from `2.0.0` → `2.2.0` to align with the upcoming `v2.2.0` GitHub release tag.
- No code changes. Release notes will be published on the tag.

## Why now

`pyproject.toml` had drifted from the released tag (stayed at `2.0.0` through `v2.1.0`). Aligning it ahead of `v2.2.0` so external tools that read `pyproject.toml` see the same version as the GitHub release.

## Test plan

- [x] `uv run ruff check pyproject.toml` passes
- [ ] CI lint + tests pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)