### PR TITLE
chore(sparkline-basic): altair impl docstring Quality 90/100

### DIFF
--- a/plots/sparkline-basic/implementations/python/altair.py
+++ b/plots/sparkline-basic/implementations/python/altair.py
@@ -1,7 +1,7 @@
 """anyplot.ai
 sparkline-basic: Basic Sparkline
 Library: altair 6.1.0 | Python 3.13.12
-Quality: /100 | Updated: 2026-05-02
+Quality: 90/100 | Updated: 2026-05-02
 """
 
 import os


### PR DESCRIPTION
## Summary

Follow-up to #5653 / #5654. The `/regen` flow blanked the `Quality:` line in the docstring header — it now reads `Quality: /100`, but should match the metadata's `quality_score: 90` populated in #5654.

```diff
-Quality: /100 | Updated: 2026-05-02
+Quality: 90/100 | Updated: 2026-05-02
```

The `regen.md` template (PR #5650) is being updated in parallel to require `{SCORE}/100`, not blank, so future regens won't drop the score.

## Test plan

- [ ] CI green
- [ ] header matches metadata `quality_score: 90`