### PR TITLE
fix(impl-generate): suppress renv stdout in R version probe

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -460,12 +460,21 @@ jobs:
           # Python libs, the R version for ggplot2. The frontend renders language_version with
           # the right language label, so we never mislabel R as "Python".
           PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+          # R/Python versions are always dot-separated digits. Anything else
+          # captured from Rscript (renv leaks, error fragments, status messages)
+          # would poison metadata and break the downstream Python heredoc, so
+          # we reject and let the existing "unknown" fallback take over.
+          is_version() {
+            [[ "$1" =~ ^[0-9]+(\.[0-9]+)*$ ]]
+          }
+
           if [ "$LANGUAGE" = "r" ]; then
             # renv's "out-of-sync" notice prints on stdout from .Rprofile, so 2>/dev/null
-            # leaves it in the captured value. RENV_CONFIG_STARTUP_QUIET silences it; the
-            # tail -n1 belt keeps a single clean line if anything else ever leaks in.
+            # leaves it in the captured value. RENV_CONFIG_STARTUP_QUIET silences renv;
+            # tail -n1 + is_version reject anything else that might leak in or land if
+            # Rscript exits non-zero after partial stdout.
             LANGUAGE_VERSION=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e 'cat(as.character(getRversion()))' 2>/dev/null | tail -n1)
-            LANGUAGE_VERSION=${LANGUAGE_VERSION:-unknown}
+            is_version "$LANGUAGE_VERSION" || LANGUAGE_VERSION="unknown"
           else
             LANGUAGE_VERSION="$PYTHON_VERSION"
           fi
@@ -477,7 +486,9 @@ jobs:
             .venv/bin/pip show "$1" 2>/dev/null | grep -i "^Version:" | awk '{print $2}'
           }
           get_r_version() {
-            RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1
+            local v
+            v=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1)
+            is_version "$v" && printf '%s' "$v"
           }
 
           if [ "$LANGUAGE" = "r" ]; then

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -461,7 +461,11 @@ jobs:
           # the right language label, so we never mislabel R as "Python".
           PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
           if [ "$LANGUAGE" = "r" ]; then
-            LANGUAGE_VERSION=$(Rscript -e 'cat(as.character(getRversion()))' 2>/dev/null || echo "unknown")
+            # renv's "out-of-sync" notice prints on stdout from .Rprofile, so 2>/dev/null
+            # leaves it in the captured value. RENV_CONFIG_STARTUP_QUIET silences it; the
+            # tail -n1 belt keeps a single clean line if anything else ever leaks in.
+            LANGUAGE_VERSION=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e 'cat(as.character(getRversion()))' 2>/dev/null | tail -n1)
+            LANGUAGE_VERSION=${LANGUAGE_VERSION:-unknown}
           else
             LANGUAGE_VERSION="$PYTHON_VERSION"
           fi
@@ -473,7 +477,7 @@ jobs:
             .venv/bin/pip show "$1" 2>/dev/null | grep -i "^Version:" | awk '{print $2}'
           }
           get_r_version() {
-            Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null
+            RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1
           }
 
           if [ "$LANGUAGE" = "r" ]; then


### PR DESCRIPTION
## Summary

- First R/ggplot2 pipeline run crashed because `renv`'s `"- The project is out-of-sync -- use \`renv::status()\` for details."` notice prints on **stdout** from `.Rprofile`, so `2>/dev/null` left it inside `LANGUAGE_VERSION` / `LIBRARY_VERSION`.
- The polluted multi-line value then broke the downstream Python heredoc (`SyntaxError: unterminated string literal`), and a backtick in the notice split the bash command so `--model` ended up as a standalone token (`--model: command not found`).
- Fix: prefix both `Rscript` probes with `RENV_CONFIG_STARTUP_QUIET=TRUE` and pipe through `tail -n1` as a belt-and-suspenders against future stdout leaks. Both `getRversion()` and `packageVersion()` emit a single line, so trailing-line slicing is safe.

## Context

Observed in [run 25972681609](https://github.com/MarkusNeusinger/anyplot/actions/runs/25972681609) (bulk-generate ggplot2 for scatter-basic), which dispatched 2+ failing impl-generate runs with identical traces:
- 25972690929 (failure)
- 25972790865 (failure)

The underlying renv.lock-vs-installed-packages drift that triggers the notice is a separate concern; this PR just stops the version probe from being a footgun.

## Test plan

- [ ] PR's own CI (lint + tests) passes
- [ ] After merge, re-trigger `bulk-generate.yml -f specification_id=scatter-basic -f library=ggplot2` and confirm impl-generate's version-probe step logs e.g. `Library version: ggplot2 = 3.5.1 (r runtime 4.4.1, pipeline python 3.13.13)` without renv noise
- [ ] Full chain (impl-generate → impl-review → impl-merge) completes and produces `plots/scatter-basic/metadata/r/ggplot2.yaml` with populated `language_version`, `quality_score`, and a reachable GCS preview image

🤖 Generated with [Claude Code](https://claude.com/claude-code)