### PR TITLE
fix(stats): apply post-merge Copilot feedback from #6608

### DIFF
--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -89,11 +89,13 @@ class TimelinePoint(BaseModel):
 
 
 class DailyImplPoint(BaseModel):
-    """Implementation updates on a single day (last-30-days timeline).
+    """Implementation updates on a single day (last-28-days timeline).
 
-    Distinct from `debug.DailyImplPoint` (which uses `impls_updated`) — kept
-    separate because the public dashboard's consumer is the stats page bundle,
-    not the admin debug view, and `count` is consistent with `TimelinePoint`.
+    Window matches the visitors chart on the stats page so the two strips
+    read side-by-side. Distinct from `debug.DailyImplPoint` (which uses
+    `impls_updated`) — kept separate because the public dashboard's consumer
+    is the stats page bundle, not the admin debug view, and `count` is
+    consistent with `TimelinePoint`.
     """
 
     date: str  # ISO "YYYY-MM-DD"

--- a/app/src/components/SectionHeader.test.tsx
+++ b/app/src/components/SectionHeader.test.tsx
@@ -31,4 +31,27 @@ describe('SectionHeader', () => {
     await user.click(screen.getByText('specs.all()'));
     expect(trackEvent).toHaveBeenCalledWith('nav_click', { source: 'section_header', target: '/specs' });
   });
+
+  it('renders an external link and tracks external_link with the hostname', async () => {
+    const user = userEvent.setup();
+    render(
+      <SectionHeader
+        prompt="❯"
+        title="visitors"
+        linkText="plausible.view()"
+        linkHref="https://plausible.io/anyplot.ai"
+      />,
+    );
+
+    const link = screen.getByText('plausible.view()');
+    expect(link).toHaveAttribute('href', 'https://plausible.io/anyplot.ai');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+
+    await user.click(link);
+    expect(trackEvent).toHaveBeenCalledWith('external_link', {
+      source: 'section_header',
+      destination: 'plausible.io',
+    });
+  });
 });

--- a/app/src/components/SectionHeader.tsx
+++ b/app/src/components/SectionHeader.tsx
@@ -3,20 +3,37 @@ import { Link } from 'react-router-dom';
 import { colors, typography } from '../theme';
 import { useAnalytics } from '../hooks';
 
-interface SectionHeaderProps {
+interface SectionHeaderBaseProps {
   /** Prefix symbol — e.g. `§`, `❯`, `$`. Rendered at the same size as the title. */
   prompt?: string;
   title: React.ReactNode;
-  linkText?: string;
-  /** Internal route (React Router). Mutually exclusive with `linkHref`. */
-  linkTo?: string;
-  /** External URL — opens in a new tab. Mutually exclusive with `linkTo`. */
-  linkHref?: string;
 }
+
+/**
+ * `linkTo` (internal route) and `linkHref` (external URL) are mutually
+ * exclusive. The discriminated union enforces this at the type level so
+ * callers can't accidentally pass both.
+ */
+type SectionHeaderLinkProps =
+  | { linkText?: never; linkTo?: never; linkHref?: never }
+  | { linkText: string; linkTo: string; linkHref?: never }
+  | { linkText: string; linkHref: string; linkTo?: never };
+
+type SectionHeaderProps = SectionHeaderBaseProps & SectionHeaderLinkProps;
 
 const titleFontSize = { xs: '1.5rem', sm: '1.875rem', md: 'clamp(1.875rem, 3.5vw, 2.5rem)' };
 
-export function SectionHeader({ prompt, title, linkText, linkTo, linkHref }: SectionHeaderProps) {
+/** Derive a low-cardinality identifier (hostname) for analytics dimensions. */
+function externalDestination(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+export function SectionHeader(props: SectionHeaderProps) {
+  const { prompt, title, linkText, linkTo, linkHref } = props;
   const { trackEvent } = useAnalytics();
   const linkSx = {
     fontFamily: typography.mono,
@@ -82,7 +99,7 @@ export function SectionHeader({ prompt, title, linkText, linkTo, linkHref }: Sec
           href={linkHref}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => trackEvent('external_link', { source: 'section_header', destination: linkHref })}
+          onClick={() => trackEvent('external_link', { source: 'section_header', destination: externalDestination(linkHref) })}
           sx={linkSx}
         >
           {linkText}


### PR DESCRIPTION
## Summary
- Rescues an orphan post-merge commit (`3a955a4`) from `claude/add-plausible-chart-7voOx`. The original PR #6608 was squash-merged, then a Copilot review-feedback fix was pushed to the (closed) branch and never landed on main.
- All three changes are still missing on main — verified by diffing `origin/main..origin/claude/add-plausible-chart-7voOx`.

## Changes
- **`api/routers/insights.py`** — fix `DailyImplPoint` docstring: `last-30-days` → `last-28-days` to match the visitors-chart window the strip is paired with.
- **`app/src/components/SectionHeader.tsx`** — convert `linkTo` / `linkHref` to a discriminated union so callers can no longer pass both. Extract `externalDestination()` helper to send only the hostname to Plausible (low-cardinality dimension) instead of the full URL.
- **`app/src/components/SectionHeader.test.tsx`** — add a unit test for the `linkHref` branch and the `external_link` tracking payload.

## Test plan
- [x] `yarn test SectionHeader.test.tsx` passes (3/3)
- [ ] CI green
- [ ] `claude/add-plausible-chart-7voOx` can be deleted after merge