### PR TITLE
ci: trigger lint and tests on merge_group event

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -13,6 +13,7 @@ on:
       - develop
       - 'specification/**'
       - 'implementation/**'
+  merge_group:
 
 concurrency:
   group: ci-lint-${{ github.ref }}
@@ -36,6 +37,10 @@ jobs:
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          BASE_SHA="${{ github.event.merge_group.base_sha }}"
+          HEAD_SHA="${{ github.event.merge_group.head_sha }}"
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
         else
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,6 +13,7 @@ on:
       - develop
       - 'specification/**'
       - 'implementation/**'
+  merge_group:
   workflow_dispatch:
     inputs:
       force_run:
@@ -46,6 +47,10 @@ jobs:
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          BASE_SHA="${{ github.event.merge_group.base_sha }}"
+          HEAD_SHA="${{ github.event.merge_group.head_sha }}"
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
         else
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
@@ -173,6 +178,10 @@ jobs:
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
+        elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+          BASE_SHA="${{ github.event.merge_group.base_sha }}"
+          HEAD_SHA="${{ github.event.merge_group.head_sha }}"
           CHANGED_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA)
         else
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- Add `merge_group` to the `on:` trigger of `ci-lint.yml` and `ci-tests.yml` so the required status checks ("Run Linting", "Run Tests", "Run Frontend Tests") fire when a PR enters the merge queue.
- Extend the change-detection blocks to use `github.event.merge_group.{base,head}_sha` so the diff used for lint/test gating reflects the actual queued change.
- This is a prerequisite for enabling the GitHub Merge Queue rule on the `main` ruleset. Without it, queued PRs would hang forever waiting for status checks that never run.

After this merges to `main`, the merge-queue rule on the `main` ruleset will be enabled (separate API call) and `strict_required_status_checks_policy` will be turned off — the queue handles "branch up to date" by building each PR rebased onto current `main`. End result: auto-merge PRs (e.g. auto-polish, impl-merge) merge themselves once green, no more "Update branch" clicks.

## Test plan
- [ ] CI passes on this PR (the new triggers don't affect the existing `pull_request` event)
- [ ] After merge + ruleset update, queue a small PR and confirm it merges without manual branch updates
- [ ] Verify auto-polish PRs flow end-to-end after the next `daily-regen` cycle