### PR TITLE
fix(prompts): make tag vocabulary advisory for 3 of 4 dimensions

### DIFF
--- a/prompts/spec-tags-generator.md
+++ b/prompts/spec-tags-generator.md
@@ -16,22 +16,31 @@ AI rules for assigning Specification-Level Tags.
 
 ## The 4 Tag Dimensions
 
+### Vocabulary policy
+
+The lists below are **canonical for `plot_type`** (any new plot type should be added here via PR before being used), and **advisory for `data_type` / `domain` / `features`** (they list common values; any well-formed, recognized data-viz term is allowed in those three dimensions).
+
+The polish workflow enforces this asymmetry:
+- It will **move** tags from one dimension to another when they're clearly misclassified (e.g. `timeseries` in `plot_type` → `data_type`, `regression` in `plot_type` → `features`).
+- It will **only remove** an out-of-vocab tag from `plot_type` (where the list is canonical). For `data_type` / `domain` / `features`, an unfamiliar but well-formed tag is left in place.
+- It will always **canonicalize** naming (lowercase, hyphens, no underscores) and prefer the canonical term when one exists (`multi-series` → `multi`, `sequential` → `stepwise`).
+
 ### 1. plot_type - "What is visualized?"
 
 **Purpose:** Describes the visual form and structure of the plot.
 
 **Question:** "How would a data visualization expert name this plot?"
 
-**Recommended Values:**
+**Vocabulary (canonical — additions to this table are gated on a PR):**
 
 | Category | Tags |
 |----------|------|
-| Basic Forms | `scatter`, `line`, `bar`, `pie`, `area`, `point` |
+| Basic Forms | `scatter`, `line`, `bar`, `pie`, `area`, `point`, `bubble` |
 | Distributions | `histogram`, `density`, `box`, `violin`, `strip`, `swarm`, `rug` |
 | Matrices | `heatmap`, `contour`, `hexbin` |
 | Hierarchies | `treemap`, `sunburst`, `dendrogram`, `icicle`, `circlepacking` |
 | Networks | `network`, `chord`, `arc`, `sankey`, `alluvial` |
-| Specialized | `candlestick`, `gauge`, `funnel`, `waterfall`, `radar`, `polar` |
+| Specialized | `candlestick`, `gauge`, `funnel`, `waterfall`, `radar`, `polar`, `gantt`, `mosaic`, `donut`, `barcode`, `pairplot`, `surface`, `step` |
 | Geospatial | `choropleth`, `map` |
 | Statistical | `qq`, `ecdf`, `calibration`, `bland-altman` |
 
@@ -39,6 +48,7 @@ AI rules for assigning Specification-Level Tags.
 - Use established names from matplotlib/seaborn/plotly documentation
 - Multiple tags allowed when plot combines multiple types
 - Example: Sankey is also a `flow` plot
+- If a spec needs a plot type not on this list, add the tag to this table first (in the same PR or earlier) — that's the only place where vocabulary expansion is intentionally gated
 
 ---
 
@@ -48,15 +58,16 @@ AI rules for assigning Specification-Level Tags.
 
 **Question:** "If someone has this type of data, would they search for this plot?"
 
-**Recommended Values:**
+**Common values (advisory — any well-formed, recognized data-shape term is allowed):**
 
 | Category | Tags |
 |----------|------|
-| Numbers | `numeric`, `continuous`, `discrete` |
-| Categories | `categorical`, `ordinal` |
-| Time | `timeseries`, `datetime` |
-| Structure | `hierarchical`, `network`, `relational` |
-| Space | `geospatial`, `spatial` |
+| Numbers | `numeric`, `continuous`, `discrete`, `binary`, `probability` |
+| Variates | `univariate`, `bivariate`, `multivariate` |
+| Categories | `categorical`, `ordinal`, `compositional` |
+| Time | `timeseries`, `datetime`, `temporal` |
+| Structure | `hierarchical`, `network`, `relational`, `paired` |
+| Space | `geospatial`, `spatial`, `angular`, `directional` |
 | Text | `text`, `frequency` |
 | Matrix | `matrix`, `correlation` |
 
@@ -64,6 +75,7 @@ AI rules for assigning Specification-Level Tags.
 - Focus on logical data structure, not technical format
 - Multiple tags when different data types are combined
 - Example: Scatter needs `numeric` for both axes
+- The table is a starting point — domain-specific shapes (`ohlc`, `genomic`, etc.) may be tagged when they're the spec's defining input
 
 ---
 
@@ -73,21 +85,22 @@ AI rules for assigning Specification-Level Tags.
 
 **Question:** "Is there an industry where this plot is particularly common?"
 
