### PR TITLE
feat(legal): add avatar to legal notice operator block

### DIFF
--- a/app/src/pages/LegalPage.test.tsx
+++ b/app/src/pages/LegalPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 import { render, screen } from '../test-utils';
 import { LegalPage } from './LegalPage';
 
@@ -6,10 +7,11 @@ vi.mock('react-helmet-async', () => ({
   Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const trackEvent = vi.fn();
 vi.mock('../hooks', () => ({
   useAnalytics: () => ({
     trackPageview: vi.fn(),
-    trackEvent: vi.fn(),
+    trackEvent: (...args: unknown[]) => trackEvent(...args),
   }),
 }));
 
@@ -59,6 +61,19 @@ describe('LegalPage', () => {
     render(<LegalPage />);
 
     expect(screen.getByText('~$34/month')).toBeInTheDocument();
+  });
+
+  it('tracks external link clicks for linkedin, x and github', () => {
+    trackEvent.mockClear();
+    render(<LegalPage />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'markus-neusinger' }));
+    fireEvent.click(screen.getByRole('link', { name: '@MarkusNeusinger' }));
+    fireEvent.click(screen.getByRole('link', { name: 'MarkusNeusinger' }));
+
+    expect(trackEvent).toHaveBeenCalledWith('external_link', { destination: 'linkedin' });
+    expect(trackEvent).toHaveBeenCalledWith('external_link', { destination: 'x' });
+    expect(trackEvent).toHaveBeenCalledWith('external_link', { destination: 'github_personal' });
   });
 
 });

--- a/app/src/pages/LegalPage.tsx
+++ b/app/src/pages/LegalPage.tsx
@@ -28,12 +28,79 @@ const firstColStyle = {
   },
 };
 
