### PR TITLE
chore(ggplot2): follow-up Copilot review fixes after #6944 merge

### DIFF
--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -573,8 +573,16 @@ jobs:
                   f"Quality: {score}/100 | {date_info}\n"
                   '"""'
               )
+              # Match an existing leading triple-quoted module docstring and
+              # replace it. If the impl file has no header (generator skipped
+              # it / regen wiped it), prepend the canonical one instead of
+              # silently leaving the file without metadata — mirrors the R
+              # branch behaviour above.
               pattern = r'^""".*?"""'
-              new_content = re.sub(pattern, new_header, content, count=1, flags=re.DOTALL)
+              if re.match(pattern, content, flags=re.DOTALL):
+                  new_content = re.sub(pattern, new_header, content, count=1, flags=re.DOTALL)
+              else:
+                  new_content = new_header + "\n" + content
 
           with open(impl_file, "w") as f:
               f.write(new_content)

--- a/app/src/components/PlotOfTheDayTerminal.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.tsx
@@ -42,9 +42,10 @@ export function PlotOfTheDayTerminal({
   const previewUrl = selectPreviewUrl(potd, isDark);
   if (!potd || !previewUrl) return null;
 
-  // File extension follows the implementation language; ggplot2 ships as .R,
-  // everything else as .py.
+  // File extension + runner command follow the implementation language;
+  // ggplot2 (R) ships as .R + Rscript, every Python library as .py + python.
   const ext = potd.language === 'r' ? '.R' : '.py';
+  const runner = potd.language === 'r' ? 'Rscript' : 'python';
   const displayFilename = `plots/${potd.spec_id}/${potd.library_id}${ext}`;
   const implPath = specPath(potd.spec_id, potd.language, potd.library_id);
   const githubFileUrl = `${GITHUB_URL}/blob/main/plots/${potd.spec_id}/implementations/${potd.language}/${potd.library_id}${ext}`;
@@ -88,7 +89,7 @@ export function PlotOfTheDayTerminal({
         }}
       >
         <Box component="span" sx={{ color: colors.primary, fontWeight: 700 }}>$</Box>
-        <Box component="span">python</Box>
+        <Box component="span">{runner}</Box>
         <Box
           component="a"
           href={githubFileUrl}

--- a/prompts/plot-generator.md
+++ b/prompts/plot-generator.md
@@ -268,7 +268,8 @@ Must pass all code quality criteria (CQ-01 through CQ-05) from `prompts/quality-
 **Forbidden (Python):**
 - Functions or classes
 - `if __name__ == '__main__':`
-- Type hints or docstrings (keep it simple)
+- Type hints
+- **Extra** docstrings beyond the required 4-line module header (see "Docstring Format" above). The module header docstring at the top of the file is **mandatory** — `impl-review.yml` rewrites it after review and the catalog renders its metadata from it. Don't add function- or class-level docstrings (there shouldn't be any functions/classes anyway).
 - Cross-library workarounds **for plotting** (e.g., using matplotlib plotting functions inside plotnine)
 
 **Forbidden (R / ggplot2):**
@@ -276,6 +277,7 @@ Must pass all code quality criteria (CQ-01 through CQ-05) from `prompts/quality-
 - Calling `print(p)` after `ggsave()` — `ggsave` already renders
 - Using a non-`ragg` device for PNG output (Cairo path is not installed in CI)
 - Falling back to base-R `plot()` / `barplot()` when ggplot2 can't express something — return NOT_FEASIBLE instead
+- **Extra** roxygen blocks beyond the required 4-line header (see "Docstring Format" above). The R equivalent of the Python rule: the `#'`-prefixed header at the top of the file is **mandatory** (`impl-review.yml` rewrites it); don't add other `#'` blocks elsewhere.
 
 > If a library cannot implement a plot type natively, **do not** fall back to another library's **plotting functions** (e.g., don't use `plt.scatter()` inside plotnine). The implementation should **fail** rather than use workarounds. Each library should demonstrate only its own native plotting capabilities.
 


### PR DESCRIPTION
## Summary

Three Copilot review comments arrived on #6944 just before/after it was merged. Picking up the actionable ones in a small follow-up.

## What's fixed

**1. `PlotOfTheDayTerminal` — hardcoded `python` prompt** (#discussion_r3253434308)
The terminal-style chip in the POTD card had a hardcoded `python` label even though the filename now flips to `.R` for ggplot2. Output would read `python plots/<spec>/ggplot2.R` — wrong. Now derives a `runner` token from `potd.language` (`Rscript` for `r`, `python` otherwise) alongside the existing `ext` switch.

**2. `prompts/plot-generator.md` — contradictory docstring rule** (#discussion_r3253434312)
The "Forbidden (Python)" list said *"Type hints or docstrings (keep it simple)"* while the same prompt elsewhere requires a 4-line module-header docstring at the top of every Python impl. Contradictory guidance can make generators omit the required header. Clarified: header docstring is mandatory, additional docstrings are forbidden. Added the R equivalent for roxygen `#'` blocks so the rule symmetric.

**3. `impl-review.yml` — Python header rewrite needs a prepend fallback** (#discussion_r3253434319)
The Python branch of the header-rewrite step ran `re.sub` on a triple-quoted docstring pattern and silently left the file unchanged if there was no header. Mirrors the R branch behaviour now: `re.match` first, prepend the canonical header if absent.

## Deliberately *not* in this PR

- **SHA-pinning `r-lib/actions/setup-r` and `setup-renv`** (#discussion_r3253434287, #discussion_r3253434297). Pinning is correct policy, but pushing a SHA I haven't verified would re-introduce the bogus-SHA blocker that #6944 already had to fix. Dependabot will pin them to a verified SHA on its next run, the same way every other action ref in the repo got there.

## Test plan

- [x] `python3 -c "import yaml; ..."` on impl-review.yml — parses
- [ ] CI: ci-lint, ci-tests, frontend tsc + vitest
- [ ] One real impl-review run that exercises the Python prepend fallback (will happen organically the next time a Python impl is reviewed)

https://claude.ai/code/session_01Kb7b7QZi3ohtSTbd39poFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb7b7QZi3ohtSTbd39poFV)_