### PR TITLE
chore: apply audit batch (lint repair + SEO/map + evaluator + docs)

### DIFF
--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -260,6 +260,22 @@ async def seo_palette():
     )
 
 
+@router.get("/seo-proxy/map")
+async def seo_map():
+    """Bot-optimized network map page with correct og:tags."""
+    return HTMLResponse(
+        BOT_HTML_TEMPLATE.format(
+            title="Network Map | anyplot.ai",
+            description=(
+                "Interactive network map of plot specifications grouped by visual similarity — "
+                "explore relationships across all anyplot.ai chart types."
+            ),
+            image=DEFAULT_HOME_IMAGE,
+            url="https://anyplot.ai/map",
+        )
+    )
+
+
 @router.get("/seo-proxy/stats")
 async def seo_stats():
     """Bot-optimized stats page with correct og:tags."""

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -69,6 +69,18 @@ export default [
         Blob: 'readonly',
         File: 'readonly',
         FileReader: 'readonly',
+        // Idle / animation callback APIs
+        requestIdleCallback: 'readonly',
+        cancelIdleCallback: 'readonly',
+        IdleRequestCallback: 'readonly',
+        IdleDeadline: 'readonly',
+        IdleRequestOptions: 'readonly',
+        IdleCallbackHandle: 'readonly',
+        FrameRequestCallback: 'readonly',
+        // IntersectionObserver type aliases
+        IntersectionObserverCallback: 'readonly',
+        IntersectionObserverInit: 'readonly',
+        IntersectionObserverEntry: 'readonly',
         // React (for JSX runtime)
         React: 'readonly',
       },
@@ -102,6 +114,7 @@ export default [
         beforeAll: 'readonly',
         afterAll: 'readonly',
         globalThis: 'readonly',
+        global: 'readonly',
       },
     },
   },

--- a/app/src/components/RelatedSpecs.tsx
+++ b/app/src/components/RelatedSpecs.tsx
@@ -47,15 +47,18 @@ export function RelatedSpecs({ specId, mode = 'spec', library, onHoverTags }: Re
   const [related, setRelated] = useState<RelatedSpec[]>([]);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState(false);
+  const [prevDeps, setPrevDeps] = useState({ specId, mode, library });
   const { isDark } = useTheme();
 
-  useEffect(() => {
-    setExpanded(false);
-  }, [specId]);
+  // React 19 "Adjusting state on prop change": runs during render, no cascading re-render.
+  if (prevDeps.specId !== specId || prevDeps.mode !== mode || prevDeps.library !== library) {
+    setPrevDeps({ specId, mode, library });
+    setLoading(true);
+    if (prevDeps.specId !== specId) setExpanded(false);
+  }
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     const params = new URLSearchParams({ limit: '24', mode });
     if (library && mode === 'full') params.set('library', library);
     fetch(`${API_URL}/insights/related/${specId}?${params}`)

--- a/app/src/components/SpecDetailView.tsx
+++ b/app/src/components/SpecDetailView.tsx
@@ -132,12 +132,14 @@ export function SpecDetailView({
     };
   }, [viewMode, updateScale]);
 
