### PR TITLE
fix(potd): include language segment in GitHub source links

### DIFF
--- a/app/src/components/PlotOfTheDay.test.tsx
+++ b/app/src/components/PlotOfTheDay.test.tsx
@@ -30,6 +30,7 @@ const mockData = {
   description: 'A scatter plot',
   library_id: 'matplotlib',
   library_name: 'Matplotlib',
+  language: 'python',
   quality_score: 9,
   preview_url: 'https://cdn.example.com/plots/scatter-basic/matplotlib/plot.png',
   image_description: 'Shows data points with clear labels',
@@ -175,7 +176,11 @@ describe('PlotOfTheDay', () => {
     await user.click(screen.getByText('Basic Scatter Plot'));
     expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_title' }));
 
-    await user.click(screen.getByText(/python plots\/scatter-basic\/matplotlib\.py/));
+    const sourceLink = screen.getByText(/python plots\/scatter-basic\/matplotlib\.py/);
+    expect(sourceLink.getAttribute('href')).toMatch(
+      /\/blob\/main\/plots\/scatter-basic\/implementations\/python\/matplotlib\.py$/,
+    );
+    await user.click(sourceLink);
     expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_source_link' }));
   });
 

--- a/app/src/components/PlotOfTheDay.tsx
+++ b/app/src/components/PlotOfTheDay.tsx
@@ -102,7 +102,7 @@ export function PlotOfTheDay() {
           <Typography sx={{ fontFamily: mono, fontSize: fontSize.xs, color: colors.primary, fontWeight: 600 }}>$</Typography>
           <Typography
             component="a"
-            href={`${GITHUB_URL}/blob/main/plots/${data.spec_id}/implementations/${data.library_id}.py`}
+            href={`${GITHUB_URL}/blob/main/plots/${data.spec_id}/implementations/${data.language}/${data.library_id}.py`}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e: React.MouseEvent) => {

--- a/app/src/components/PlotOfTheDayTerminal.test.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.test.tsx
@@ -52,7 +52,11 @@ describe('PlotOfTheDayTerminal', () => {
     await user.click(screen.getByText(/plots\/scatter-basic\/matplotlib\.py/));
     expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_terminal_filename' }));
 
-    await user.click(screen.getByLabelText('Open source on GitHub'));
+    const githubLink = screen.getByLabelText('Open source on GitHub');
+    expect(githubLink.getAttribute('href')).toMatch(
+      /\/blob\/main\/plots\/scatter-basic\/implementations\/python\/matplotlib\.py$/,
+    );
+    await user.click(githubLink);
     expect(trackEvent).toHaveBeenCalledWith('nav_click', expect.objectContaining({ source: 'potd_terminal_github' }));
 
     await user.click(screen.getByLabelText(/Open Basic Scatter implementation/));

--- a/app/src/components/PlotOfTheDayTerminal.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.tsx
@@ -44,7 +44,7 @@ export function PlotOfTheDayTerminal({
 
   const displayFilename = `plots/${potd.spec_id}/${potd.library_id}.py`;
   const implPath = specPath(potd.spec_id, potd.language, potd.library_id);
-  const githubFileUrl = `${GITHUB_URL}/blob/main/plots/${potd.spec_id}/implementations/${potd.library_id}.py`;
+  const githubFileUrl = `${GITHUB_URL}/blob/main/plots/${potd.spec_id}/implementations/${potd.language}/${potd.library_id}.py`;
 
   return (
     <Box


### PR DESCRIPTION
## Summary

The "plot of the day" component links to the implementation file on GitHub, but the URL was not updated for the per-language path migration. Links currently 404 because they point to `plots/{spec}/implementations/{library}.py` (e.g. `plots/indicator-rsi/implementations/plotly.py`) instead of the correct `plots/{spec}/implementations/{language}/{library}.py` (e.g. `plots/indicator-rsi/implementations/python/plotly.py`).

This adds the missing `{language}` segment in both potd components.

## Changes

- `app/src/components/PlotOfTheDay.tsx` — insert `${data.language}/` before the library file in the GitHub `href`.
- `app/src/components/PlotOfTheDayTerminal.tsx` — same fix for `githubFileUrl`.

## Test plan

- [ ] Open the homepage, hover/click the potd source link — confirm the URL contains `/implementations/python/` and resolves on GitHub.
- [ ] Same for the terminal-styled potd variant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGVq3ftxEBM4oqLNy5Dt8M)_