### PR TITLE
fix(potd): remove letterbox strips around plot of the day image

### DIFF
--- a/app/src/components/PlotOfTheDayTerminal.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.tsx
@@ -144,13 +144,11 @@ export function PlotOfTheDayTerminal({
           maxHeight: maxPlotHeight,
           borderTop: '1px dashed var(--rule)',
           borderBottom: '1px dashed var(--rule)',
-          bgcolor: 'var(--bg-elevated)',
+          bgcolor: 'var(--bg-surface)',
           aspectRatio: '16 / 10',
           position: 'relative',
           overflow: 'hidden',
           cursor: 'pointer',
-          transition: 'background 0.2s',
-          '&:hover': { bgcolor: 'var(--bg-page)' },
           '&:focus-visible': { outline: `2px solid ${colors.primary}`, outlineOffset: -2 },
         }}
       >


### PR DESCRIPTION
## Summary
- The Plot of the Day frame had a 16:10 aspect ratio with `bgcolor: var(--bg-elevated)` and a hover swap to `var(--bg-page)`. Since the image uses `object-fit: contain`, non-16:10 plots were letterboxed, and the elevated background showed as light strips above and below the plot — strips that changed colour on hover and read as unrelated to the actual plot.
- Match the frame background to the surrounding card (`var(--bg-surface)`) and drop the hover colour change. The dashed top/bottom rules remain as the visual separators.

## Test plan
- [x] `yarn test PlotOfTheDayTerminal --run` passes
- [x] `yarn type-check` passes
- [ ] Visual check on landing page: no visible strips above/below the plot image, no colour flip on hover, dashed rules still present

https://claude.ai/code/session_01YGdKQ58HEtiRKGhaSN1HgC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGdKQ58HEtiRKGhaSN1HgC)_