-  // Reset interactive size when switching library
-  useEffect(() => {
+  // Reset interactive size when switching library — React 19 "adjust state on prop change".
+  const [prevLibrary, setPrevLibrary] = useState(selectedLibrary);
+  if (prevLibrary !== selectedLibrary) {
+    setPrevLibrary(selectedLibrary);
     setSizeReady(false);
     setContentWidth(INITIAL_WIDTH);
     setContentHeight(INITIAL_HEIGHT);
-  }, [selectedLibrary]);
+  }
 
   const handleZoomToggle = useCallback(
     (e: React.MouseEvent) => {

--- a/app/src/components/SpecOverview.test.tsx
+++ b/app/src/components/SpecOverview.test.tsx
@@ -148,10 +148,7 @@ describe('SpecOverview', () => {
     });
     // SpecOverview checks `impl.preview_url` as truthy -> falsy string renders skeleton
     const { container } = render(
-      <SpecOverview
-        {...defaultProps}
-        implementations={[makeImpl({ library_id: 'bokeh', preview_url: '' as unknown as string })]}
-      />,
+      <SpecOverview {...defaultProps} implementations={[implNoPreview]} />,
     );
     const skeleton = container.querySelector('.MuiSkeleton-root');
     expect(skeleton).toBeInTheDocument();

--- a/app/src/hooks/useFeaturedSpecs.ts
+++ b/app/src/hooks/useFeaturedSpecs.ts
@@ -5,6 +5,11 @@ import { shuffleArray } from '../utils/shuffle';
 import { useAppData } from './useLayoutContext';
 
 
+function pickRandom<T>(items: T[]): T {
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+
 export interface FeaturedImpl {
   spec_id: string;
   spec_title: string;
@@ -60,7 +65,7 @@ export function useFeaturedSpecs(count: number = 5): FeaturedImpl[] | null {
 
     return shuffled.map((spec) => {
       const impls = imagesBySpec[spec.id];
-      const pick = impls[Math.floor(Math.random() * impls.length)];
+      const pick = pickRandom(impls);
       return {
         spec_id: spec.id,
         spec_title: spec.title,

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -204,17 +204,23 @@ export function DebugPage() {
   const [missingLibrary, setMissingLibrary] = useState('');
 
   const [pings, setPings] = useState<Array<{ ms: number; ok: boolean }>>([]);
+  const [prevFetchKey, setPrevFetchKey] = useState({ adminToken, reloadCounter });
 
-  useEffect(() => {
+  // React 19 "adjust state on prop change": reset loading/error when fetch deps change.
+  if (prevFetchKey.adminToken !== adminToken || prevFetchKey.reloadCounter !== reloadCounter) {
+    setPrevFetchKey({ adminToken, reloadCounter });
     setLoading(true);
     setError(null);
+  }
+
+  useEffect(() => {
     adminFetch(`${DEBUG_API_URL}/debug/status`, adminToken)
       .then(async r => {
         // Reaching here means the fetch promise resolved (the response may
         // still be 401/403/503 — those are handled below). Clear the one-shot
         // reload guard so a future cross-origin CF Access redirect can
         // re-trigger the bootstrap.
-        try { sessionStorage.removeItem(RELOAD_GUARD_KEY); } catch {}
+        try { sessionStorage.removeItem(RELOAD_GUARD_KEY); } catch { /* sessionStorage may be unavailable in private mode */ }
         // 403 is the Cloudflare Access JWT path's denial: a signed-in Google
         // account that isn't on the admin_allowed_emails allow-list. Surface
         // it on the auth-required screen with the server's message so the
@@ -242,9 +248,9 @@ export function DebugPage() {
         // the second load ALSO fails (e.g. wrong allow-list).
         if (e instanceof TypeError) {
           let alreadyTried = false;
-          try { alreadyTried = !!sessionStorage.getItem(RELOAD_GUARD_KEY); } catch {}
+          try { alreadyTried = !!sessionStorage.getItem(RELOAD_GUARD_KEY); } catch { /* sessionStorage may be unavailable in private mode */ }
           if (!alreadyTried) {
-            try { sessionStorage.setItem(RELOAD_GUARD_KEY, '1'); } catch {}
+            try { sessionStorage.setItem(RELOAD_GUARD_KEY, '1'); } catch { /* sessionStorage may be unavailable in private mode */ }
             // replace() not assign() — assign would push the broken pre-auth
             // /debug onto the back-stack, so the user could navigate back
             // into the same loop after logging in.

--- a/app/src/pages/MapPage.test.tsx
+++ b/app/src/pages/MapPage.test.tsx
@@ -410,7 +410,6 @@ describe('MapPage', () => {
     it('is a no-op when there are no nodes', () => {
       const force = outlierSquashForce(0.95, 200, 0.18);
       // initialize with empty array; force(alpha) must not throw.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (force as unknown as { initialize: (n: SimNode[]) => void }).initialize([]);
       expect(() => force(1)).not.toThrow();
     });

--- a/app/src/pages/SpecsListPage.tsx
+++ b/app/src/pages/SpecsListPage.tsx
@@ -23,6 +23,14 @@ interface SpecListItem {
   images: PlotImage[];
 }
 
+function initRotationIndices(specs: SpecListItem[]): Record<string, number> {
+  const init: Record<string, number> = {};
+  specs.forEach((spec) => {
+    init[spec.id] = Math.floor(Math.random() * spec.images.length);
+  });
+  return init;
+}
+
 export function SpecsListPage() {
   const { specsData } = useAppData();
   const { saveScrollPosition } = useHomeState();
@@ -95,16 +103,11 @@ export function SpecsListPage() {
     return specs;
   }, [allImages, specsData]);
 
-  // Initialize random rotation indices once specs are loaded
-  useEffect(() => {
-    if (specList.length > 0 && Object.keys(rotationIndex).length === 0) {
-      const initialIndices: Record<string, number> = {};
-      specList.forEach((spec) => {
-        initialIndices[spec.id] = Math.floor(Math.random() * spec.images.length);
-      });
-      setRotationIndex(initialIndices);
-    }
-  }, [specList, rotationIndex]);
+  // Initialize random rotation indices once specs are loaded — runs once because rotationIndex
+  // becomes non-empty after the first call, and stays non-empty.
+  if (specList.length > 0 && Object.keys(rotationIndex).length === 0) {
+    setRotationIndex(initRotationIndices(specList));
+  }
 
   // Show/hide scroll-to-top button based on scroll position
   useEffect(() => {

--- a/core/config.py
+++ b/core/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
     # AI MODEL CONFIGURATION
     # =============================================================================
 
-    claude_model: str = "claude-3-5-sonnet-20240620"
+    claude_model: str = "claude-sonnet-4-6"
     """Claude model to use for code generation and review"""
 
     claude_max_tokens: int = 4000

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -197,6 +197,8 @@ carry `spec`, `library`, or `value` for richer breakdowns.
 | `LCP` | `value`, `rating` | reportWebVitals.ts | Largest Contentful Paint (rounded to nearest 100ms) |
 | `CLS` | `value`, `rating` | reportWebVitals.ts | Cumulative Layout Shift (2 decimal places) |
 | `INP` | `value`, `rating` | reportWebVitals.ts | Interaction to Next Paint (rounded to nearest 50ms) |
+| `FCP` | `value`, `rating` | reportWebVitals.ts | First Contentful Paint (rounded to nearest 100ms) |
+| `TTFB` | `value`, `rating` | reportWebVitals.ts | Time to First Byte (rounded to nearest 100ms) |
 
 **Rating values**: `good`, `needs-improvement`, `poor` (per web-vitals thresholds)
 
@@ -460,9 +462,11 @@ User lands on anyplot.ai
 | `LCP` | `value`, `rating` | reportWebVitals.ts |
 | `CLS` | `value`, `rating` | reportWebVitals.ts |
 | `INP` | `value`, `rating` | reportWebVitals.ts |
+| `FCP` | `value`, `rating` | reportWebVitals.ts |
+| `TTFB` | `value`, `rating` | reportWebVitals.ts |
 | `og_image_view` | `page`, `platform`, `spec`?, `language`?, `library`?, `filter_*`? | api/analytics.py (server-side) |
 
-**Total: 28 client-side + 1 server-side = 29 events**
+**Total: 30 client-side + 1 server-side = 31 events**
 
 > Every pageview and event additionally carries a `theme` ambient prop (`dark` /
 > `light`). Set in `RootLayout` via `setAnalyticsAmbientProps` whenever the user

--- a/scripts/evaluate-plot.py
+++ b/scripts/evaluate-plot.py
@@ -133,14 +133,17 @@ LIBRARY_PATTERNS = {
 }
 
 
-def get_plot_paths(spec_id: str, library: str) -> dict:
+def get_plot_paths(spec_id: str, library: str, language: str = "python") -> dict:
     """Get all relevant paths for a plot implementation."""
     plots_dir = PROJECT_ROOT / "plots" / spec_id
+    impl_dir = plots_dir / "implementations" / language
     return {
         "spec": plots_dir / "specification.md",
-        "impl": plots_dir / "implementations" / f"{library}.py",
-        "metadata": plots_dir / "metadata" / f"{library}.yaml",
-        "image": plots_dir / "implementations" / "plot.png",
+        "impl": impl_dir / f"{library}.py",
+        "metadata": plots_dir / "metadata" / language / f"{library}.yaml",
+        "image": impl_dir / "plot.png",
+        "image_light": impl_dir / "plot-light.png",
+        "image_dark": impl_dir / "plot-dark.png",
         "library_rules": PROJECT_ROOT / "prompts" / "library" / f"{library}.md",
         "quality_criteria": PROJECT_ROOT / "prompts" / "quality-criteria.md",
         "quality_evaluator": PROJECT_ROOT / "prompts" / "quality-evaluator.md",
@@ -374,6 +377,14 @@ def create_evaluation_prompt(spec_id: str, library: str, paths: dict) -> str:
     return f"""{evaluator_content}
 
 ---
+
+## Local CLI Mode — Single Render Only
+
+This invocation is from the `evaluate-plot.py` local CLI, not the production
+review workflow. Only a single rendered preview (`plot.png`) is attached, and
+there is no `plot-light.png` / `plot-dark.png` theme pair (or `plot-*.html`)
+available. Score VQ-07 (Palette Compliance) and any other theme-aware criteria
+based on the single render shown — do not deduct for "missing theme variant".
 
 ## Inputs
 

--- a/scripts/evaluate-plot.py
+++ b/scripts/evaluate-plot.py
@@ -143,6 +143,7 @@ def get_plot_paths(spec_id: str, library: str) -> dict:
         "image": plots_dir / "implementations" / "plot.png",
         "library_rules": PROJECT_ROOT / "prompts" / "library" / f"{library}.md",
         "quality_criteria": PROJECT_ROOT / "prompts" / "quality-criteria.md",
+        "quality_evaluator": PROJECT_ROOT / "prompts" / "quality-evaluator.md",
     }
 
 
@@ -361,104 +362,50 @@ def run_auto_reject_checks(spec_id: str, library: str, run_code: bool = True) ->
 # =============================================================================
 
 def create_evaluation_prompt(spec_id: str, library: str, paths: dict) -> str:
-    """Create the evaluation prompt for Claude (v2 criteria)."""
+    """Build the evaluation prompt by composing the canonical evaluator + criteria
+    files (mirrors the workflow pattern — single source of truth for the rubric).
+    """
     spec_content = paths["spec"].read_text() if paths["spec"].exists() else "NOT FOUND"
     impl_content = paths["impl"].read_text() if paths["impl"].exists() else "NOT FOUND"
     criteria_content = paths["quality_criteria"].read_text() if paths["quality_criteria"].exists() else "NOT FOUND"
+    evaluator_content = paths["quality_evaluator"].read_text() if paths["quality_evaluator"].exists() else "NOT FOUND"
     library_rules = paths["library_rules"].read_text() if paths["library_rules"].exists() else ""
 
-    return f"""## Task: Evaluate Plot Quality (v2 Criteria)
+    return f"""{evaluator_content}
 
-You are evaluating a **{library}** implementation of **{spec_id}**.
+---
 
-**Important:** This implementation has already passed Auto-Reject checks (syntax, runtime, output, library usage).
-Focus purely on QUALITY evaluation.
+## Inputs
+
+You are evaluating **{library}** implementation of **{spec_id}**. The implementation
+has already passed Stage 1 auto-reject checks (syntax, runtime, output, library
+usage). Focus purely on Stage 2 quality scoring.
 
 ### Specification
+
 ```markdown
 {spec_content}
 ```
 
 ### Implementation ({library}.py)
+
 ```python
 {impl_content}
 ```
 
 ### Library Rules
+
 ```markdown
 {library_rules}
 ```
 
-### Quality Criteria
+### Quality Criteria (full rubric)
+
 ```markdown
 {criteria_content}
 ```
 
-### Your Task
-
-Evaluate STRICTLY. Remember:
-- 90-100 = Publication quality (Nature/Science)
-- 70-89 = Professional
-- 50-69 = Acceptable
-- <50 = Rejected
-
-Provide evaluation as JSON:
-
-```json
-{{
-  "score": <0-100>,
-  "tier": "<Excellent|Good|Acceptable|Poor>",
-
-  "visual_quality": {{
-    "vq01_text_legibility": {{"score": <0-10>, "note": "..."}},
-    "vq02_no_overlap": {{"score": <0-8>, "note": "..."}},
-    "vq03_element_visibility": {{"score": <0-8>, "note": "..."}},
-    "vq04_color_accessibility": {{"score": <0-5>, "note": "..."}},
-    "vq05_layout_balance": {{"score": <0-5>, "note": "..."}},
-    "vq06_axis_labels": {{"score": <0-2>, "note": "..."}},
-    "vq07_grid_legend": {{"score": <0-2>, "note": "..."}},
-    "total": <0-40>
-  }},
-
-  "spec_compliance": {{
-    "sc01_plot_type": {{"score": <0-8>, "note": "..."}},
-    "sc02_data_mapping": {{"score": <0-5>, "note": "..."}},
-    "sc03_required_features": {{"score": <0-5>, "note": "..."}},
-    "sc04_data_range": {{"score": <0-3>, "note": "..."}},
-    "sc05_legend_accuracy": {{"score": <0-2>, "note": "..."}},
-    "sc06_title_format": {{"score": <0-2>, "note": "..."}},
-    "total": <0-25>
-  }},
-
-  "data_quality": {{
-    "dq01_feature_coverage": {{"score": <0-8>, "note": "..."}},
-    "dq02_realistic_context": {{"score": <0-7>, "note": "..."}},
-    "dq03_appropriate_scale": {{"score": <0-5>, "note": "..."}},
-    "total": <0-20>
-  }},
-
-  "code_quality": {{
-    "cq01_kiss_structure": {{"score": <0-3>, "note": "..."}},
-    "cq02_reproducibility": {{"score": <0-3>, "note": "..."}},
-    "cq03_clean_imports": {{"score": <0-2>, "note": "..."}},
-    "cq04_no_deprecated_api": {{"score": <0-1>, "note": "..."}},
-    "cq05_output_correct": {{"score": <0-1>, "note": "..."}},
-    "total": <0-10>
-  }},
-
-  "library_features": {{
-    "lf01_distinctive_features": {{"score": <0-5>, "note": "..."}},
-    "total": <0-5>
-  }},
-
-  "strengths": ["..."],
-  "weaknesses": ["..."],
-  "improvements": ["..."],
-  "summary": "One sentence summary"
-}}
-```
-
-Be STRICT - a "good" plot should score around 70-80, not 95.
+Return the JSON output in the exact shape specified in the evaluator's "Output Format" section.
 """
 
 
@@ -560,21 +507,23 @@ def print_quality_result(result: dict, verbose: bool = False):
     print(f"QUALITY SCORE: {score}/100 ({tier})")
     print("="*60)
 
-    # Category scores
+    # Category scores — must match the canonical 6-category rubric in prompts/quality-criteria.md.
     vq = result.get("visual_quality", {}).get("total", "?")
+    de = result.get("design_excellence", {}).get("total", "?")
     sc = result.get("spec_compliance", {}).get("total", "?")
     dq = result.get("data_quality", {}).get("total", "?")
     cq = result.get("code_quality", {}).get("total", "?")
-    lf = result.get("library_features", {}).get("total", "?")
+    lm = result.get("library_mastery", {}).get("total", "?")
 
-    print(f"\n  Visual Quality:    {vq}/40")
-    print(f"  Spec Compliance:   {sc}/25")
-    print(f"  Data Quality:      {dq}/20")
+    print(f"\n  Visual Quality:    {vq}/30")
+    print(f"  Design Excellence: {de}/20")
+    print(f"  Spec Compliance:   {sc}/15")
+    print(f"  Data Quality:      {dq}/15")
     print(f"  Code Quality:      {cq}/10")
-    print(f"  Library Features:  {lf}/5")
+    print(f"  Library Mastery:   {lm}/10")
 
     if verbose:
-        for category in ["visual_quality", "spec_compliance", "data_quality", "code_quality", "library_features"]:
+        for category in ["visual_quality", "design_excellence", "spec_compliance", "data_quality", "code_quality", "library_mastery"]:
             cat_data = result.get(category, {})
             print(f"\n{category.upper()}:")
             for key, val in cat_data.items():

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -731,6 +731,14 @@ class TestSeoProxyRouter:
         assert "og:title" in response.text
         assert "https://anyplot.ai/palette" in response.text
 
+    def test_seo_map(self, client: TestClient) -> None:
+        """SEO map page should return HTML with og:tags."""
+        response = client.get("/seo-proxy/map")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        assert "og:title" in response.text
+        assert "https://anyplot.ai/map" in response.text
+
     def test_seo_stats(self, client: TestClient) -> None:
         """SEO stats page should return HTML with og:tags."""
         response = client.get("/seo-proxy/stats")


### PR DESCRIPTION
## Summary

Five quick-win items from `agentic/audits/latest.md` (2026-05-05):

1. **Frontend lint CI repair** — 32 errors → 0 (audit Critical #1).
2. **`/seo-proxy/map`** — bot prerender for the network map (audit Critical #5 partial).
3. **evaluate-plot.py** — switch to canonical 6-category rubric + bump model default (audit High #2).
4. **plausible.md** — document FCP/TTFB Web-Vitals events (audit High #3).
5. **CodeQL #101** — already user-dismissed 2026-05-05; called out in PR body, no code change.

## Detail

### 1. Lint repair (`yarn lint` 32→0 errors)

- `app/eslint.config.js`: added `IdleRequestCallback`, `IdleDeadline`, `IdleCallbackHandle`, `IdleRequestOptions`, `requestIdleCallback`, `cancelIdleCallback`, `FrameRequestCallback`, `IntersectionObserverCallback`, `IntersectionObserverInit`, `IntersectionObserverEntry` to production globals; added Node `global` to test-entry globals.
- 5× `react-hooks/set-state-in-effect`: refactored to React 19's "adjust state on prop change" pattern (`if (prev !== current) { setPrev(current); ... }` during render — no cascading re-render):
  - `RelatedSpecs.tsx` — combined `setExpanded(false)` + `setLoading(true)` resets into a single `prevDeps` guard.
  - `SpecDetailView.tsx` — interactive size reset on `selectedLibrary` change.
  - `DebugPage.tsx` — `setLoading(true)/setError(null)` reset on `[adminToken, reloadCounter]` change.
  - `SpecsListPage.tsx` — random rotation init driven by `Object.keys(rotationIndex).length === 0` guard (reference-compare on `specList` was attempted first but trips an infinite re-render in the test mock, which returns a fresh `specsData` array each call).
- 1× `react-hooks/purity`: `Math.random` in `useFeaturedSpecs.ts` extracted into a module-level `pickRandom<T>(items)` helper.
- 3× `no-empty`: sessionStorage swallows in `DebugPage.tsx` annotated with a comment.
- 1× unused var `implNoPreview` (`SpecOverview.test.tsx`): now used in the test (was a copy-paste oversight).
- 1× unused eslint-disable (`MapPage.test.tsx:413`) removed.

### 2. SEO `/map` handler

Mirrors the about/palette pattern in `api/routers/seo.py`. Bots now get a real `<title>` (`Network Map | anyplot.ai`) and a meta description.

### 3. evaluate-plot.py modernization

- Replace inline 5-category JSON template (Visual Quality 40 / Spec Compliance 25 / Data Quality 20 / Code Quality 10 / Library Features 5) with the canonical 6-category rubric driven by `prompts/quality-evaluator.md` + `prompts/quality-criteria.md` (Visual Quality 30 / Design Excellence 20 / Spec Compliance 15 / Data Quality 15 / Code Quality 10 / Library Mastery 10 = 100).
- `print_quality_result` and the `--verbose` loop updated to the new keys + denominators (was reading `library_features` / `vq…/40` etc., now reads `library_mastery` / `vq…/30`).
- `core/config.py`: `claude_model` default bumped from `claude-3-5-sonnet-20240620` (18 months old) to `claude-sonnet-4-6`.

### 4. Plausible docs (FCP/TTFB)

`docs/reference/plausible.md`: added FCP and TTFB rows to Custom Events table + Implementation Checklist; bumped total client-side events from 28 → 30.

> ⚠️ **Follow-up needed**: FCP/TTFB are already emitted from `reportWebVitals.ts` but must also be **registered in the Plausible dashboard** as custom events, otherwise they're silently dropped server-side. Documenting them here doesn't make them appear; that's a separate manual step.

### 5. CodeQL #101 — already dismissed

`gh api repos/.../code-scanning/alerts/101` shows `state: dismissed` since `2026-05-05T21:38:46Z` (dismissed by @MarkusNeusinger as "false positive — 'private' is a literal field name in a demo radar-chart axis dataset"). Audit was generated on the same day and listed it as still open. **No code change in this PR for this item.**

The audit's broader recommendation — "exclude `plots/` from CodeQL scan" — would require switching from default to advanced code-scanning setup (workflow file + `.github/codeql/codeql-config.yml`). Not done here; left as a future hygiene task.

## Test plan

- [x] `yarn lint` → 0 errors (2 pre-existing react-refresh warnings unchanged)
- [x] `yarn tsc --noEmit` → clean
- [x] `yarn test --run` → 466/466 pass
- [x] `uv run ruff check api/ core/` → clean
- [x] `uv run ruff format --check api/ core/` → clean
- [ ] CI green on this PR (will watch)
- [ ] Post-merge: register FCP/TTFB in Plausible dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)