### PR TITLE
fix(app): polyfill requestIdleCallback for iOS Safari

### DIFF
--- a/app/src/components/Layout.test.tsx
+++ b/app/src/components/Layout.test.tsx
@@ -150,5 +150,9 @@ describe('AppDataProvider', () => {
     });
 
     expect(screen.getByTestId('child')).toHaveTextContent('renders without TypeError');
+
+    // Restore stubbed globals so subsequent tests in this file (or future ones
+    // appended after this) don't see `undefined` for the idle callback APIs.
+    vi.unstubAllGlobals();
   });
 });

--- a/app/src/components/Layout.test.tsx
+++ b/app/src/components/Layout.test.tsx
@@ -127,4 +127,28 @@ describe('AppDataProvider', () => {
     expect(screen.getByTestId('child')).toHaveTextContent('still renders');
     consoleSpy.mockRestore();
   });
+
+  it('falls back to setTimeout when requestIdleCallback is unavailable (iOS Safari)', async () => {
+    // Simulate Safari/iOS where requestIdleCallback is undefined by default.
+    vi.stubGlobal('requestIdleCallback', undefined);
+    vi.stubGlobal('cancelIdleCallback', undefined);
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    wrap(
+      <AppDataProvider>
+        <div data-testid="child">renders without TypeError</div>
+      </AppDataProvider>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    expect(screen.getByTestId('child')).toHaveTextContent('renders without TypeError');
+  });
 });

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -38,9 +38,11 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
     setHomeState((prev) => ({ ...prev, scrollY: window.scrollY }));
   }, []);
 
-  // Load shared data after browser is idle — gives /plots/filter bandwidth priority
+  // Load shared data after browser is idle — gives /plots/filter bandwidth priority.
+  // Safari/iOS doesn't ship requestIdleCallback by default, so feature-detect
+  // and fall back to setTimeout — otherwise the TypeError takes the app down.
   useEffect(() => {
-    const id = window.requestIdleCallback(async () => {
+    const callback = async () => {
       try {
         const [specsRes, libsRes, statsRes] = await Promise.all([
           fetch(`${API_URL}/specs`),
@@ -65,8 +67,17 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
       } catch (err) {
         console.warn('Initial data load incomplete:', err instanceof Error ? err.message : err);
       }
-    }, { timeout: 2000 });
-    return () => window.cancelIdleCallback(id);
+    };
+
+    const hasRIC = typeof window.requestIdleCallback === 'function';
+    const id: number = hasRIC
+      ? window.requestIdleCallback(callback, { timeout: 2000 })
+      : window.setTimeout(callback, 1);
+
+    return () => {
+      if (hasRIC) window.cancelIdleCallback(id);
+      else window.clearTimeout(id);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

- iPhone users could not use the app: every iOS Safari (and CriOS, which uses WebKit) instance threw `TypeError: window.requestIdleCallback is not a function` at `AppDataProvider` mount, which `ErrorBoundary` caught — leaving the user stuck on the error fallback. Surfaced by the on-device debug console added in #5808.
- `requestIdleCallback` is documented as unsupported on Safari/iOS by [caniuse](https://caniuse.com/requestidlecallback), [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback), and [WebKit bug 164193](https://bugs.webkit.org/show_bug.cgi?id=164193). It exists only behind the *Experimental Features* toggle, which is off by default — so this is a hard regression for **every** iOS visitor, not a one-off device bug.
- Fix is an inline feature-detect in the existing `useEffect`: use `requestIdleCallback` if present, otherwise fall back to `setTimeout(cb, 1)`. Cleanup picks the matching cancel function via captured boolean. No new npm dependency, no global mutation.
- Adds a regression test that stubs both idle APIs as `undefined` and asserts the three initial fetches still fire and children still render.

### Original iPhone error report

```
Message: window.requestIdleCallback is not a function. (In 'window.requestIdleCallback(async()=>{try{let[e,t,n]=await Promise.all([fetch(`${T}/specs`),fetch(`${T}/libraries`),fetch(`${T}/stats`)]);...},{timeout:2e3})')
URL: https://anyplot.ai/?debug=1
User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 26_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/148.0.7778.100 Mobile/15E148 Safari/604.1
```

## Test plan

- [x] `cd app && yarn test --run` — 467/467 pass, including new `falls back to setTimeout when requestIdleCallback is unavailable (iOS Safari)` case in `Layout.test.tsx`.
- [x] `cd app && yarn build` — TypeScript / Vite build green.
- [x] Pre-existing lint findings on `main` unchanged; no new findings introduced by this PR.
- [ ] Production verification on the reporter's iPhone after deploy (visit https://anyplot.ai/?debug=1, confirm home page loads and the Eruda console is clean).

## Why this approach (not a polyfill package)

- Two well-known polyfills exist ([aFarkas/requestIdleCallback](https://github.com/aFarkas/requestIdleCallback), [pladaria/requestidlecallback-polyfill](https://github.com/pladaria/requestidlecallback-polyfill)) but both internally just wrap `setTimeout` — there is no way to truly polyfill real browser idle time. Adding a dependency would ship bytes to every modern-browser user for the same effect we get inline.
- Single call site in the entire repo — per CLAUDE.md "no abstractions beyond what the task requires", a per-file inline fix is the right shape. If a second call site appears later, that is the moment to extract a `utils/idleCallback.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)