### PR TITLE
fix(impl-generate): forward change_request on auto-retry

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -831,12 +831,16 @@ jobs:
             # Clean up generate label before retry
             gh issue edit "$ISSUE" --remove-label "generate:${LIBRARY}" 2>/dev/null || true
 
-            # Automatic retry via workflow_dispatch
+            # Automatic retry via workflow_dispatch.
+            # Forward `change_request` so cross-library divergence hints from
+            # daily-regen pre-flight survive the retry — otherwise the first
+            # attempt has the hint but the retry doesn't, defeating the audit.
             gh workflow run impl-generate.yml \
               -f specification_id="${SPEC_ID}" \
               -f library="${LIBRARY}" \
               -f issue_number="${ISSUE}" \
-              -f model="${MODEL}"
+              -f model="${MODEL}" \
+              -f change_request="${{ inputs.change_request }}"
 
-            echo "::notice::Triggered automatic retry for ${LIBRARY}/${SPEC_ID} (attempt $((ATTEMPT + 1)), model=${MODEL})"
+            echo "::notice::Triggered automatic retry for ${LIBRARY}/${SPEC_ID} (attempt $((ATTEMPT + 1)), model=${MODEL}, change_request=$([ -n "${{ inputs.change_request }}" ] && echo present || echo none))"
           fi

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -773,6 +773,9 @@ jobs:
           LIBRARY: ${{ steps.inputs.outputs.library }}
           ISSUE: ${{ steps.issue.outputs.number }}
           MODEL: ${{ steps.inputs.outputs.model }}
+          # Pass via env (not template-interpolated into the script) so hints
+          # containing quotes / $ / backticks can't break shell parsing.
+          CHANGE_REQUEST: ${{ inputs.change_request }}
         run: |
           echo "::notice::Handling generation failure for $LIBRARY/$SPEC_ID"
 
@@ -835,12 +838,18 @@ jobs:
             # Forward `change_request` so cross-library divergence hints from
             # daily-regen pre-flight survive the retry — otherwise the first
             # attempt has the hint but the retry doesn't, defeating the audit.
+            # CHANGE_REQUEST is read from env to keep raw quotes/$/backticks
+            # inside the hint from breaking shell parsing.
             gh workflow run impl-generate.yml \
               -f specification_id="${SPEC_ID}" \
               -f library="${LIBRARY}" \
               -f issue_number="${ISSUE}" \
               -f model="${MODEL}" \
-              -f change_request="${{ inputs.change_request }}"
+              -f change_request="${CHANGE_REQUEST}"
 
-            echo "::notice::Triggered automatic retry for ${LIBRARY}/${SPEC_ID} (attempt $((ATTEMPT + 1)), model=${MODEL}, change_request=$([ -n "${{ inputs.change_request }}" ] && echo present || echo none))"
+            if [ -n "${CHANGE_REQUEST}" ]; then
+              echo "::notice::Triggered automatic retry for ${LIBRARY}/${SPEC_ID} (attempt $((ATTEMPT + 1)), model=${MODEL}, change_request=present)"
+            else
+              echo "::notice::Triggered automatic retry for ${LIBRARY}/${SPEC_ID} (attempt $((ATTEMPT + 1)), model=${MODEL}, change_request=none)"
+            fi
           fi


### PR DESCRIPTION
## Summary

The auto-retry dispatch in `impl-generate.yml` (lines 835-840) called
`gh workflow run impl-generate.yml` without forwarding the `change_request`
input, so cross-library divergence hints from `daily-regen` pre-flight were
silently dropped when an attempt failed and got retried.

## Why

Observed in `daily-regen` run [25392762766](https://github.com/MarkusNeusinger/anyplot/actions/runs/25392762766):
the similarity audit flagged matplotlib (Product A–D 42/28/18/12 percentages
matched highcharts and letsplot exactly) and `bulk-generate` correctly passed
the hint to matplotlib's first impl-generate dispatch. But that first attempt
failed at "Process plot images (light + dark)" → the auto-retry re-dispatched
without `-f change_request=...` → the hint was lost on retry.

By chance Claude picked a different scenario (Survey responses) on the retry
anyway, but the plumbing was defective: next time the same cluster could
re-converge.

## Changes

- `impl-generate.yml`: pass `-f change_request="${{ inputs.change_request }}"`
  on the auto-retry dispatch.
- Added a one-line comment explaining the why so future maintainers don't
  accidentally remove it.
- Notice line now reports whether the change_request was present.

## Test plan
- [ ] On next `daily-regen` cycle that hits a flagged library AND that
      library's first attempt fails, verify the retry logs show
      `::notice::Change request staged: ...`.
- [ ] Manual re-trigger by failing matplotlib's first attempt artificially is
      not necessary — observed in the wild on run 25392762766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)