### PR TITLE
feat(debug): on-device console + richer ErrorBoundary for mobile crashes

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -24,6 +24,23 @@
       })();
     </script>
 
+    <!-- On-device debug console (Eruda), gated behind ?debug=1 so it never
+         ships to normal users. Plain <script> (not type="module") so it runs
+         before module parse-time errors and can capture them — critical for
+         debugging mobile-only crashes where remote DevTools aren't available. -->
+    <script>
+      (function () {
+        try {
+          if (new URLSearchParams(location.search).has('debug')) {
+            var s = document.createElement('script');
+            s.src = 'https://cdn.jsdelivr.net/npm/eruda';
+            s.onload = function () { try { eruda.init(); } catch (e) {} };
+            document.head.appendChild(s);
+          }
+        } catch (e) { /* URLSearchParams unavailable on very old browsers */ }
+      })();
+    </script>
+
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://anyplot.ai/" />

--- a/app/src/components/ErrorBoundary.test.tsx
+++ b/app/src/components/ErrorBoundary.test.tsx
@@ -55,6 +55,53 @@ describe('ErrorBoundary', () => {
     expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
   });
 
+  it('toggles technical details disclosure', async () => {
+    const { userEvent } = await import('../test-utils');
+    const user = userEvent.setup();
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="boom on iOS" />
+      </ErrorBoundary>
+    );
+
+    expect(screen.queryByTestId('error-details')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /show technical details/i }));
+
+    const details = screen.getByTestId('error-details');
+    expect(details).toBeInTheDocument();
+    expect(details.textContent).toContain('boom on iOS');
+    expect(details.textContent).toContain('User-Agent:');
+    expect(details.textContent).toContain('URL:');
+
+    await user.click(screen.getByRole('button', { name: /hide technical details/i }));
+    expect(screen.queryByTestId('error-details')).not.toBeInTheDocument();
+  });
+
+  it('copies details to the clipboard', async () => {
+    const { userEvent } = await import('../test-utils');
+    const user = userEvent.setup();
+
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent message="copy me" />
+      </ErrorBoundary>
+    );
+
+    await user.click(screen.getByRole('button', { name: /copy details/i }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain('copy me');
+    expect(await screen.findByRole('button', { name: /copied/i })).toBeInTheDocument();
+  });
+
   it('recovers when Try Again is clicked', async () => {
     const { userEvent } = await import('../test-utils');
     const user = userEvent.setup();

--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import ReplayIcon from '@mui/icons-material/Replay';
 import HomeIcon from '@mui/icons-material/Home';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 interface Props {
   children: ReactNode;
@@ -15,24 +16,36 @@ interface Props {
 interface State {
   hasError: boolean;
   error: Error | null;
+  componentStack: string | null;
+  showDetails: boolean;
+  copied: boolean;
 }
 
 /**
  * Error boundary component that catches rendering errors in child components.
- * Displays a user-friendly error message with recovery options.
+ * Displays a user-friendly error message with recovery options and — behind
+ * a disclosure — the diagnostic context (message, stack, UA, URL) needed to
+ * debug device-specific crashes (e.g. iOS-only WebKit incompatibilities).
  */
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = {
+      hasError: false,
+      error: null,
+      componentStack: null,
+      showDetails: false,
+      copied: false,
+    };
   }
 
-  static getDerivedStateFromError(error: Error): State {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
+    this.setState({ componentStack: errorInfo.componentStack ?? null });
   }
 
   handleReload = (): void => {
@@ -44,7 +57,46 @@ export class ErrorBoundary extends Component<Props, State> {
   };
 
   handleRetry = (): void => {
-    this.setState({ hasError: false, error: null });
+    this.setState({
+      hasError: false,
+      error: null,
+      componentStack: null,
+      showDetails: false,
+      copied: false,
+    });
+  };
+
+  handleToggleDetails = (): void => {
+    this.setState((s) => ({ showDetails: !s.showDetails }));
+  };
+
+  buildDetails = (): string => {
+    const { error, componentStack } = this.state;
+    const lines = [
+      `Message: ${error?.message ?? '(unknown)'}`,
+      `URL: ${typeof window !== 'undefined' ? window.location.href : '(unknown)'}`,
+      `User-Agent: ${typeof navigator !== 'undefined' ? navigator.userAgent : '(unknown)'}`,
+      `Timestamp: ${new Date().toISOString()}`,
+      '',
+      '--- Stack ---',
+      error?.stack ?? '(no stack)',
+    ];
+    if (componentStack) {
+      lines.push('', '--- React component stack ---', componentStack.trim());
+    }
+    return lines.join('\n');
+  };
+
+  handleCopyDetails = async (): Promise<void> => {
+    const text = this.buildDetails();
+    try {
+      await navigator.clipboard?.writeText(text);
+      this.setState({ copied: true });
+      window.setTimeout(() => this.setState({ copied: false }), 2000);
+    } catch {
+      // Clipboard API unavailable (older iOS, insecure context). The text is
+      // already visible in the disclosure block, so the user can copy manually.
+    }
   };
 
   render(): ReactNode {
@@ -52,6 +104,8 @@ export class ErrorBoundary extends Component<Props, State> {
       if (this.props.fallback) {
         return this.props.fallback;
       }
+
+      const { error, componentStack, showDetails, copied } = this.state;
 
       return (
         <Box
@@ -68,7 +122,7 @@ export class ErrorBoundary extends Component<Props, State> {
           <Alert
             severity="error"
             sx={{
-              maxWidth: 500,
+              maxWidth: 640,
               width: '100%',
               mb: 3,
             }}
@@ -79,7 +133,8 @@ export class ErrorBoundary extends Component<Props, State> {
             <Typography variant="body2" sx={{ color: 'var(--ink-muted)' }}>
               An unexpected error occurred. Please try reloading the page.
             </Typography>
-            {import.meta.env.DEV && this.state.error && (
+
+            {error && (
               <Typography
                 variant="caption"
                 component="pre"
@@ -90,12 +145,76 @@ export class ErrorBoundary extends Component<Props, State> {
                   color: 'var(--ink-soft)',
                   borderRadius: 1,
                   overflow: 'auto',
-                  maxHeight: 100,
+                  maxHeight: 80,
                   textAlign: 'left',
                   fontFamily: 'monospace',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
                 }}
               >
-                {this.state.error.message}
+                {error.message || error.name || 'Unknown error'}
+              </Typography>
+            )}
+
+            <Box
+              sx={{
+                mt: 2,
+                display: 'flex',
+                gap: 1,
+                flexWrap: 'wrap',
+                justifyContent: 'center',
+              }}
+            >
+              <Button
+                size="small"
+                variant="text"
+                onClick={this.handleToggleDetails}
+                sx={{ textTransform: 'none' }}
+                aria-expanded={showDetails}
+              >
+                {showDetails ? 'Hide technical details' : 'Show technical details'}
+              </Button>
+              <Button
+                size="small"
+                variant="text"
+                startIcon={<ContentCopyIcon fontSize="small" />}
+                onClick={this.handleCopyDetails}
+                sx={{ textTransform: 'none' }}
+              >
+                {copied ? 'Copied' : 'Copy details'}
+              </Button>
+            </Box>
+
+            {showDetails && (
+              <Typography
+                variant="caption"
+                component="pre"
+                data-testid="error-details"
+                sx={{
+                  mt: 2,
+                  p: 1.5,
+                  bgcolor: 'var(--bg-surface)',
+                  color: 'var(--ink-soft)',
+                  borderRadius: 1,
+                  overflow: 'auto',
+                  maxHeight: 280,
+                  textAlign: 'left',
+                  fontFamily: 'monospace',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  fontSize: '0.7rem',
+                }}
+              >
+                {this.buildDetails()}
+              </Typography>
+            )}
+
+            {componentStack && import.meta.env.DEV && !showDetails && (
+              <Typography
+                variant="caption"
+                sx={{ mt: 1, display: 'block', color: 'var(--ink-muted)' }}
+              >
+                React component stack available — click "Show technical details".
               </Typography>
             )}
           </Alert>


### PR DESCRIPTION
## Summary

Adds two surgical debugging affordances so we can diagnose mobile-only crashes (like the iOS regression in #5805) now and in the future, without needing a Mac + USB cable for Safari Remote Debugging.

- **`app/index.html`** — Loads [Eruda](https://github.com/liriliri/eruda) behind `?debug=1` so anyone (us or a user on a flaky device) can open `https://anyplot.ai/?debug=1`, get a full DevTools-style console, and capture the actual stack trace. Loaded as a classic `<script>` (not `type="module"`) so it runs *before* module parse-time errors and can surface them — critical for the iOS case where the bundle itself may fail to parse.
- **`app/src/components/ErrorBoundary.tsx`** — When the boundary trips, the user now sees:
  - The error message (always, not just in DEV — this is the part we actually need them to send us).
  - A **"Show technical details"** disclosure with the full stack, React component stack, `navigator.userAgent`, current URL, and an ISO timestamp.
  - A **"Copy details"** button using `navigator.clipboard` so users can paste the full bug report straight into chat or email. Falls back gracefully when the Clipboard API is unavailable (older iOS / insecure context) — the text is already visible in the disclosure.
- **`ErrorBoundary.test.tsx`** — Two new tests cover the disclosure toggle and the clipboard copy flow.

Intentionally minimal: no new dependencies, no Sentry / external error tracking yet (worth a follow-up PR with explicit cost discussion), no changes to the existing `DebugPage` or other surfaces.

## Why this matters

The boundary previously only showed the error message in `import.meta.env.DEV`, so a production user hitting a crash had nothing to give us. With these changes, the path from "user reports crash" to "we have a stack trace" is one screenshot or one paste — and for power users, `?debug=1` gives them a full console on the device.

## Test plan

- [x] `yarn test --run src/components/ErrorBoundary.test.tsx` — 7/7 passing (5 existing + 2 new).
- [x] `yarn test --run` — full suite 466/466 passing.
- [x] `yarn type-check` — clean.
- [x] `yarn lint` on the changed files — no new errors (the 32 pre-existing errors in `SpecsListPage.tsx`, `test-utils.tsx`, and tests are unchanged by this PR).
- [x] `yarn build` — bundles cleanly.
- [ ] Manual verification on a real iOS device once deployed: open `https://anyplot.ai/?debug=1` and confirm Eruda's bug icon appears + console captures the actual error from #5805.
- [ ] Manual verification of the boundary UI: trigger a render error in dev, confirm "Show technical details" reveals stack + UA + URL, and "Copy details" puts the same payload on the clipboard.

## Follow-ups (out of scope)

- Once Eruda gives us the iOS stack trace, fix the actual root cause in #5805 (likely Vite 8 build target or a transitive dep using regex lookbehind / modern syntax).
- Evaluate Sentry or a similar lightweight error reporter for production so we don't depend on users manually copying details.

Closes part of #5805 (debugging tooling; the underlying crash fix is still TBD).


---
_Generated by [Claude Code](https://claude.ai/code/session_012uXa2UqzejwTHvfADqmRWR)_