### PR TITLE
chore(daily-regen): enable auto-merge on auto-polish PRs

### DIFF
--- a/.github/workflows/daily-regen.yml
+++ b/.github/workflows/daily-regen.yml
@@ -222,7 +222,7 @@ jobs:
             echo "skip_polish=0" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Spec polish (autonomous, opens PR — no auto-merge)
+      - name: Spec polish (autonomous, opens PR with auto-merge)
         if: ${{ steps.gate.outputs.skip_polish == '0' && !inputs.dry_run }}
         # Optional quality pass: a transient action failure here must not
         # block the main regeneration pipeline. Skip cleanly and continue.

--- a/prompts/workflow-prompts/spec-polish-claude.md
+++ b/prompts/workflow-prompts/spec-polish-claude.md
@@ -68,7 +68,7 @@ Run these commands:
 
 Then open the PR. Use a HEREDOC for the body so multi-line markdown survives:
 
-    gh pr create \
+    PR_URL=$(gh pr create \
       --title "chore(spec): auto-polish {SPEC_ID}" \
       --label "auto-polish" \
       --body "$(cat <<'EOF'
@@ -87,10 +87,19 @@ Then open the PR. Use a HEREDOC for the body so multi-line markdown survives:
     - No semantic changes (data shape, plot type, requirements identical)
     - `updated` bumped to current UTC
 
-    Awaiting human review. The skip-gate in `daily-regen` will prevent
-    additional auto-polish PRs for this spec while this one is open.
+    Auto-merge enabled — will merge once required checks pass. The
+    skip-gate in `daily-regen` prevents stacking polish PRs for this spec.
     EOF
-    )"
+    )")
+
+    # Enable auto-merge so the PR squash-merges automatically once required
+    # checks (Run Linting / Tests / Frontend Tests) go green and the head
+    # is in sync with main. Auto-merge handles the strict status-check
+    # policy by updating the branch on our behalf. If auto-merge cannot be
+    # enabled (e.g. checks already complete and branch is up-to-date), this
+    # is non-fatal — the PR still exists for human follow-up.
+    gh pr merge "$PR_URL" --auto --squash --delete-branch || \
+      echo "::warning::Could not enable auto-merge for $PR_URL — leaving PR open for manual handling"
 
 Substitute the literal `{SPEC_ID}` with the actual spec id when running the commands. The block above is illustrative; the bash you actually execute should have the value already filled in.
 
@@ -102,7 +111,8 @@ Substitute the literal `{SPEC_ID}` with the actual spec id when running the comm
 
 ## What you must NOT do
 
-- Do not auto-merge the PR. Do not add the `approved` label.
+- Do not add the `approved` label (it's reserved for spec-create's merge gate, not polish).
+- Do not bypass required status checks (no `--admin`, no force-merging). Auto-merge waits for CI.
 - Do not push to `main` directly under any circumstances, even if the polish is "trivial".
 - Do not edit any spec other than `{SPEC_ID}`. Do not touch implementations under `plots/{SPEC_ID}/implementations/` — your job is the spec only.
 - Do not regenerate or re-run anything in `plots/{SPEC_ID}/metadata/`. Implementation metadata is owned by the impl-* workflows.


### PR DESCRIPTION
## Summary
- Auto-polish PRs (e.g. #5916, #5870, #5860) were sitting open with all required checks green because the polish prompt explicitly forbade auto-merge — they piled up waiting for a human to click merge.
- Patch the polish prompt to call \`gh pr merge --auto --squash --delete-branch\` right after \`gh pr create\`. Auto-merge handles the strict required-status-check rule on \`main\` by updating the branch automatically when behind.
- Update the \"What you must NOT do\" section accordingly (remove \"do not auto-merge\", keep the \`approved\` label restriction and the no-\`--admin\` rule).
- Rename the workflow step from \"opens PR — no auto-merge\" to \"opens PR with auto-merge\" so log titles match behavior.

If \`gh pr merge --auto\` fails for any reason it falls back to a warning — the PR is still open and can be merged manually.

## Test plan
- [ ] Next \`daily-regen\` cycle produces a polish PR with auto-merge enabled (visible via \`gh pr view <num> --json autoMergeRequest\`).
- [ ] After CI passes, the PR squash-merges into main without manual intervention.
- [ ] If the polish step finds nothing (\`NOOP\`), no PR is created (existing behavior).