### PR TITLE
fix(style-experiment): apply post-merge Copilot feedback from #6378

### DIFF
--- a/scripts/style-experiment.py
+++ b/scripts/style-experiment.py
@@ -101,7 +101,17 @@ def load_variants(path: Path, names: list[str]) -> list[Variant]:
     if not path.is_file():
         sys.exit(f"Variants file not found: {path}")
     data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict):
+        sys.exit(
+            f"Variants file is empty or not a YAML mapping: {path} "
+            f"(got {type(data).__name__})"
+        )
     catalog = data.get("variants") or {}
+    if not isinstance(catalog, dict):
+        sys.exit(
+            f"'variants' key in {path} must be a mapping "
+            f"(got {type(catalog).__name__})"
+        )
     missing = [n for n in names if n not in catalog]
     if missing:
         sys.exit(
@@ -139,8 +149,10 @@ def _restore_all() -> None:
         try:
             path.write_text(original)
         except Exception as exc:
-            print(f"[style-experiment] WARNING: failed to restore {path}: {exc}",
+            print(f"[style-experiment] WARNING: failed to restore {path}: {exc}; "
+                  f"will retry on next cleanup hook",
                   file=sys.stderr)
+            continue
         _pending_restores.pop(path, None)
 
 


### PR DESCRIPTION
## Summary
- Rescues an orphan post-merge commit (`c8e6828`) from `claude/improve-plot-responsiveness-gHYM5`. PR #6378 was squash-merged on 2026-05-11; a Copilot follow-up fix was pushed to the (closed) branch ~1h later and never landed on main.
- Verified missing on main: `isinstance(data, Mapping)` guard is absent, and `_pending_restores.pop` runs unconditionally instead of only on successful restore.

## Changes
- **`scripts/style-experiment.py`**
  - `_restore_all`: skip the `_pending_restores.pop` when the disk write fails, so atexit / signal handlers / `patched_in_place` cleanup can retry. Previously a failed restore silently dropped the entry and could leave the repo patched.
  - `load_variants`: validate that the loaded YAML is a mapping and that the `variants` key (if present) is also a mapping. Empty/scalar YAML used to crash with a cryptic `AttributeError` on `data.get(...)`.

## Test plan
- [x] `python3 -m py_compile scripts/style-experiment.py` passes
- [ ] CI green
- [ ] `claude/improve-plot-responsiveness-gHYM5` can be deleted after merge