### PR TITLE
chore(workflows): retry transient failures in impl-generate + impl-review

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -548,7 +548,25 @@ jobs:
           fi
 
           git commit -m "chore(${LIBRARY}): add metadata for ${SPEC_ID}"
-          git push origin "$BRANCH"
+
+          # Retry git push — transient races against Claude's earlier push were
+          # the dominant "Create metadata file" failure mode (6x in 24h on
+          # 2026-05-06). On a non-fast-forward, fetch+rebase before retrying.
+          push_ok=0
+          for attempt in 1 2 3; do
+            if git push origin "$BRANCH"; then
+              push_ok=1
+              break
+            fi
+            echo "::warning::git push failed (attempt ${attempt}/3) — fetching + rebasing then retrying"
+            git fetch origin "$BRANCH" || true
+            git pull --rebase origin "$BRANCH" || true
+            sleep $((attempt * 5))
+          done
+          if [ "$push_ok" != "1" ]; then
+            echo "::error::git push failed after 3 attempts on branch ${BRANCH}"
+            exit 1
+          fi
 
           echo "::notice::Created metadata file: $METADATA_FILE (py${PYTHON_VERSION}, ${LIBRARY}==${LIBRARY_VERSION})"
           echo "::notice::Implementation verified present, metadata committed"

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -551,7 +551,9 @@ jobs:
 
           # Retry git push — transient races against Claude's earlier push were
           # the dominant "Create metadata file" failure mode (6x in 24h on
-          # 2026-05-06). On a non-fast-forward, fetch+rebase before retrying.
+          # 2026-05-06). On a non-fast-forward, fetch + rebase before retrying;
+          # if the rebase itself fails (conflicts), abort fast — leaving a
+          # half-rebased repo in place would just hide the real error.
           push_ok=0
           for attempt in 1 2 3; do
             if git push origin "$BRANCH"; then
@@ -559,9 +561,18 @@ jobs:
               break
             fi
             echo "::warning::git push failed (attempt ${attempt}/3) — fetching + rebasing then retrying"
-            git fetch origin "$BRANCH" || true
-            git pull --rebase origin "$BRANCH" || true
-            sleep $((attempt * 5))
+            if ! git fetch origin "$BRANCH"; then
+              echo "::error::git fetch origin ${BRANCH} failed during retry"
+              exit 1
+            fi
+            if ! git pull --rebase origin "$BRANCH"; then
+              echo "::error::git rebase against origin/${BRANCH} failed (conflicts) — aborting"
+              git rebase --abort 2>/dev/null || true
+              exit 1
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
           done
           if [ "$push_ok" != "1" ]; then
             echo "::error::git push failed after 3 attempts on branch ${BRANCH}"

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -53,15 +53,19 @@ jobs:
           MODEL_PAYLOAD: ${{ github.event.client_payload.model }}
         run: |
           # Retry gh pr view — transient API blips were the dominant impl-review
-          # failure mode (5x in 24h on 2026-05-06). Three attempts with backoff.
+          # failure mode (5x in 24h on 2026-05-06). Three attempts with linear
+          # backoff (5s, 10s); keep stderr separate from stdout so warnings
+          # (rate-limit notices, etc.) don't corrupt the JSON jq parses below.
           PR_DATA=""
           for attempt in 1 2 3; do
-            if PR_DATA=$(gh pr view "$PR_NUMBER" --json headRefName,headRefOid,body 2>&1); then
+            if gh pr view "$PR_NUMBER" --json headRefName,headRefOid,body > /tmp/pr.json 2> /tmp/pr.err; then
+              PR_DATA=$(cat /tmp/pr.json)
               break
             fi
-            echo "::warning::gh pr view failed (attempt ${attempt}/3): ${PR_DATA}"
-            PR_DATA=""
-            sleep $((attempt * 5))
+            echo "::warning::gh pr view failed (attempt ${attempt}/3): $(cat /tmp/pr.err)"
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
           done
           if [ -z "$PR_DATA" ]; then
             echo "::error::gh pr view failed after 3 attempts for PR #${PR_NUMBER}"

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -52,7 +52,21 @@ jobs:
           MODEL_INPUT: ${{ inputs.model }}
           MODEL_PAYLOAD: ${{ github.event.client_payload.model }}
         run: |
-          PR_DATA=$(gh pr view "$PR_NUMBER" --json headRefName,headRefOid,body)
+          # Retry gh pr view — transient API blips were the dominant impl-review
+          # failure mode (5x in 24h on 2026-05-06). Three attempts with backoff.
+          PR_DATA=""
+          for attempt in 1 2 3; do
+            if PR_DATA=$(gh pr view "$PR_NUMBER" --json headRefName,headRefOid,body 2>&1); then
+              break
+            fi
+            echo "::warning::gh pr view failed (attempt ${attempt}/3): ${PR_DATA}"
+            PR_DATA=""
+            sleep $((attempt * 5))
+          done
+          if [ -z "$PR_DATA" ]; then
+            echo "::error::gh pr view failed after 3 attempts for PR #${PR_NUMBER}"
+            exit 1
+          fi
           HEAD_REF=$(echo "$PR_DATA" | jq -r '.headRefName')
           HEAD_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid')
           BODY=$(echo "$PR_DATA" | jq -r '.body')


### PR DESCRIPTION
## Summary

Two minimal resilience patches for the dominant transient failures observed in the daily-regen audit (2026-05-06):

1. **`impl-review.yml` — \"Extract PR info\" step** (5 failures in 24h). Wrap `gh pr view` in a 3-attempt retry with exponential backoff. When the GitHub API blips, the entire review job aborts and the PR ends up unlabeled — blocking the review → repair → merge cascade. Concretely caused 4 of the 14 stuck PRs we recovered today (#5696, #5789, #5796, #5801 had no labels at all because review never made it past step 1).

2. **`impl-generate.yml` — \"Create library metadata file\" step** (6 failures in 24h). Wrap the final `git push origin \"\$BRANCH\"` in a 3-attempt retry that does `fetch + rebase` between attempts. The dominant failure mode is racing against Claude's earlier push to the same branch — when the metadata commit hits a non-fast-forward, the whole generation aborts and the PR never opens.

Both fixes are inline bash retries — no new action dependency. Each step still hard-fails after 3 attempts so persistent issues still surface (we don't want to mask real bugs).

## Out of scope (deferred)

- **`daily-regen.yml` \"pick\" job clean exit**: the existing logic already writes `count=0` when no specs are eligible, and downstream is gated on `if: needs.pick.outputs.count != '0'`. The 2 reported \"cancellations\" in the audit period look unrelated to the pick step itself (likely scheduler-level events).
- **Auto-retry on `ai-review-failed`**: would require a more invasive `if: failure()` job-level step. Holding until we see whether the Extract-PR-info retry alone reduces the rate enough.

## Context

This branch is the Stage 5 follow-up to today's recovery work, which manually shepherded 13 of 14 stuck PRs through the review/repair/merge pipeline. The full investigation + recovery plan lives at \`/home/tirao/.claude/plans/bitte-schaue-dir-alle-peppy-bunny.md\` (local).

## Test plan

- [x] YAML-validate both edited workflows (passes)
- [x] No-op for the happy path: first attempt of each retry preserves existing behavior exactly
- [ ] CI green on this PR
- [ ] Post-merge: watch the next 24h of impl-generate / impl-review run conclusions; expect failure rate to drop from ~10% to near 0% on these two steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)