+const AVATAR_URL = 'https://storage.googleapis.com/anyplot-static/images/markusneusinger.webp';
+
 export function LegalPage() {
   const { trackPageview, trackEvent } = useAnalytics();
 
   useEffect(() => {
     trackPageview('/legal');
   }, [trackPageview]);
+
+  const operatorContactBlock = (
+    <>
+      <Typography sx={subheadingStyle}>operator</Typography>
+      <Typography sx={textStyle}>
+        Markus Neusinger
+        <br />
+        Visp, Switzerland
+      </Typography>
+
+      <Typography sx={subheadingStyle}>contact</Typography>
+      <Typography sx={textStyle}>
+        email:{' '}
+        <Link href="mailto:admin@anyplot.ai" sx={proseLinkStyle}>
+          admin@anyplot.ai
+        </Link>
+        <br />
+        linkedin:{' '}
+        <Link
+          href="https://www.linkedin.com/in/markus-neusinger/"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackEvent('external_link', { destination: 'linkedin' })}
+          sx={proseLinkStyle}
+        >
+          markus-neusinger
+        </Link>
+        <br />
+        x:{' '}
+        <Link
+          href="https://x.com/MarkusNeusinger"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackEvent('external_link', { destination: 'x' })}
+          sx={proseLinkStyle}
+        >
+          @MarkusNeusinger
+        </Link>
+        <br />
+        github:{' '}
+        <Link
+          href="https://github.com/MarkusNeusinger"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackEvent('external_link', { destination: 'github_personal' })}
+          sx={proseLinkStyle}
+        >
+          MarkusNeusinger
+        </Link>
+      </Typography>
+    </>
+  );
+
+  const disclaimerBlock = (
+    <>
+      <Typography sx={subheadingStyle}>disclaimer</Typography>
+      <Typography sx={textStyle}>
+        this is a personal portfolio project showcasing data visualization examples, generated and
+        maintained through ai-powered workflows. all code examples are meant for inspiration and
+        learning — take them as a starting point, adapt them to your data and requirements, or use
+        ai tools to customize them for your specific needs. code is provided &quot;as is&quot; under
+        the MIT License and should be reviewed before production use.
+      </Typography>
+    </>
+  );
 
   return (
     <>
@@ -51,62 +118,27 @@ export function LegalPage() {
           <SectionHeader prompt="❯" title={<em>legal notice</em>} />
 
           <Box sx={{ maxWidth: 760, mx: 'auto' }}>
-            <Typography sx={subheadingStyle}>operator</Typography>
-            <Typography sx={textStyle}>
-              Markus Neusinger
-              <br />
-              Visp, Switzerland
-            </Typography>
-
-            <Typography sx={subheadingStyle}>contact</Typography>
-            <Typography sx={textStyle}>
-              email:{' '}
-              <Link href="mailto:admin@anyplot.ai" sx={proseLinkStyle}>
-                admin@anyplot.ai
-              </Link>
-              <br />
-              linkedin:{' '}
-              <Link
-                href="https://www.linkedin.com/in/markus-neusinger/"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent('external_link', { destination: 'linkedin' })}
-                sx={proseLinkStyle}
-              >
-                markus-neusinger
-              </Link>
-              <br />
-              x:{' '}
-              <Link
-                href="https://x.com/MarkusNeusinger"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent('external_link', { destination: 'x' })}
-                sx={proseLinkStyle}
-              >
-                @MarkusNeusinger
-              </Link>
-              <br />
-              github:{' '}
-              <Link
-                href="https://github.com/MarkusNeusinger"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent('external_link', { destination: 'github_personal' })}
-                sx={proseLinkStyle}
-              >
-                MarkusNeusinger
-              </Link>
-            </Typography>
-
-            <Typography sx={subheadingStyle}>disclaimer</Typography>
-            <Typography sx={textStyle}>
-              this is a personal portfolio project showcasing data visualization examples, generated and
-              maintained through ai-powered workflows. all code examples are meant for inspiration and
-              learning — take them as a starting point, adapt them to your data and requirements, or use
-              ai tools to customize them for your specific needs. code is provided &quot;as is&quot; under
-              the MIT License and should be reviewed before production use.
-            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 6,
+                alignItems: 'center',
+                flexDirection: { xs: 'column', sm: 'row' },
+                mb: 2,
+              }}
+            >
+              <Box
+                component="img"
+                src={AVATAR_URL}
+                alt="Markus Neusinger"
+                width={240}
+                height={519}
+                loading="lazy"
+                sx={{ width: 120, height: 'auto', flexShrink: 0, display: 'block' }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>{operatorContactBlock}</Box>
+            </Box>
+            {disclaimerBlock}
           </Box>
         </Box>
 

--- a/app/src/pages/LegalPage.tsx
+++ b/app/src/pages/LegalPage.tsx
@@ -130,9 +130,10 @@ export function LegalPage() {
               <Box
                 component="img"
                 src={AVATAR_URL}
-                alt="Markus Neusinger"
+                alt=""
+                aria-hidden="true"
                 width={240}
-                height={519}
+                height={518}
                 loading="lazy"
                 sx={{ width: 120, height: 'auto', flexShrink: 0, display: 'block' }}
               />


### PR DESCRIPTION
## Summary

- Adds a Markus Neusinger avatar image to the **legal notice** section, y-centered next to the operator + contact text. Disclaimer flows full-width below.
- Image is served from GCS (`gs://anyplot-static/images/markusneusinger.webp`) with a 1-year immutable cache — same pattern already used for fonts. Image is **not** in the repo.
- WebP, 240×518 px (2× retina for the 120 px display), **22 KB** (the original PNG was 412 KB).
- Pre-processing removed the white halo (semi-transparent near-white edge pixels) and a stray solid-grey baseline stripe at the bottom row of the source — both visible on the dark background. Verified clean in dark mode.

## Test plan

- [x] `yarn vitest run src/pages/LegalPage.test.tsx` passes (6/6)
- [x] `yarn eslint src/pages/LegalPage.tsx` clean
- [x] Visual check in light mode (`http://localhost:3000/legal`)
- [x] Visual check in dark mode — no halo, no white stripe at the bottom of the pants
- [x] Image responds 200 with `cache-control: public, max-age=31536000, immutable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)