### PR TITLE
fix(mobile): prevent horizontal page scroll on /stats and /mcp

### DIFF
--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -49,6 +49,13 @@ export function RootLayout() {
     window.scrollTo(0, 0);
   }, [pathname, hash, navigationType]);
 
+  // Always reset horizontal scroll on route change. If a previous page leaked
+  // page-level horizontal scroll (e.g. a wide table on mobile), the offset
+  // otherwise persists into the next page and clips its left edge.
+  useEffect(() => {
+    window.scrollTo({ left: 0, top: window.scrollY });
+  }, [pathname]);
+
   return (
     <Box sx={{
       display: 'flex',

--- a/app/src/pages/McpPage.tsx
+++ b/app/src/pages/McpPage.tsx
@@ -28,6 +28,9 @@ const inlineCodeSx = {
   padding: '2px 6px',
   borderRadius: '3px',
   color: 'var(--ink)',
+  // Long URLs / commands sit in TableCells; without explicit wrapping they
+  // force the table wider than a mobile viewport.
+  overflowWrap: 'anywhere' as const,
 };
 
 export function McpPage() {

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -62,6 +62,14 @@
 /* MonoLisa script variant (italic ss02) — test */
 html { font-feature-settings: "ss02"; }
 
+/* Defense-in-depth against page-level horizontal scroll on mobile. `clip`
+   (not `hidden`) so the masthead's `position: sticky` keeps working — `hidden`
+   would create a scroll container and break it. Wide elements still need their
+   own local containment (e.g. tables, code blocks); this just stops a stray
+   overflow from leaking into viewport-wide horizontal scroll, which on SPA
+   nav otherwise persists across routes. */
+html, body { overflow-x: clip; }
+
 /* Animations */
 @keyframes rise {
   from { opacity: 0; transform: translateY(8px); }


### PR DESCRIPTION
## Summary

On mobile, `/stats` and `/mcp` could be side-scrolled horizontally even though no visible content extended past the viewport. Worse, that scroll position persisted across SPA navigation, so returning to `/` arrived horizontally offset and the left edge of the landing page was clipped.

### Root cause

- `McpPage.tsx` renders MUI `<Table>`s with inline-code spans containing un-breakable URLs like `https://api.anyplot.ai/mcp/` and `npx @modelcontextprotocol/inspector https://api.anyplot.ai/mcp/`. Default `table-layout: auto` + un-breakable mono-font content forces the table to ~530px wide — well past a mobile viewport.
- There was no global `overflow-x` guard, so wide content on any page leaks into viewport-level horizontal scroll.
- `RootLayout` reset vertical scroll on route change but not horizontal scroll, so the offset from one page persisted into the next.

### Fix

- `app/src/pages/McpPage.tsx` — add `overflowWrap: 'anywhere'` to `inlineCodeSx` so URLs/commands break inside TableCells instead of forcing the table wider than the viewport.
- `app/src/styles/tokens.css` — add `overflow-x: clip` on `html, body` as a defense-in-depth safety net. `clip` (not `hidden`) keeps the sticky masthead working since it doesn't create a scroll container.
- `app/src/components/RootLayout.tsx` — also reset `window.scrollX` on `pathname` change so any leftover offset doesn't carry into the next page.

## Test plan

- [x] `yarn type-check` passes
- [x] `yarn lint` passes (no new warnings)
- [x] `yarn test --run` passes for `McpPage`, `StatsPage`, `RootLayout`
- [ ] Manually verify on a mobile viewport (≤ 375px) that `/mcp` and `/stats` no longer side-scroll
- [ ] Manually verify that navigating from `/mcp` → `/` no longer arrives horizontally offset
- [ ] Verify the sticky masthead still sticks while scrolling on `/about`, `/legal`, `/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9D9L3UhWK8UvKuP6yCwMM)_