-**Recommended Values:**
+**Common values (advisory — any real-world domain or sub-discipline is allowed):**
 
 | Category | Tags |
 |----------|------|
 | Universal | `general` |
-| Science | `statistics`, `science`, `research` |
-| Business | `business`, `finance`, `marketing` |
-| Technology | `engineering`, `technology` |
-| Other | `healthcare`, `education`, `energy`, `environment` |
+| Science | `statistics`, `science`, `research`, `physics`, `chemistry`, `biology`, `bioinformatics`, `genetics`, `geology` |
+| Business | `business`, `finance`, `marketing`, `trading`, `logistics`, `project-management` |
+| Technology | `engineering`, `technology`, `signal-processing`, `data-science` |
+| Other | `healthcare`, `education`, `energy`, `environment`, `meteorology`, `transportation`, `politics`, `demographics` |
 | ML/AI | `machine-learning`, `model-evaluation` |
 
 **Rules:**
 - `general` is default for universally applicable plots
 - Specific domains only when plot is particularly established there
 - Example: Candlestick → `finance`, Forest Plot → `healthcare`
+- The table is illustrative — narrower disciplines (`econometrics`, `music`, `infrastructure`, `monitoring`, etc.) are valid when the spec is genuinely characteristic of that field
 
 ---
 
@@ -97,22 +110,24 @@ AI rules for assigning Specification-Level Tags.
 
 **Question:** "What distinguishes this variant from the base version?"
 
-**Recommended Values:**
+**Common values (advisory — any meaningful feature descriptor is allowed):**
 
 | Category | Tags |
 |----------|------|
 | Complexity | `basic`, `advanced` |
-| Layout | `grouped`, `stacked`, `horizontal`, `multi`, `faceted` |
+| Layout | `grouped`, `stacked`, `horizontal`, `multi`, `multi-series`, `faceted`, `overlay`, `composite`, `combined` |
 | Dimensions | `2d`, `3d` |
 | Interaction | `interactive`, `animated`, `static` |
-| Function | `comparison`, `distribution`, `correlation`, `ranking` |
-| Display | `annotated`, `color-mapped`, `proportional` |
-| Special | `flow`, `temporal`, `cumulative`, `stepwise` |
+| Function | `comparison`, `distribution`, `correlation`, `ranking`, `regression`, `clustering`, `classification`, `model-evaluation`, `diagnostic` |
+| Display | `annotated`, `color-mapped`, `proportional`, `normalized`, `printable` |
+| Statistical | `confidence-interval`, `uncertainty`, `density`, `quartiles`, `threshold`, `trend` |
+| Special | `flow`, `flow-visualization`, `temporal`, `cumulative`, `stepwise`, `circular`, `radial`, `directional`, `multivariate`, `hierarchical`, `drilldown`, `technical-analysis` |
 
 **Rules:**
 - Describe what makes the plot SPECIAL
 - Multiple tags allowed
-- `basic` is informative - indicates base variant
+- `basic` is informative — indicates base variant
+- This table is a non-exhaustive starting point. New feature tags are encouraged when they capture a real distinction; prefer canonical wording (`stepwise` not `sequential`, `multi` not `multi-series` when describing layout, etc.)
 
 ---
 
@@ -197,6 +212,7 @@ tags:
 
 1. **Specific but not excessive** - 2-4 tags per dimension is typical
 2. **Think like a user** - What would someone type in a search?
-3. **Use established terms** - Prefer listed vocabulary, but any recognized term from the data-viz community is valid
+3. **Use established terms** - Prefer listed vocabulary, but any recognized term from the data-viz community is valid in `data_type`, `domain`, and `features`. `plot_type` is the only dimension where the table is canonical.
 4. **general is OK** - Not every plot needs a specialized domain
 5. **basic is informative** - Indicates this is the base variant
+6. **Right-dimension matters more than perfect-vocabulary** - A statistical operation like `regression` belongs in `features`, not `plot_type`. A data-shape like `timeseries` belongs in `data_type`, not `plot_type`. The polish workflow will move misclassified tags to the right dimension rather than just dropping them.

--- a/prompts/workflow-prompts/spec-polish-claude.md
+++ b/prompts/workflow-prompts/spec-polish-claude.md
@@ -28,7 +28,9 @@ For each, decide if the spec needs work:
 1. **Wording** — descriptions concise and unambiguous? applications realistic? data fields include types/sizes? notes actionable?
 2. **Missing sections** — every section from `specification.md` template present?
 3. **Tag completeness** — all 4 dimensions (`plot_type`, `data_type`, `domain`, `features`) have ≥1 value?
