### PR TITLE
feat(prompts): include language in plot title format (closes #6958)

### DIFF
--- a/prompts/library/ggplot2.md
+++ b/prompts/library/ggplot2.md
@@ -222,7 +222,7 @@ df <- tibble::tibble(
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(df, aes(x, y)) +
   geom_point(color = OKABE_ITO[1], size = 4, alpha = 0.7) +
-  labs(title = "Basic Scatter", x = "X", y = "Y") +
+  labs(title = "scatter-basic · R · ggplot2 · anyplot.ai", x = "X", y = "Y") +
   theme_minimal(base_size = 14) +
   theme(
     plot.background  = element_rect(fill = PAGE_BG, color = PAGE_BG),

--- a/prompts/plot-generator.md
+++ b/prompts/plot-generator.md
@@ -118,7 +118,7 @@ ax.scatter(study_hours, exam_scores, alpha=0.7, s=200,
 # Style
 ax.set_xlabel('Study Hours per Day', fontsize=20, color=INK)
 ax.set_ylabel('Exam Score (%)', fontsize=20, color=INK)
-ax.set_title('scatter-basic · matplotlib · anyplot.ai',
+ax.set_title('scatter-basic · Python · matplotlib · anyplot.ai',
              fontsize=24, fontweight='medium', color=INK)
 ax.tick_params(axis='both', labelsize=16, colors=INK_SOFT)
 ax.spines['top'].set_visible(False)
@@ -138,23 +138,26 @@ plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight', facecolor=PAGE_BG
 **Always use this format for the plot title:**
 
 ```
-{spec-id} · {library} · anyplot.ai
+{spec-id} · {Language} · {library} · anyplot.ai
 ```
 
+`{Language}` is the implementation's language, capitalized: `Python` or `R`. The language token is **required** — viewers cannot tell from `ggplot2` alone whether a chart is Python or R (`plotnine` is the Python ggplot port), and going forward every rendered title must surface the runtime language.
+
 Examples:
-- `scatter-basic · matplotlib · anyplot.ai`
-- `bar-grouped · seaborn · anyplot.ai`
-- `heatmap-correlation · plotly · anyplot.ai`
+- `scatter-basic · Python · matplotlib · anyplot.ai`
+- `bar-grouped · Python · seaborn · anyplot.ai`
+- `heatmap-correlation · Python · plotly · anyplot.ai`
+- `biplot-pca · R · ggplot2 · anyplot.ai`
 
 **Optional descriptive prefix**: If the spec-id alone doesn't explain the example data well, add a descriptive title before it:
 
 ```
-{Descriptive Title} · {spec-id} · {library} · anyplot.ai
+{Descriptive Title} · {spec-id} · {Language} · {library} · anyplot.ai
 ```
 
 Examples:
-- `Tesla Stock 2024 · candle-ohlc · matplotlib · anyplot.ai`
-- `Sales by Region · bar-grouped · seaborn · anyplot.ai`
+- `Tesla Stock 2024 · candle-ohlc · Python · matplotlib · anyplot.ai`
+- `Sales by Region · bar-grouped · Python · seaborn · anyplot.ai`
 
 Only add the descriptive prefix when it adds value - most basic plots don't need it.
 

--- a/prompts/quality-criteria.md
+++ b/prompts/quality-criteria.md
@@ -332,7 +332,7 @@ This category evaluates aesthetic sophistication beyond mere correctness. A plot
 
 | Points | Criterion |
 |--------|-----------|
-| 3 | Title format `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R}) AND legend labels correct |
+| 3 | Title is `{spec-id} · {Language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (Language ∈ {Python, R}). Legend labels correct |
 | 2 | Title format correct but legend issues, or vice versa |
 | 1 | Partially correct |
 | 0 | Missing or wrong |

--- a/prompts/quality-criteria.md
+++ b/prompts/quality-criteria.md
@@ -332,7 +332,7 @@ This category evaluates aesthetic sophistication beyond mere correctness. A plot
 
 | Points | Criterion |
 |--------|-----------|
-| 3 | Title format `{spec-id} · {library} · anyplot.ai` AND legend labels correct |
+| 3 | Title format `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R}) AND legend labels correct |
 | 2 | Title format correct but legend issues, or vice versa |
 | 1 | Partially correct |
 | 0 | Missing or wrong |

--- a/prompts/quality-evaluator.md
+++ b/prompts/quality-evaluator.md
@@ -204,7 +204,7 @@ If found: `auto_reject: "AR-08"`, score = 0, stop evaluation.
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All spec features present? |
 | SC-03 | Data Mapping | 3 | X/Y correctly assigned? All data visible? |
-| SC-04 | Title & Legend | 3 | `{spec-id} · {library} · anyplot.ai`? Legend labels correct? |
+| SC-04 | Title & Legend | 3 | `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R})? Legend labels correct? |
 
 ### Step 4: Data Quality (15 pts)
 

--- a/prompts/quality-evaluator.md
+++ b/prompts/quality-evaluator.md
@@ -204,7 +204,7 @@ If found: `auto_reject: "AR-08"`, score = 0, stop evaluation.
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All spec features present? |
 | SC-03 | Data Mapping | 3 | X/Y correctly assigned? All data visible? |
-| SC-04 | Title & Legend | 3 | `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R})? Legend labels correct? |
+| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {Language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (Language ∈ {Python, R}). Legend labels correct? |
 
 ### Step 4: Data Quality (15 pts)
 

--- a/prompts/workflow-prompts/ai-quality-review.md
+++ b/prompts/workflow-prompts/ai-quality-review.md
@@ -107,7 +107,7 @@ Read `prompts/quality-criteria.md` and evaluate:
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All features from spec? |
 | SC-03 | Data Mapping | 3 | X/Y correct? Axes show all data? |
-| SC-04 | Title & Legend | 3 | `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R})? Legend labels match? |
+| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {Language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (Language ∈ {Python, R}). Legend labels match? |
 
 #### Data Quality (15 pts)
 | ID | Criterion | Max | Check |

--- a/prompts/workflow-prompts/ai-quality-review.md
+++ b/prompts/workflow-prompts/ai-quality-review.md
@@ -107,7 +107,7 @@ Read `prompts/quality-criteria.md` and evaluate:
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All features from spec? |
 | SC-03 | Data Mapping | 3 | X/Y correct? Axes show all data? |
-| SC-04 | Title & Legend | 3 | `{spec-id} · {library} · anyplot.ai`? Legend labels match? |
+| SC-04 | Title & Legend | 3 | `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R})? Legend labels match? |
 
 #### Data Quality (15 pts)
 | ID | Criterion | Max | Check |


### PR DESCRIPTION
## Summary

- Plot title format changes from `{spec-id} · {library} · anyplot.ai` to `{spec-id} · {Language} · {library} · anyplot.ai` (Language ∈ {Python, R}).
- Necessary now that R/ggplot2 implementations sit alongside the Python libraries — and because **plotnine** is the Python port of ggplot, the library name alone is ambiguous to viewers.
- Existing R implementations keep their old titles; only generations after this merge use the new format (per discussion in #6958 and the planning step).

## Files touched

- `prompts/plot-generator.md` — canonical format spec, the Python script example title (`ax.set_title('scatter-basic · Python · matplotlib · anyplot.ai', …)`), and all four example tables.
- `prompts/quality-evaluator.md`, `prompts/quality-criteria.md`, `prompts/workflow-prompts/ai-quality-review.md` — the SC-04 title-format check now lists `{Language}` so review won't flag the new pattern.

No code in `core/`, `api/`, or `app/` is touched. The frontend / filter / carousel changes called for in the same conversation will land in a follow-up PR.

## Test plan

- [ ] After merge, trigger `bulk-generate.yml` on one spec across one Python library (e.g. `matplotlib`) and `ggplot2`, and visually confirm both rendered PNGs include the new language token in the image title.
- [ ] Confirm `quality-evaluator` SC-04 passes on the new format (impl-review CI log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)