### PR TITLE
chore(release): bump version to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # pyproject.toml
 [project]
 name = "anyplot"
-version = "2.2.0"
+version = "2.3.0"
 description = "AI-powered plotting examples"
 authors = [{ name = "Markus Neusinger", email = "admin@anyplot.ai" }]
 requires-python = ">=3.13"


### PR DESCRIPTION
Version bump for the v2.3.0 release. Release notes attached to the tag once this lands.