-4. **Tag quality** — naming conventions enforced (lowercase, hyphens, no underscores)? values from `spec-tags-generator.md` vocabulary?
+4. **Tag quality** — naming conventions enforced (lowercase, hyphens, no underscores)? Vocabulary policy:
+   - **`plot_type` is canonical**: the table in `spec-tags-generator.md` is the allowed set. Tags outside the table must either be moved to the correct dimension (e.g. `regression` → `features`, `timeseries` → `data_type`) or dropped if they're not really plot types.
+   - **`data_type` / `domain` / `features` are advisory**: their tables list common values, but any well-formed, recognized data-viz term is allowed. **Do NOT remove** an unfamiliar but valid tag from these three dimensions just because it isn't in the table — a niche but accurate domain (`bioinformatics`, `signal-processing`), a real feature (`confidence-interval`, `clustering`, `multi-series`), or a domain-specific data shape (`ohlc`, `compositional`) is fine to keep. Only canonicalize obvious synonyms (e.g. `sequential` → `stepwise`, `labeled` → `color-mapped` when describing color encoding) or fix naming-convention violations.
 5. **Tag accuracy** — do tags actually match the spec's content?
 
 ## Step 3: Decide


### PR DESCRIPTION
## Summary

The auto-polish step in `daily-regen` was treating the recommended-values tables in `spec-tags-generator.md` as canonical for **every** tag dimension (`plot_type`, `data_type`, `domain`, `features`), but the doc's own best-practices section says *"any recognized term from the data-viz community is valid"*. The asymmetry between intent and enforcement was causing valid tags to get stripped from specs.

## What an audit of all 327 specs shows

| Dimension | Unique out-of-vocab tags | Verdict |
|---|---|---|
| `plot_type` | 138 unique tags (257 usages) | Mix: legitimate additions (`surface`, `bubble`, `gantt`, `mosaic`, `donut`, `barcode`, `pairplot`, `step`) **and** misclassifications (`regression`/`timeseries`/`flow`/`grid`/`stacked`/`distribution` belong in `features`/`data_type`) |
| `data_type` | 16 unique tags (30 usages) | **All legitimate** — `multivariate`, `binary`, `bivariate`, `paired`, `angular`, `compositional`, `probability`, `ohlc`, … |
| `domain` | 23 unique tags (45 usages) | **All legitimate** — `trading`, `meteorology`, `bioinformatics`, `chemistry`, `biology`, `transportation`, `signal-processing`, … |
| `features` | 207 unique tags (343 usages) | Vast majority legitimate — `confidence-interval`, `uncertainty`, `clustering`, `regression`, `multi-series`, `density`, `model-evaluation`, `trend`, `threshold`, … |

## Two-file fix

### 1. `prompts/spec-tags-generator.md`
- Add a **Vocabulary policy** preamble making the asymmetry explicit:
  - `plot_type` is **canonical** — the table is authoritative; new plot types must be added via PR.
  - `data_type` / `domain` / `features` are **advisory** — the tables list common values but any well-formed, recognized data-viz term is valid.
- Expand each table with the most-used legitimate tags from the audit, so the polish prompt has more guidance for what's already-canonical (e.g. `bubble`/`surface`/`gantt` join the `plot_type` canon; `multivariate`/`paired`/`angular` join `data_type`; `bioinformatics`/`meteorology`/`signal-processing` join `domain`; `confidence-interval`/`clustering`/`multi-series` join `features`).

### 2. `prompts/workflow-prompts/spec-polish-claude.md`
- Rewrite the **Tag-quality** audit step to reflect the policy:
  - Polish **moves** misclassified tags to the right dimension (`timeseries` from `plot_type` → `data_type`, `regression` from `plot_type` → `features`) — this is what triggered today's PRs and is correct.
  - Polish **canonicalizes synonyms** (`sequential` → `stepwise`, `multi-series` → `multi` when describing layout) — also correct.
  - Polish must **NOT remove** an unfamiliar-but-valid tag from `data_type` / `domain` / `features` just because it's not in the table. A niche but accurate domain (`bioinformatics`), a real feature (`confidence-interval`), or a domain-specific data shape (`ohlc`) is fine to keep.

## Practical impact

Today's auto-polish PRs (line-multi, scatter-regression-linear, bar-grouped, etc.) were all **correct** under the new policy — they moved or canonicalized tags rather than dropping them. Going forward, polish will leave alone the long tail of legitimate but uncommon `domain` / `features` tags that previous polishes were at risk of stripping.

## Test plan

- [x] Diff stays local to two prompt files; no code changes
- [ ] Next `daily-regen` tick exercises the updated prompt (Haiku reads both updated docs as part of Step 1)
- [ ] Spot-check the next auto-polish PR — it should NOT remove valid out-of-vocab tags from `data_type` / `domain` / `features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)