### PR TITLE
feat(frontend+api): surface language across the site + cross-language carousel

### DIFF
--- a/alembic/versions/c5f9a3d72be1_update_language_descriptions.py
+++ b/alembic/versions/c5f9a3d72be1_update_language_descriptions.py
@@ -20,6 +20,7 @@ Create Date: 2026-05-17
 from __future__ import annotations
 
 import sqlalchemy as sa
+
 from alembic import op
 
 

--- a/alembic/versions/c5f9a3d72be1_update_language_descriptions.py
+++ b/alembic/versions/c5f9a3d72be1_update_language_descriptions.py
@@ -1,0 +1,83 @@
+"""update language descriptions and backfill metadata
+
+Refreshes the seeded `languages` rows so they carry meaningful descriptions
+and complete metadata. The initial seed (LANGUAGES_METADATA) populated
+python with a meta-y placeholder ("the default language for anyplot plot
+implementations") that didn't actually describe Python, which made the new
+language tooltip on plot cards unhelpful. The python row also ended up with
+NULL `runtime_version` and `documentation_url` on the live DB, so we
+backfill both rows defensively from the current LANGUAGES_METADATA.
+
+We UPDATE explicitly rather than relying on the seeder because
+`sync_to_postgres.py` uses `on_conflict_do_nothing`, so once a language row
+is seeded it stays frozen on subsequent runs.
+
+Revision ID: c5f9a3d72be1
+Revises: 3a7e1b5c0c4f
+Create Date: 2026-05-17
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c5f9a3d72be1"
+down_revision: str | None = "3a7e1b5c0c4f"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+_NEW_ROWS = {
+    "python": {
+        "runtime_version": "3.13",
+        "documentation_url": "https://www.python.org",
+        "description": (
+            "General-purpose, high-level programming language with a clean, readable syntax. "
+            "The lingua franca of data science, scientific computing, and the SciPy / PyData ecosystem."
+        ),
+    },
+    "r": {
+        "runtime_version": "4.4",
+        "documentation_url": "https://www.r-project.org",
+        "description": (
+            "Language and environment for statistical computing and graphics. "
+            "Widely used in academia, biotech, and finance research, with a rich package ecosystem on CRAN."
+        ),
+    },
+}
+
+# Roll-back values for the description field only — the missing
+# runtime_version / documentation_url on python were never explicitly set
+# pre-migration, so downgrade leaves those backfills in place rather than
+# re-nulling them.
+_OLD_DESCRIPTIONS = {
+    "python": "The default language for anyplot plot implementations.",
+    "r": ("R is a statistical computing environment widely used in academia, biotech, and finance research."),
+}
+
+
+def _languages_table() -> sa.Table:
+    return sa.table(
+        "languages",
+        sa.column("id", sa.String),
+        sa.column("runtime_version", sa.String),
+        sa.column("documentation_url", sa.String),
+        sa.column("description", sa.Text),
+    )
+
+
+def upgrade() -> None:
+    languages = _languages_table()
+    bind = op.get_bind()
+    for lang_id, values in _NEW_ROWS.items():
+        bind.execute(languages.update().where(languages.c.id == lang_id).values(**values))
+
+
+def downgrade() -> None:
+    languages = _languages_table()
+    bind = op.get_bind()
+    for lang_id, desc in _OLD_DESCRIPTIONS.items():
+        bind.execute(languages.update().where(languages.c.id == lang_id).values(description=desc))

--- a/api/main.py
+++ b/api/main.py
@@ -28,6 +28,7 @@ from api.routers import (  # noqa: E402
     download_router,
     health_router,
     insights_router,
+    languages_router,
     libraries_router,
     og_images_router,
     plots_router,
@@ -118,7 +119,7 @@ async def add_cache_headers(request: Request, call_next):
     path = request.url.path
 
     # Static data — changes only on deploy (10 min cache, 1h stale-while-revalidate)
-    if path in ("/libraries", "/stats"):
+    if path in ("/libraries", "/languages", "/stats"):
         response.headers["Cache-Control"] = "public, max-age=600, stale-while-revalidate=3600"
     # Specs list (5 min cache, 1h stale-while-revalidate)
     elif path == "/specs":
@@ -144,6 +145,7 @@ app.include_router(health_router)
 app.include_router(stats_router)
 app.include_router(specs_router)
 app.include_router(libraries_router)
+app.include_router(languages_router)
 app.include_router(plots_router)
 app.include_router(insights_router)
 app.include_router(download_router)

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -4,6 +4,7 @@ from api.routers.debug import router as debug_router
 from api.routers.download import router as download_router
 from api.routers.health import router as health_router
 from api.routers.insights import router as insights_router
+from api.routers.languages import router as languages_router
 from api.routers.libraries import router as libraries_router
 from api.routers.og_images import router as og_images_router
 from api.routers.plots import router as plots_router
@@ -18,6 +19,7 @@ __all__ = [
     "download_router",
     "health_router",
     "insights_router",
+    "languages_router",
     "libraries_router",
     "og_images_router",
     "plots_router",

--- a/api/routers/languages.py
+++ b/api/routers/languages.py
@@ -1,0 +1,56 @@
+"""Language endpoints."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.cache import cache_key, get_or_set_cache
+from api.dependencies import optional_db
+from core.config import settings
+from core.constants import LANGUAGES_METADATA
+from core.database import LanguageRepository
+from core.database.connection import get_db_context
+
+
+router = APIRouter(tags=["languages"])
+
+
+def _serialize(language) -> dict:
+    return {
+        "id": language.id,
+        "name": language.name,
+        "file_extension": language.file_extension,
+        "runtime_version": language.runtime_version,
+        "documentation_url": language.documentation_url,
+        "description": language.description,
+    }
+
+
+async def _refresh_languages() -> dict:
+    """Standalone factory for background refresh (creates own DB session)."""
+    async with get_db_context() as db:
+        repo = LanguageRepository(db)
+        languages = await repo.get_all()
+        return {"languages": [_serialize(lang) for lang in languages]}
+
+
+@router.get("/languages")
+async def get_languages(db: AsyncSession | None = Depends(optional_db)):
+    """
+    Get list of all supported implementation languages.
+
+    Returns language information including display name, file extension,
+    runtime version, documentation URL, and a one-line description. Used by
+    the frontend to render language chips on library cards and the
+    clickable language tooltip on plot cards (deep-link to upstream docs).
+    """
+    if db is None:
+        return {"languages": LANGUAGES_METADATA}
+
+    async def _fetch() -> dict:
+        repo = LanguageRepository(db)
+        languages = await repo.get_all()
+        return {"languages": [_serialize(lang) for lang in languages]}
+
+    return await get_or_set_cache(
+        cache_key("languages"), _fetch, refresh_after=settings.cache_refresh_after, refresh_factory=_refresh_languages
+    )

--- a/api/routers/plots.py
+++ b/api/routers/plots.py
@@ -79,13 +79,7 @@ def _get_category_values(
 
 
 def _category_matches_filter(
-    category: str,
-    values: list[str],
-    spec_id: str,
-    library: str,
-    language: str,
-    spec_tags: dict,
-    impl_tags: dict,
+    category: str, values: list[str], spec_id: str, library: str, language: str, spec_tags: dict, impl_tags: dict
 ) -> bool:
     """
     Check if any of the filter values match the category's values.
@@ -107,12 +101,7 @@ def _category_matches_filter(
 
 
 def _image_matches_groups(
-    spec_id: str,
-    library: str,
-    language: str,
-    groups: list[dict],
-    spec_lookup: dict,
-    impl_lookup: dict,
+    spec_id: str, library: str, language: str, groups: list[dict], spec_lookup: dict, impl_lookup: dict
 ) -> bool:
     """Check if an image matches a set of filter groups."""
     if spec_id not in spec_lookup:
@@ -130,12 +119,7 @@ def _image_matches_groups(
 
 
 def _increment_category_counts(
-    counts: dict,
-    spec_id: str,
-    library: str,
-    language: str,
-    spec_tags: dict,
-    impl_tags: dict,
+    counts: dict, spec_id: str, library: str, language: str, spec_tags: dict, impl_tags: dict
 ) -> None:
     """Increment counts for all categories based on an image's spec/impl tags."""
     all_categories = ["lang", "lib", "spec", "plot", "data", "dom", "feat", "dep", "tech", "pat", "prep", "style"]

--- a/api/routers/plots.py
+++ b/api/routers/plots.py
@@ -46,22 +46,27 @@ _IMPL_EXTRACTORS: dict[str, Callable[[dict], list[str]]] = {
 }
 
 
-def _get_category_values(category: str, spec_id: str, library: str, spec_tags: dict, impl_tags: dict) -> list[str]:
+def _get_category_values(
+    category: str, spec_id: str, library: str, language: str, spec_tags: dict, impl_tags: dict
+) -> list[str]:
     """
     Get the values for a category from the appropriate tag source.
 
     This unified function replaces the repeated if/elif chains throughout the module.
 
     Args:
-        category: Filter category (lib, spec, plot, data, dom, feat, dep, tech, pat, prep, style)
+        category: Filter category (lang, lib, spec, plot, data, dom, feat, dep, tech, pat, prep, style)
         spec_id: Specification ID
         library: Library ID
+        language: Implementation language id (e.g. "python", "r")
         spec_tags: Spec-level tags dict
         impl_tags: Implementation-level tags dict
 
     Returns:
         List of values that match this category for the given image/spec/impl
     """
+    if category == "lang":
+        return [language] if language else []
     if category == "lib":
         return [library]
     if category == "spec":
@@ -74,7 +79,13 @@ def _get_category_values(category: str, spec_id: str, library: str, spec_tags: d
 
 
 def _category_matches_filter(
-    category: str, values: list[str], spec_id: str, library: str, spec_tags: dict, impl_tags: dict
+    category: str,
+    values: list[str],
+    spec_id: str,
+    library: str,
+    language: str,
+    spec_tags: dict,
+    impl_tags: dict,
 ) -> bool:
     """
     Check if any of the filter values match the category's values.
@@ -84,17 +95,25 @@ def _category_matches_filter(
         values: Filter values to match against
         spec_id: Specification ID
         library: Library ID
+        language: Implementation language id
         spec_tags: Spec-level tags dict
         impl_tags: Implementation-level tags dict
 
     Returns:
         True if any filter value matches, False otherwise
     """
-    category_values = _get_category_values(category, spec_id, library, spec_tags, impl_tags)
+    category_values = _get_category_values(category, spec_id, library, language, spec_tags, impl_tags)
     return any(v in category_values for v in values)
 
 
-def _image_matches_groups(spec_id: str, library: str, groups: list[dict], spec_lookup: dict, impl_lookup: dict) -> bool:
+def _image_matches_groups(
+    spec_id: str,
+    library: str,
+    language: str,
+    groups: list[dict],
+    spec_lookup: dict,
+    impl_lookup: dict,
+) -> bool:
     """Check if an image matches a set of filter groups."""
     if spec_id not in spec_lookup:
         return False
@@ -105,22 +124,30 @@ def _image_matches_groups(spec_id: str, library: str, groups: list[dict], spec_l
         category = group["category"]
         values = group["values"]
 
-        if not _category_matches_filter(category, values, spec_id, library, spec_tags, impl_tags):
+        if not _category_matches_filter(category, values, spec_id, library, language, spec_tags, impl_tags):
             return False
     return True
 
 
-def _increment_category_counts(counts: dict, spec_id: str, library: str, spec_tags: dict, impl_tags: dict) -> None:
+def _increment_category_counts(
+    counts: dict,
+    spec_id: str,
+    library: str,
+    language: str,
+    spec_tags: dict,
+    impl_tags: dict,
+) -> None:
     """Increment counts for all categories based on an image's spec/impl tags."""
-    all_categories = ["lib", "spec", "plot", "data", "dom", "feat", "dep", "tech", "pat", "prep", "style"]
+    all_categories = ["lang", "lib", "spec", "plot", "data", "dom", "feat", "dep", "tech", "pat", "prep", "style"]
     for category in all_categories:
-        for value in _get_category_values(category, spec_id, library, spec_tags, impl_tags):
+        for value in _get_category_values(category, spec_id, library, language, spec_tags, impl_tags):
             counts[category][value] = counts[category].get(value, 0) + 1
 
 
 def _create_empty_counts() -> dict:
     """Create an empty counts dictionary with all categories initialized."""
     return {
+        "lang": {},
         "lib": {},
         "spec": {},
         "plot": {},
@@ -157,7 +184,8 @@ def _calculate_global_counts(all_specs: list) -> dict:
                 continue
 
             impl_tags = impl.impl_tags or {}
-            _increment_category_counts(global_counts, spec_obj.id, impl.library_id, spec_tags, impl_tags)
+            language = impl.library.language if impl.library else "python"
+            _increment_category_counts(global_counts, spec_obj.id, impl.library_id, language, spec_tags, impl_tags)
 
     return _sort_counts(global_counts)
 
@@ -169,10 +197,11 @@ def _calculate_contextual_counts(filtered_images: list[dict], spec_id_to_tags: d
     for img in filtered_images:
         spec_id = img["spec_id"]
         library = img["library"]
+        language = img.get("language", "")
         spec_tags = spec_id_to_tags.get(spec_id, {})
         impl_tags = impl_lookup.get((spec_id, library), {})
 
-        _increment_category_counts(counts, spec_id, library, spec_tags, impl_tags)
+        _increment_category_counts(counts, spec_id, library, language, spec_tags, impl_tags)
 
     return _sort_counts(counts)
 
@@ -202,7 +231,9 @@ def _calculate_or_counts(
         images_with_other_filters = [
             img
             for img in all_images
-            if _image_matches_groups(img["spec_id"], img["library"], other_groups, spec_lookup, impl_lookup)
+            if _image_matches_groups(
+                img["spec_id"], img["library"], img.get("language", ""), other_groups, spec_lookup, impl_lookup
+            )
         ]
 
         # Count each value for this group's category
@@ -212,11 +243,12 @@ def _calculate_or_counts(
         for img in images_with_other_filters:
             spec_id = img["spec_id"]
             library = img["library"]
+            language = img.get("language", "")
             spec_tags = spec_id_to_tags.get(spec_id, {})
             impl_tags = impl_lookup.get((spec_id, library), {})
 
             # Use unified value extractor
-            for value in _get_category_values(category, spec_id, library, spec_tags, impl_tags):
+            for value in _get_category_values(category, spec_id, library, language, spec_tags, impl_tags):
                 group_counts[value] = group_counts.get(value, 0) + 1
 
         # Sort by count descending
@@ -241,6 +273,7 @@ def _parse_filter_groups(request: Request) -> list[dict]:
 
     # Valid filter categories (spec-level and impl-level)
     valid_categories = (
+        "lang",
         "lib",
         "spec",
         "plot",
@@ -374,7 +407,9 @@ def _filter_images(
     return [
         img
         for img in all_images
-        if _image_matches_groups(img["spec_id"], img["library"], filter_groups, spec_lookup, impl_lookup)
+        if _image_matches_groups(
+            img["spec_id"], img["library"], img.get("language", ""), filter_groups, spec_lookup, impl_lookup
+        )
     ]
 
 
@@ -394,6 +429,7 @@ async def get_filtered_plots(
     - Different categories: AND (lib=matplotlib&plot=scatter)
 
     Query params (comma-separated for OR, multiple params for AND):
+    - lang: Language filter (python, r)
     - lib: Library filter (matplotlib, seaborn, etc.)
     - spec: Spec ID filter (scatter-basic, etc.)
     - plot: Plot type tag (scatter, bar, line, etc.)

--- a/app/src/components/ImageCard.test.tsx
+++ b/app/src/components/ImageCard.test.tsx
@@ -10,9 +10,18 @@ vi.mock('../hooks/useCodeFetch', () => ({
 
 const baseImage: PlotImage = {
   library: 'matplotlib',
+  language: 'python',
   url: 'https://example.com/plot.png',
   spec_id: 'scatter-basic',
   title: 'Basic Scatter Plot',
+};
+
+const rImage: PlotImage = {
+  library: 'ggplot2',
+  language: 'r',
+  url: 'https://example.com/biplot.png',
+  spec_id: 'biplot-pca',
+  title: 'PCA Biplot',
 };
 
 const defaultProps = {
@@ -82,5 +91,57 @@ describe('ImageCard', () => {
       />
     );
     expect(screen.getByText('A basic scatter plot example')).toBeInTheDocument();
+  });
+
+  describe('language token', () => {
+    it('renders the language token in normal mode for python', () => {
+      render(<ImageCard {...defaultProps} />);
+      expect(screen.getByLabelText('Language: Python')).toHaveTextContent('Python');
+    });
+
+    it('renders the language token in normal mode for r', () => {
+      render(<ImageCard {...defaultProps} image={rImage} />);
+      expect(screen.getByLabelText('Language: R')).toHaveTextContent('R');
+    });
+
+    it('toggles the language tooltip on click', async () => {
+      const { userEvent } = await import('../test-utils');
+      const user = userEvent.setup();
+      const onTooltipToggle = vi.fn();
+      render(<ImageCard {...defaultProps} onTooltipToggle={onTooltipToggle} />);
+
+      await user.click(screen.getByLabelText('Language: Python'));
+      expect(onTooltipToggle).toHaveBeenCalledWith('lang-scatter-basic-matplotlib');
+    });
+
+    it('shows the language description + docs link when its tooltip is open', () => {
+      render(
+        <ImageCard
+          {...defaultProps}
+          languageDescription="High-level programming language."
+          languageDocUrl="https://www.python.org"
+          openTooltip="lang-scatter-basic-matplotlib"
+        />
+      );
+      expect(screen.getByText('High-level programming language.')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /www\.python\.org/i });
+      expect(link).toHaveAttribute('href', 'https://www.python.org');
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('does not show the language token in compact mode', () => {
+      render(<ImageCard {...defaultProps} imageSize="compact" />);
+      expect(screen.queryByLabelText('Language: Python')).not.toBeInTheDocument();
+    });
+
+    it('embeds the language as a file-extension suffix on the library in compact mode (python)', () => {
+      render(<ImageCard {...defaultProps} imageSize="compact" />);
+      expect(screen.getByText('mpl.py')).toBeInTheDocument();
+    });
+
+    it('embeds the language as a file-extension suffix on the library in compact mode (r)', () => {
+      render(<ImageCard {...defaultProps} image={rImage} imageSize="compact" />);
+      expect(screen.getByText('ggplot2.r')).toBeInTheDocument();
+    });
   });
 });

--- a/app/src/components/ImageCard.tsx
+++ b/app/src/components/ImageCard.tsx
@@ -38,6 +38,8 @@ interface ImageCardProps {
   selectedSpec: string;
   libraryDescription?: string;
   libraryDocUrl?: string;
+  languageDescription?: string;
+  languageDocUrl?: string;
   specDescription?: string;
   openTooltip: string | null;
   imageSize: ImageSize;
@@ -53,6 +55,8 @@ export const ImageCard = memo(function ImageCard({
   selectedSpec,
   libraryDescription,
   libraryDocUrl,
+  languageDescription,
+  languageDocUrl,
   specDescription,
   openTooltip,
   imageSize,
@@ -113,8 +117,10 @@ export const ImageCard = memo(function ImageCard({
   const cardId = `${image.spec_id}-${image.library}`;
   const specTooltipId = `spec-${cardId}`;
   const libTooltipId = `lib-${cardId}`;
+  const langTooltipId = `lang-${cardId}`;
   const isSpecTooltipOpen = openTooltip === specTooltipId;
   const isLibTooltipOpen = openTooltip === libTooltipId;
+  const isLangTooltipOpen = openTooltip === langTooltipId;
 
   // Animate first batch only (initial load), subsequent batches appear instantly
   const isFirstBatch = index < BATCH_SIZE;
@@ -293,18 +299,74 @@ export const ImageCard = memo(function ImageCard({
         {showLanguageToken && (
           <>
             <Typography sx={{ color: 'var(--ink-muted)', fontSize: labelFontSize }}>·</Typography>
-            <Typography
-              aria-label={`Language: ${languageDisplay}`}
-              sx={{
-                fontSize: labelFontSize,
-                letterSpacing: labelLetterSpacing,
-                fontWeight: 400,
-                fontFamily: typography.fontFamily,
-                color: 'var(--ink-muted)',
+
+            {/* Clickable Language — same visual weight as spec/library tokens.
+                Tooltip body shows the language description (from /languages)
+                and a link to the upstream homepage. */}
+            <Tooltip
+              title={
+                <Box>
+                  <Typography sx={{ fontSize: '0.8rem', mb: languageDocUrl ? 1 : 0 }}>
+                    {languageDescription || 'No description available'}
+                  </Typography>
+                  {languageDocUrl && (
+                    <Link
+                      href={languageDocUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        fontSize: '0.75rem',
+                        color: colors.tooltipLight,
+                        textDecoration: 'underline',
+                        '&:hover': { color: '#fff' },
+                      }}
+                    >
+                      {languageDocUrl.replace(/^https?:\/\//, '')} <OpenInNewIcon sx={{ fontSize: 12 }} />
+                    </Link>
+                  )}
+                </Box>
+              }
+              arrow
+              placement="bottom"
+              open={isLangTooltipOpen}
+              disableFocusListener
+              disableHoverListener
+              disableTouchListener
+              slotProps={{
+                tooltip: {
+                  sx: {
+                    maxWidth: { xs: '80vw', sm: 400 },
+                    fontFamily: typography.fontFamily,
+                    fontSize: labelFontSize,
+                  },
+                },
               }}
             >
-              {languageDisplay}
-            </Typography>
+              <Typography
+                data-description-btn
+                aria-label={`Language: ${languageDisplay}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onTooltipToggle(isLangTooltipOpen ? null : langTooltipId);
+                }}
+                sx={{
+                  fontSize: labelFontSize,
+                  letterSpacing: labelLetterSpacing,
+                  fontWeight: 600,
+                  fontFamily: typography.fontFamily,
+                  color: isLangTooltipOpen ? colors.primary : semanticColors.labelText,
+                  cursor: 'pointer',
+                  '&:hover': {
+                    color: colors.primary,
+                  },
+                }}
+              >
+                {languageDisplay}
+              </Typography>
+            </Tooltip>
           </>
         )}
 

--- a/app/src/components/ImageCard.tsx
+++ b/app/src/components/ImageCard.tsx
@@ -93,8 +93,10 @@ export const ImageCard = memo(function ImageCard({
 
     setCopyState('loading');
     try {
-      // Use cached code if available, otherwise fetch
-      const code = image.code ?? await fetchCode(image.spec_id, image.library);
+      // Use cached code if available, otherwise fetch. Pass `image.language`
+      // so R impls (ggplot2 today) hit the right DB row — the code endpoint
+      // defaults to Python and would 404 on an R artifact otherwise.
+      const code = image.code ?? await fetchCode(image.spec_id, image.library, image.language);
       if (code) {
         await navigator.clipboard.writeText(code);
         setCopyState('copied');
@@ -106,7 +108,7 @@ export const ImageCard = memo(function ImageCard({
     } catch {
       setCopyState('idle');
     }
-  }, [image.spec_id, image.library, image.code, copyState, fetchCode, onTrackEvent]);
+  }, [image.spec_id, image.library, image.language, image.code, copyState, fetchCode, onTrackEvent]);
 
   const cardId = `${image.spec_id}-${image.library}`;
   const specTooltipId = `spec-${cardId}`;

--- a/app/src/components/ImageCard.tsx
+++ b/app/src/components/ImageCard.tsx
@@ -12,7 +12,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import type { PlotImage } from '../types';
-import { BATCH_SIZE, type ImageSize } from '../constants';
+import { BATCH_SIZE, LANG_DISPLAY, LANG_EXT, type ImageSize } from '../constants';
 import { useCodeFetch } from '../hooks';
 import { buildSrcSet, getResponsiveSizes, getFallbackSrc } from '../utils/responsiveImage';
 import { useThemedPreviewUrl } from '../utils/themedPreview';
@@ -70,11 +70,17 @@ export const ImageCard = memo(function ImageCard({
   const [copyState, setCopyState] = useState<'idle' | 'loading' | 'copied'>('idle');
 
   // Library display: in compact mode - hidden on xs, abbreviated otherwise
-  // In normal mode - always show full name
+  // In normal mode - always show full name. Compact mode embeds the language
+  // as a file-extension suffix on the abbreviation (e.g. "mpl.py", "ggplot2.r")
+  // so the row stays as two tokens — normal mode shows language as a separate
+  // middot-token between spec-id and library.
   const showLibrary = imageSize === 'normal' || !isXs;
+  const langExt = LANG_EXT[image.language];
   const libraryDisplay = imageSize === 'compact'
-    ? (LIBRARY_ABBR[image.library] || image.library)
+    ? `${LIBRARY_ABBR[image.library] || image.library}${langExt ? '.' + langExt : ''}`
     : image.library;
+  const languageDisplay = LANG_DISPLAY[image.language] || image.language;
+  const showLanguageToken = imageSize === 'normal' && !!image.language && showLibrary;
 
   // Stable click handler - calls onClick with image
   const handleClick = useCallback(() => {
@@ -281,6 +287,24 @@ export const ImageCard = memo(function ImageCard({
             {image.spec_id}
           </Typography>
         </Tooltip>
+
+        {showLanguageToken && (
+          <>
+            <Typography sx={{ color: 'var(--ink-muted)', fontSize: labelFontSize }}>·</Typography>
+            <Typography
+              aria-label={`Language: ${languageDisplay}`}
+              sx={{
+                fontSize: labelFontSize,
+                letterSpacing: labelLetterSpacing,
+                fontWeight: 400,
+                fontFamily: typography.fontFamily,
+                color: 'var(--ink-muted)',
+              }}
+            >
+              {languageDisplay}
+            </Typography>
+          </>
+        )}
 
         {showLibrary && (
           <>

--- a/app/src/components/ImagesGrid.tsx
+++ b/app/src/components/ImagesGrid.tsx
@@ -4,7 +4,7 @@ import Grid from '@mui/material/Grid';
 import Alert from '@mui/material/Alert';
 import { ImageCard } from './ImageCard';
 import { LoaderSpinner } from './LoaderSpinner';
-import type { PlotImage, LibraryInfo, SpecInfo } from '../types';
+import type { PlotImage, LibraryInfo, LanguageInfo, SpecInfo } from '../types';
 import type { ImageSize } from '../constants';
 
 interface ImagesGridProps {
@@ -16,6 +16,7 @@ interface ImagesGridProps {
   isLoadingMore: boolean;
   isTransitioning: boolean;
   librariesData: LibraryInfo[];
+  languagesData?: LanguageInfo[];
   specsData: SpecInfo[];
   openTooltip: string | null;
   loadMoreRef: React.RefObject<HTMLDivElement | null>;
@@ -34,6 +35,7 @@ export function ImagesGrid({
   isLoadingMore,
   isTransitioning,
   librariesData,
+  languagesData,
   specsData,
   openTooltip,
   loadMoreRef,
@@ -56,6 +58,12 @@ export function ImagesGrid({
     librariesData.forEach(lib => map.set(lib.id, lib));
     return map;
   }, [librariesData]);
+
+  const languageMap = useMemo(() => {
+    const map = new Map<string, LanguageInfo>();
+    (languagesData || []).forEach(lang => map.set(lang.id, lang));
+    return map;
+  }, [languagesData]);
 
   const specMap = useMemo(() => {
     const map = new Map<string, SpecInfo>();
@@ -119,6 +127,7 @@ export function ImagesGrid({
             >
             {images.map((image, index) => {
               const lib = libraryMap.get(image.library);
+              const lang = languageMap.get(image.language);
               const spec = specMap.get(image.spec_id || '');
               return (
                 <Grid
@@ -132,6 +141,8 @@ export function ImagesGrid({
                     selectedSpec={selectedSpec}
                     libraryDescription={lib?.description}
                     libraryDocUrl={lib?.documentation_url}
+                    languageDescription={lang?.description}
+                    languageDocUrl={lang?.documentation_url}
                     specDescription={spec?.description}
                     openTooltip={openTooltip}
                     imageSize={imageSize}

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, type ReactNode } from 'react';
 
 import { API_URL } from '../constants';
-import type { LibraryInfo, SpecInfo } from '../types';
+import type { LanguageInfo, LibraryInfo, SpecInfo } from '../types';
 import {
   AppDataContext,
   HomeStateContext,
@@ -16,6 +16,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   const themeMode = useThemeMode();
   const [specsData, setSpecsData] = useState<SpecInfo[]>([]);
   const [librariesData, setLibrariesData] = useState<LibraryInfo[]>([]);
+  const [languagesData, setLanguagesData] = useState<LanguageInfo[]>([]);
   const [stats, setStats] = useState<{ specs: number; plots: number; libraries: number; lines_of_code?: number } | null>(null);
 
   // Persistent home state (both ref for sync access and state for reactivity)
@@ -39,9 +40,10 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const callback = async () => {
       try {
-        const [specsRes, libsRes, statsRes] = await Promise.all([
+        const [specsRes, libsRes, langsRes, statsRes] = await Promise.all([
           fetch(`${API_URL}/specs`),
           fetch(`${API_URL}/libraries`),
+          fetch(`${API_URL}/languages`),
           fetch(`${API_URL}/stats`),
         ]);
 
@@ -53,6 +55,11 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
         if (libsRes.ok) {
           const data = await libsRes.json();
           setLibrariesData(data.libraries || []);
+        }
+
+        if (langsRes.ok) {
+          const data = await langsRes.json();
+          setLanguagesData(data.languages || []);
         }
 
         if (statsRes.ok) {
@@ -77,7 +84,7 @@ export function AppDataProvider({ children }: { children: ReactNode }) {
 
   return (
     <ThemeContext.Provider value={themeMode}>
-      <AppDataContext.Provider value={{ specsData, librariesData, stats }}>
+      <AppDataContext.Provider value={{ specsData, librariesData, languagesData, stats }}>
         <HomeStateContext.Provider value={{ homeState, homeStateRef, setHomeState, saveScrollPosition }}>
           {children}
         </HomeStateContext.Provider>

--- a/app/src/components/LibrariesSection.tsx
+++ b/app/src/components/LibrariesSection.tsx
@@ -19,7 +19,7 @@ export function LibrariesSection({
   // Use known library order, with counts from stats if available
   const libList = LIBRARIES.map(name => {
     const info = libraries.find(l => l.id === name);
-    return { name, count: info ? undefined : undefined }; // counts come from API if available
+    return { name, language: info?.language, count: info ? undefined : undefined }; // counts come from API if available
   });
 
   const maxWidth = widthTier === 'catalog' ? 'var(--max-catalog)' : 'var(--max)';
@@ -42,6 +42,7 @@ export function LibrariesSection({
           <LibraryCard
             key={lib.name}
             name={lib.name}
+            language={lib.language}
             onClick={() => onLibraryClick(lib.name)}
           />
         ))}

--- a/app/src/components/LibraryCard.test.tsx
+++ b/app/src/components/LibraryCard.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, userEvent } from '../test-utils';
+import { LibraryCard } from './LibraryCard';
+
+describe('LibraryCard', () => {
+  it('renders the library name', () => {
+    render(<LibraryCard name="matplotlib" onClick={vi.fn()} />);
+    expect(screen.getByText('matplotlib')).toBeInTheDocument();
+  });
+
+  it('renders the language chip in the corner when language is provided', () => {
+    render(<LibraryCard name="ggplot2" language="r" onClick={vi.fn()} />);
+    expect(screen.getByLabelText('Language: R')).toHaveTextContent('R');
+  });
+
+  it('renders an uppercased Python chip for python libraries', () => {
+    render(<LibraryCard name="matplotlib" language="python" onClick={vi.fn()} />);
+    expect(screen.getByLabelText('Language: PYTHON')).toHaveTextContent('PYTHON');
+  });
+
+  it('does not render a chip when language is missing', () => {
+    render(<LibraryCard name="matplotlib" onClick={vi.fn()} />);
+    expect(screen.queryByLabelText(/Language:/)).not.toBeInTheDocument();
+  });
+
+  it('renders the example count when provided', () => {
+    render(<LibraryCard name="matplotlib" language="python" count={42} onClick={vi.fn()} />);
+    expect(screen.getByText('42 examples')).toBeInTheDocument();
+  });
+
+  it('fires onClick when the card is clicked', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryCard name="matplotlib" language="python" onClick={onClick} />);
+
+    await user.click(screen.getByRole('button', { name: /Browse matplotlib examples/i }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/LibraryCard.tsx
+++ b/app/src/components/LibraryCard.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import { colors, typography } from '../theme';
+import { LANG_DISPLAY } from '../constants';
 
 const DESCRIPTIONS: Record<string, string> = {
   matplotlib: 'The foundation. Publication-ready figures with total control.',
@@ -11,15 +12,18 @@ const DESCRIPTIONS: Record<string, string> = {
   pygal: 'Minimalistic SVG charts with a clean API.',
   highcharts: 'Interactive web charts, stock charts, and maps.',
   letsplot: 'Grammar of graphics by JetBrains. Interactive.',
+  ggplot2: 'The reference grammar of graphics. R’s expressive plotting standard.',
 };
 
 interface LibraryCardProps {
   name: string;
+  language?: string;
   count?: number;
   onClick: () => void;
 }
 
-export function LibraryCard({ name, count, onClick }: LibraryCardProps) {
+export function LibraryCard({ name, language, count, onClick }: LibraryCardProps) {
+  const langLabel = language ? (LANG_DISPLAY[language] || language).toUpperCase() : null;
   return (
     <Box
       component="button"
@@ -64,14 +68,40 @@ export function LibraryCard({ name, count, onClick }: LibraryCardProps) {
         },
       }}
     >
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-        <Box sx={{
-          fontFamily: typography.mono,
-          fontSize: '15px',
-          fontWeight: 700,
-          color: 'var(--ink)',
-        }}>
-          {name}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+          {langLabel && (
+            <Box
+              aria-label={`Language: ${langLabel}`}
+              sx={{
+                fontFamily: typography.mono,
+                fontSize: '9px',
+                fontWeight: 600,
+                color: 'var(--ink-muted)',
+                bgcolor: 'var(--bg-elevated)',
+                border: '1px solid var(--rule)',
+                borderRadius: '4px',
+                px: 0.75,
+                py: 0.25,
+                letterSpacing: '0.08em',
+                lineHeight: 1.4,
+                flexShrink: 0,
+              }}
+            >
+              {langLabel}
+            </Box>
+          )}
+          <Box sx={{
+            fontFamily: typography.mono,
+            fontSize: '15px',
+            fontWeight: 700,
+            color: 'var(--ink)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}>
+            {name}
+          </Box>
         </Box>
         {count != null && (
           <Box sx={{
@@ -79,6 +109,7 @@ export function LibraryCard({ name, count, onClick }: LibraryCardProps) {
             fontSize: '10px',
             color: 'var(--ink-muted)',
             letterSpacing: '0.08em',
+            flexShrink: 0,
           }}>
             {count} examples
           </Box>

--- a/app/src/components/LibraryCard.tsx
+++ b/app/src/components/LibraryCard.tsx
@@ -68,40 +68,49 @@ export function LibraryCard({ name, language, count, onClick }: LibraryCardProps
         },
       }}
     >
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
-          {langLabel && (
-            <Box
-              aria-label={`Language: ${langLabel}`}
-              sx={{
-                fontFamily: typography.mono,
-                fontSize: '9px',
-                fontWeight: 600,
-                color: 'var(--ink-muted)',
-                bgcolor: 'var(--bg-elevated)',
-                border: '1px solid var(--rule)',
-                borderRadius: '4px',
-                px: 0.75,
-                py: 0.25,
-                letterSpacing: '0.08em',
-                lineHeight: 1.4,
-                flexShrink: 0,
-              }}
-            >
-              {langLabel}
-            </Box>
-          )}
-          <Box sx={{
+      {/* Top-right corner chip — sits above the card's flow content so it
+          doesn't push the library name around. Top offset clears the 2px
+          hover-accent that animates in via ::before. */}
+      {langLabel && (
+        <Box
+          aria-label={`Language: ${langLabel}`}
+          sx={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
             fontFamily: typography.mono,
-            fontSize: '15px',
-            fontWeight: 700,
-            color: 'var(--ink)',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}>
-            {name}
-          </Box>
+            fontSize: '9px',
+            fontWeight: 600,
+            color: 'var(--ink-muted)',
+            bgcolor: 'var(--bg-elevated)',
+            border: '1px solid var(--rule)',
+            borderRadius: '4px',
+            px: 0.75,
+            py: 0.25,
+            letterSpacing: '0.08em',
+            lineHeight: 1.4,
+            pointerEvents: 'none',
+          }}
+        >
+          {langLabel}
+        </Box>
+      )}
+
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 1 }}>
+        <Box sx={{
+          fontFamily: typography.mono,
+          fontSize: '15px',
+          fontWeight: 700,
+          color: 'var(--ink)',
+          // Reserve space under the absolute-positioned chip so a long
+          // library name doesn't slide under it.
+          pr: langLabel ? 5 : 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}>
+          {name}
         </Box>
         {count != null && (
           <Box sx={{

--- a/app/src/components/LibraryPills.tsx
+++ b/app/src/components/LibraryPills.tsx
@@ -21,6 +21,7 @@ const LIBRARY_ABBREV: Record<string, string> = {
 interface Implementation {
   library_id: string;
   library_name: string;
+  language: string;
   quality_score: number | null;
 }
 

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -44,3 +44,18 @@ export const LIB_TO_LANG: Record<string, string> = {
   pygal: 'python',
   seaborn: 'python',
 };
+
+// Display label for a language id (e.g. used in titles, breadcrumbs, chips).
+export const LANG_DISPLAY: Record<string, string> = {
+  python: 'Python',
+  r: 'R',
+};
+
+// File-extension token for a language id (e.g. used as the suffix in compact
+// plot cards: "mpl.py", "ggplot2.r"). The .R extension is uppercase on disk
+// for R scripts, but the suffix here mirrors the language id for symmetry
+// with "py" — display only, not a filesystem reference.
+export const LANG_EXT: Record<string, string> = {
+  python: 'py',
+  r: 'r',
+};

--- a/app/src/hooks/useLayoutContext.ts
+++ b/app/src/hooks/useLayoutContext.ts
@@ -24,6 +24,7 @@ export interface HomeStateContextValue {
 export interface AppData {
   specsData: import('../types').SpecInfo[];
   librariesData: import('../types').LibraryInfo[];
+  languagesData: import('../types').LanguageInfo[];
   stats: { specs: number; plots: number; libraries: number; lines_of_code?: number } | null;
 }
 

--- a/app/src/pages/LibrariesPage.tsx
+++ b/app/src/pages/LibrariesPage.tsx
@@ -32,12 +32,12 @@ export function LibrariesPage() {
         <title>libraries | anyplot.ai</title>
         <meta
           name="description"
-          content="Nine Python plotting libraries — matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot. Same specs, every library."
+          content="Ten plotting libraries across Python and R — matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot, ggplot2. Same specs, every library."
         />
         <meta property="og:title" content="libraries | anyplot.ai" />
         <meta
           property="og:description"
-          content="Nine Python plotting libraries — same specs, every library."
+          content="Ten plotting libraries across Python and R — same specs, every library."
         />
         <link rel="canonical" href="https://anyplot.ai/libraries" />
       </Helmet>
@@ -59,7 +59,7 @@ export function LibrariesPage() {
             const meta = byId.get(name);
             return (
               <Box key={name} sx={{ position: 'relative' }}>
-                <LibraryCard name={name} onClick={() => handleLibraryClick(name)} />
+                <LibraryCard name={name} language={meta?.language} onClick={() => handleLibraryClick(name)} />
                 {meta?.documentation_url && (
                   <Box sx={{
                     display: 'flex',

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -125,9 +125,14 @@ export function PlotsPage() {
       }
       saveScrollPosition();
       const specId = img.spec_id || '';
-      navigate(specPath(specId, img.language, img.library));
+      // If the user is browsing under an active language filter, propagate it
+      // as `?language=…` so the destination impl-page carousel stays scoped to
+      // that language. Without the filter, the carousel walks all impls.
+      const langActive = activeFilters.some((f) => f.category === 'lang');
+      const qs = langActive && img.language ? `?language=${encodeURIComponent(img.language)}` : '';
+      navigate(`${specPath(specId, img.language, img.library)}${qs}`);
     },
-    [navigate, saveScrollPosition]
+    [navigate, saveScrollPosition, activeFilters]
   );
 
   const handleContainerClick = useCallback(

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -18,7 +18,7 @@ import { colors } from '../theme';
 export function PlotsPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { specsData, librariesData } = useAppData();
+  const { specsData, librariesData, languagesData } = useAppData();
   const { homeStateRef, saveScrollPosition } = useHomeState();
 
   // Disable browser's automatic scroll restoration so we can restore from
@@ -210,6 +210,7 @@ export function PlotsPage() {
         isLoadingMore={false}
         isTransitioning={false}
         librariesData={librariesData}
+        languagesData={languagesData}
         specsData={specsData}
         openTooltip={openImageTooltip}
         loadMoreRef={loadMoreRef}

--- a/app/src/pages/SpecPage.test.tsx
+++ b/app/src/pages/SpecPage.test.tsx
@@ -182,4 +182,66 @@ describe('SpecPage', () => {
     const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(fetchUrl).toContain('/specs/scatter-basic');
   });
+
+  describe('language in title + breadcrumb', () => {
+    it('includes ` · Python · matplotlib` in the document title in detail mode', async () => {
+      mockParams = { specId: 'scatter-basic', language: 'python', library: 'matplotlib' };
+      mockSearchParams.delete('language');
+      mockFetchSuccess();
+      render(<SpecPage />);
+
+      await waitFor(() => {
+        expect(document.title).toContain('Basic Scatter Plot · Python · matplotlib');
+      });
+    });
+
+    it('includes ` · Python` in the document title when ?language= is set in hub mode', async () => {
+      mockParams = { specId: 'scatter-basic' };
+      mockSearchParams.set('language', 'python');
+      mockFetchSuccess();
+      render(<SpecPage />);
+
+      await waitFor(() => {
+        expect(document.title).toContain('Basic Scatter Plot · Python');
+      });
+      mockSearchParams.delete('language');
+    });
+  });
+
+  describe('carousel-scope conflict drop', () => {
+    it('drops ?language= when it conflicts with the URL path language in detail mode', async () => {
+      // Spec has both a python/matplotlib and a python/seaborn impl. We put
+      // ?language=r on the URL so the carousel scope (r) conflicts with the
+      // path language (python) — the effect should call setSearchParams to
+      // strip the query.
+      mockParams = { specId: 'scatter-basic', language: 'python', library: 'matplotlib' };
+      mockSearchParams.set('language', 'r');
+      mockFetchSuccess();
+      render(<SpecPage />);
+
+      await waitFor(() => {
+        expect(mockSetSearchParams).toHaveBeenCalled();
+      });
+      // The drop call passes a URLSearchParams with no `language` key.
+      const lastCall = mockSetSearchParams.mock.calls.at(-1);
+      const params = lastCall?.[0] as URLSearchParams;
+      expect(params.get('language')).toBeNull();
+      mockSearchParams.delete('language');
+    });
+
+    it('does not drop ?language= when it matches the URL path language', async () => {
+      mockParams = { specId: 'scatter-basic', language: 'python', library: 'matplotlib' };
+      mockSearchParams.set('language', 'python');
+      mockSetSearchParams.mockClear();
+      mockFetchSuccess();
+      render(<SpecPage />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('spec-detail-view')).toBeInTheDocument();
+      });
+      // No drop call — the languages agree.
+      expect(mockSetSearchParams).not.toHaveBeenCalled();
+      mockSearchParams.delete('language');
+    });
+  });
 });

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -137,6 +137,19 @@ export function SpecPage() {
     setSearchParams(params, { replace: true });
   }, [mode, specData, languageFilter, availableLanguages, searchParams, setSearchParams]);
 
+  // Detail mode: if `?language=…` conflicts with the URL path's language
+  // (e.g. `/biplot-pca/r/ggplot2?language=python` from a stale deep link),
+  // drop the query. The URL path is the source of truth for "what's being
+  // viewed"; the carousel filter would otherwise exclude the currently
+  // selected impl and centre the pills on the wrong library.
+  useEffect(() => {
+    if (mode !== 'detail' || !carouselLanguage || !urlLanguage) return;
+    if (carouselLanguage === urlLanguage) return;
+    const params = new URLSearchParams(searchParams);
+    params.delete('language');
+    setSearchParams(params, { replace: true });
+  }, [mode, carouselLanguage, urlLanguage, searchParams, setSearchParams]);
+
   // Get current implementation (only in detail mode)
   const currentImpl = useMemo(() => {
     if (!specData || !selectedLibrary) return null;

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -456,24 +456,6 @@ export function SpecPage() {
             </Box>
           </Box>
         )}
-        {mode === 'detail' && detailLanguage && selectedLibrary && (
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'flex-start',
-              alignItems: 'center',
-              gap: 0.75,
-              mb: 0.5,
-              fontFamily: typography.mono,
-              fontSize: fontSize.sm,
-              color: semanticColors.mutedText,
-            }}
-          >
-            <Box component="span">{detailLanguage}</Box>
-            <Box component="span" sx={{ color: 'var(--ink-muted)' }}>·</Box>
-            <Box component="span">{selectedLibrary}</Box>
-          </Box>
-        )}
 
         <Typography
           variant="h4"

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -8,7 +8,7 @@ import Skeleton from '@mui/material/Skeleton';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { NotFoundPage } from './NotFoundPage';
 
-import { API_URL, GITHUB_URL } from '../constants';
+import { API_URL, GITHUB_URL, LANG_DISPLAY } from '../constants';
 import { typography, colors, fontSize, semanticColors } from '../theme';
 import { useAnalytics, useCodeFetch } from '../hooks';
 import { useAppData } from '../hooks';
@@ -55,7 +55,14 @@ export function SpecPage() {
 
   const mode: Mode = urlLibrary ? 'detail' : 'hub';
   const selectedLibrary = urlLibrary || null;
-  const languageFilter = mode === 'hub' ? searchParams.get('language') : null;
+  // Carousel scope. The `?language=` query param expresses user intent —
+  // "I'm browsing R impls" — independent of which impl is currently rendered.
+  // It's set in both hub and detail mode. Without it, the carousel walks
+  // through ALL impls (cross-language). With it, the carousel stays scoped to
+  // that language. This is also what lets a future python.anyplot.ai-style
+  // subdomain pin the scope without users having to manually re-filter.
+  const carouselLanguage = searchParams.get('language');
+  const languageFilter = mode === 'hub' ? carouselLanguage : null;
 
   const getLibraryMeta = useCallback(
     (libraryId: string) => librariesData.find((lib) => lib.id === libraryId),
@@ -104,11 +111,16 @@ export function SpecPage() {
     fetchSpec();
   }, [specId, urlLanguage, urlLibrary, navigate]);
 
-  // Implementations for the selected language (used in detail mode for library pills)
-  const langImpls = useMemo(() => {
-    if (!specData || !urlLanguage) return specData?.implementations || [];
-    return specData.implementations.filter((i) => i.language === urlLanguage);
-  }, [specData, urlLanguage]);
+  // Implementations the carousel cycles through. In detail mode, this is what
+  // `<LibraryPills>` walks via prev/next. ALL impls of the spec by default; if
+  // the user arrived via `?language=…` it stays scoped to that language. We
+  // deliberately do NOT filter by `urlLanguage` (the path segment) — that
+  // segment identifies the impl being viewed, not the user's chosen scope.
+  const carouselImpls = useMemo(() => {
+    if (!specData) return [];
+    if (!carouselLanguage) return specData.implementations;
+    return specData.implementations.filter((i) => i.language === carouselLanguage);
+  }, [specData, carouselLanguage]);
 
   // Languages present in this spec (for hub mode)
   const availableLanguages = useMemo(() => {
@@ -142,26 +154,36 @@ export function SpecPage() {
 
   const currentCode = specId && selectedLibrary ? getCode(specId, selectedLibrary, urlLanguage) : null;
 
-  // Handle library switch (in detail mode)
+  // Build a `?language=…` query string when the carousel scope is pinned.
+  // Empty otherwise — kept stable to avoid clutter in shareable URLs.
+  const carouselQuery = carouselLanguage ? `?language=${encodeURIComponent(carouselLanguage)}` : '';
+
+  // Handle library switch (in detail mode). Cross-language nav: the URL path's
+  // language segment follows the picked impl's *own* language, not whatever
+  // the current path says. The `?language=…` scope is preserved when set.
   const handleLibrarySelect = useCallback(
     (libraryId: string) => {
-      if (!specId || !urlLanguage) return;
+      if (!specId || !specData) return;
+      const impl = specData.implementations.find((i) => i.library_id === libraryId);
+      if (!impl) return;
       setImageLoaded(false);
-      navigate(specPath(specId, urlLanguage, libraryId), { replace: true });
+      navigate(`${specPath(specId, impl.language, libraryId)}${carouselQuery}`, { replace: true });
     },
-    [specId, urlLanguage, navigate]
+    [specId, specData, carouselQuery, navigate]
   );
 
-  // Handle implementation click (in language overview)
+  // Handle implementation click (in language overview). Preserves any active
+  // `?language=…` so the carousel on the detail page stays scoped to what the
+  // user was browsing.
   const handleImplClick = useCallback(
     (libraryId: string) => {
       if (!specId) return;
       const impl = specData?.implementations.find((i) => i.library_id === libraryId);
       const lang = impl?.language || urlLanguage;
       if (!lang) return;
-      navigate(specPath(specId, lang, libraryId));
+      navigate(`${specPath(specId, lang, libraryId)}${carouselQuery}`);
     },
-    [specId, urlLanguage, specData, navigate]
+    [specId, urlLanguage, specData, carouselQuery, navigate]
   );
 
   // Interactive view mode (driven by ?view=interactive)
@@ -262,7 +284,7 @@ export function SpecPage() {
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return;
-      const sorted = [...langImpls].sort((a, b) => a.library_id.localeCompare(b.library_id));
+      const sorted = [...carouselImpls].sort((a, b) => a.library_id.localeCompare(b.library_id));
       const idx = sorted.findIndex((impl) => impl.library_id === selectedLibrary);
       if (idx < 0) return;
 
@@ -279,7 +301,7 @@ export function SpecPage() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [mode, specData, langImpls, selectedLibrary, handleLibrarySelect]);
+  }, [mode, specData, carouselImpls, selectedLibrary, handleLibrarySelect]);
 
   // Loading state
   if (loading) {
@@ -318,7 +340,18 @@ export function SpecPage() {
       ? `https://anyplot.ai/${specId}/${urlLanguage}/${selectedLibrary}`
       : `https://anyplot.ai/${specId}`;
 
-  const titleSuffix = mode === 'detail' ? ` - ${selectedLibrary}` : '';
+  // Page title surfaces language alongside library so the browser tab matches
+  // the rendered image-title format `{spec-id} · {Language} · {library}`. Hub
+  // mode under a `?language=` filter also surfaces the language so users see
+  // what's been narrowed down.
+  const detailLanguage = mode === 'detail' && urlLanguage ? (LANG_DISPLAY[urlLanguage] || urlLanguage) : null;
+  const hubFilterLanguage = languageFilter ? (LANG_DISPLAY[languageFilter] || languageFilter) : null;
+  const titleSuffix =
+    mode === 'detail' && detailLanguage && selectedLibrary
+      ? ` · ${detailLanguage} · ${selectedLibrary}`
+      : hubFilterLanguage
+        ? ` · ${hubFilterLanguage}`
+        : '';
 
   // Implementations to render in the grid: hub mode optionally filtered by ?language=
   const gridImpls =
@@ -332,7 +365,10 @@ export function SpecPage() {
     { name: specData.title, item: `https://anyplot.ai/${specId}` },
   ];
   if (mode === 'detail' && urlLanguage && selectedLibrary) {
-    breadcrumbItems.push({ name: urlLanguage, item: `https://anyplot.ai/${specId}/${urlLanguage}` });
+    breadcrumbItems.push({
+      name: LANG_DISPLAY[urlLanguage] || urlLanguage,
+      item: `https://anyplot.ai/${specId}/${urlLanguage}`,
+    });
     breadcrumbItems.push({ name: selectedLibrary, item: canonical });
   }
   const breadcrumbJsonLd = {
@@ -405,6 +441,24 @@ export function SpecPage() {
             >
               report issue ↗
             </Box>
+          </Box>
+        )}
+        {mode === 'detail' && detailLanguage && selectedLibrary && (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'flex-start',
+              alignItems: 'center',
+              gap: 0.75,
+              mb: 0.5,
+              fontFamily: typography.mono,
+              fontSize: fontSize.sm,
+              color: semanticColors.mutedText,
+            }}
+          >
+            <Box component="span">{detailLanguage}</Box>
+            <Box component="span" sx={{ color: 'var(--ink-muted)' }}>·</Box>
+            <Box component="span">{selectedLibrary}</Box>
           </Box>
         )}
 
@@ -490,7 +544,7 @@ export function SpecPage() {
         ) : (
           <>
             <LibraryPills
-              implementations={langImpls}
+              implementations={carouselImpls}
               selectedLibrary={selectedLibrary || ''}
               onSelect={handleLibrarySelect}
               onAll={() => navigate(specPath(specId!))}
@@ -500,7 +554,7 @@ export function SpecPage() {
               specTitle={specData.title}
               selectedLibrary={selectedLibrary || ''}
               currentImpl={currentImpl}
-              implementations={langImpls}
+              implementations={carouselImpls}
               imageLoaded={imageLoaded}
               codeCopied={codeCopied}
               downloadDone={downloadDone}

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -20,6 +20,7 @@ export interface PlotImage {
 // Spec-level categories describe WHAT is visualized
 // Impl-level categories describe HOW the code implements it (issue #2434)
 export type FilterCategory =
+  | 'lang'
   | 'lib'
   | 'spec'
   | 'plot'
@@ -35,6 +36,7 @@ export type FilterCategory =
 // Display labels for filter categories
 export const FILTER_LABELS: Record<FilterCategory, string> = {
   // Spec-level
+  lang: 'language',
   lib: 'library',
   spec: 'spec',
   plot: 'type',
@@ -52,7 +54,8 @@ export const FILTER_LABELS: Record<FilterCategory, string> = {
 // Tooltip descriptions for filter categories
 export const FILTER_TOOLTIPS: Record<FilterCategory, string> = {
   // Spec-level: WHAT is visualized
-  lib: 'python plotting library',
+  lang: 'programming language of the implementation (Python or R)',
+  lib: 'plotting library',
   spec: 'plot specification by identifier',
   plot: 'type of visualization or chart',
   data: 'structure of the input data',
@@ -69,6 +72,7 @@ export const FILTER_TOOLTIPS: Record<FilterCategory, string> = {
 // All filter categories in display order
 export const FILTER_CATEGORIES: FilterCategory[] = [
   // Spec-level
+  'lang',
   'lib',
   'spec',
   'plot',

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -118,6 +118,15 @@ export interface LibraryInfo {
   description?: string;
 }
 
+export interface LanguageInfo {
+  id: string;
+  name: string;
+  file_extension?: string;
+  runtime_version?: string;
+  documentation_url?: string;
+  description?: string;
+}
+
 export interface SpecInfo {
   id: string;
   title: string;

--- a/core/constants.py
+++ b/core/constants.py
@@ -28,7 +28,7 @@ LANGUAGES_METADATA = [
         "file_extension": ".py",
         "runtime_version": "3.13",
         "documentation_url": "https://www.python.org",
-        "description": "The default language for anyplot plot implementations.",
+        "description": "General-purpose, high-level programming language with a clean, readable syntax. The lingua franca of data science, scientific computing, and the SciPy / PyData ecosystem.",
     },
     {
         "id": "r",
@@ -36,7 +36,7 @@ LANGUAGES_METADATA = [
         "file_extension": ".R",
         "runtime_version": "4.4",
         "documentation_url": "https://www.r-project.org",
-        "description": "R is a statistical computing environment widely used in academia, biotech, and finance research.",
+        "description": "Language and environment for statistical computing and graphics. Widely used in academia, biotech, and finance research, with a rich package ecosystem on CRAN.",
     },
 ]
 

--- a/core/database/__init__.py
+++ b/core/database/__init__.py
@@ -15,7 +15,13 @@ from core.database.connection import (
     is_db_configured,
 )
 from core.database.models import LANGUAGES_SEED, LIBRARIES_SEED, Impl, Language, Library, Spec
-from core.database.repositories import BaseRepository, ImplRepository, LibraryRepository, SpecRepository
+from core.database.repositories import (
+    BaseRepository,
+    ImplRepository,
+    LanguageRepository,
+    LibraryRepository,
+    SpecRepository,
+)
 
 
 __all__ = [
@@ -39,5 +45,6 @@ __all__ = [
     "BaseRepository",
     "SpecRepository",
     "LibraryRepository",
+    "LanguageRepository",
     "ImplRepository",
 ]

--- a/core/database/repositories.py
+++ b/core/database/repositories.py
@@ -10,7 +10,7 @@ from sqlalchemy import String, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, undefer
 
-from core.database.models import Impl, Library, Spec
+from core.database.models import Impl, Language, Library, Spec
 
 
 T = TypeVar("T")
@@ -27,6 +27,7 @@ SPEC_UPDATABLE_FIELDS = frozenset(
 )
 
 LIBRARY_UPDATABLE_FIELDS = frozenset({"name", "version", "documentation_url", "description"})
+LANGUAGE_UPDATABLE_FIELDS = frozenset({"name", "file_extension", "runtime_version", "documentation_url", "description"})
 
 IMPL_UPDATABLE_FIELDS = frozenset(
     {
@@ -243,6 +244,33 @@ class LibraryRepository(BaseRepository[Library]):
             await self.session.refresh(existing)
             return existing
         return await self.create(library_data)
+
+
+class LanguageRepository(BaseRepository[Language]):
+    """Repository for Language operations."""
+
+    model = Language
+    updatable_fields = LANGUAGE_UPDATABLE_FIELDS
+
+    async def get_all(self) -> list[Language]:
+        """Get all languages ordered by name."""
+        query = select(Language).order_by(Language.name)
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def upsert(self, language_data: dict) -> Language:
+        """Create or update a language by ID."""
+        language_id = language_data.get("id")
+        if not language_id:
+            raise ValueError("language_data must include 'id' field")
+
+        existing = await self.get_by_id(language_id)
+        if existing:
+            self._apply_updates(existing, language_data)
+            await self.session.commit()
+            await self.session.refresh(existing)
+            return existing
+        return await self.create(language_data)
 
 
 class ImplRepository(BaseRepository[Impl]):

--- a/tests/unit/api/test_plots_helpers.py
+++ b/tests/unit/api/test_plots_helpers.py
@@ -27,66 +27,78 @@ from api.routers.plots import (
 class TestGetCategoryValues:
     """Tests for _get_category_values."""
 
+    def test_lang_category(self) -> None:
+        result = _get_category_values("lang", "scatter-basic", "matplotlib", "python", {}, {})
+        assert result == ["python"]
+
+    def test_lang_category_r(self) -> None:
+        result = _get_category_values("lang", "biplot-pca", "ggplot2", "r", {}, {})
+        assert result == ["r"]
+
+    def test_lang_category_empty(self) -> None:
+        result = _get_category_values("lang", "s", "m", "", {}, {})
+        assert result == []
+
     def test_lib_category(self) -> None:
-        result = _get_category_values("lib", "scatter-basic", "matplotlib", {}, {})
+        result = _get_category_values("lib", "scatter-basic", "matplotlib", "python", {}, {})
         assert result == ["matplotlib"]
 
     def test_spec_category(self) -> None:
-        result = _get_category_values("spec", "scatter-basic", "matplotlib", {}, {})
+        result = _get_category_values("spec", "scatter-basic", "matplotlib", "python", {}, {})
         assert result == ["scatter-basic"]
 
     def test_spec_level_category(self) -> None:
         spec_tags = {"plot_type": ["scatter", "line"]}
-        result = _get_category_values("plot", "s", "m", spec_tags, {})
+        result = _get_category_values("plot", "s", "m", "python", spec_tags, {})
         assert result == ["scatter", "line"]
 
     def test_impl_level_category(self) -> None:
         impl_tags = {"techniques": ["annotations", "colorbar"]}
-        result = _get_category_values("tech", "s", "m", {}, impl_tags)
+        result = _get_category_values("tech", "s", "m", "python", {}, impl_tags)
         assert result == ["annotations", "colorbar"]
 
     def test_unknown_category(self) -> None:
-        result = _get_category_values("unknown", "s", "m", {}, {})
+        result = _get_category_values("unknown", "s", "m", "python", {}, {})
         assert result == []
 
     def test_data_category(self) -> None:
         spec_tags = {"data_type": ["numeric"]}
-        result = _get_category_values("data", "s", "m", spec_tags, {})
+        result = _get_category_values("data", "s", "m", "python", spec_tags, {})
         assert result == ["numeric"]
 
     def test_dom_category(self) -> None:
         spec_tags = {"domain": ["statistics", "finance"]}
-        result = _get_category_values("dom", "s", "m", spec_tags, {})
+        result = _get_category_values("dom", "s", "m", "python", spec_tags, {})
         assert result == ["statistics", "finance"]
 
     def test_feat_category(self) -> None:
         spec_tags = {"features": ["basic", "3d"]}
-        result = _get_category_values("feat", "s", "m", spec_tags, {})
+        result = _get_category_values("feat", "s", "m", "python", spec_tags, {})
         assert result == ["basic", "3d"]
 
     def test_dep_category(self) -> None:
         impl_tags = {"dependencies": ["scipy"]}
-        result = _get_category_values("dep", "s", "m", {}, impl_tags)
+        result = _get_category_values("dep", "s", "m", "python", {}, impl_tags)
         assert result == ["scipy"]
 
     def test_pat_category(self) -> None:
         impl_tags = {"patterns": ["data-generation"]}
-        result = _get_category_values("pat", "s", "m", {}, impl_tags)
+        result = _get_category_values("pat", "s", "m", "python", {}, impl_tags)
         assert result == ["data-generation"]
 
     def test_prep_category(self) -> None:
         impl_tags = {"dataprep": ["binning"]}
-        result = _get_category_values("prep", "s", "m", {}, impl_tags)
+        result = _get_category_values("prep", "s", "m", "python", {}, impl_tags)
         assert result == ["binning"]
 
     def test_style_category(self) -> None:
         impl_tags = {"styling": ["minimal-chrome"]}
-        result = _get_category_values("style", "s", "m", {}, impl_tags)
+        result = _get_category_values("style", "s", "m", "python", {}, impl_tags)
         assert result == ["minimal-chrome"]
 
     def test_missing_key_in_tags(self) -> None:
         spec_tags = {"other_key": ["value"]}
-        result = _get_category_values("plot", "s", "m", spec_tags, {})
+        result = _get_category_values("plot", "s", "m", "python", spec_tags, {})
         assert result == []
 
 
@@ -94,21 +106,27 @@ class TestCategoryMatchesFilter:
     """Tests for _category_matches_filter."""
 
     def test_matching_lib(self) -> None:
-        assert _category_matches_filter("lib", ["matplotlib"], "s", "matplotlib", {}, {}) is True
+        assert _category_matches_filter("lib", ["matplotlib"], "s", "matplotlib", "python", {}, {}) is True
 
     def test_non_matching_lib(self) -> None:
-        assert _category_matches_filter("lib", ["seaborn"], "s", "matplotlib", {}, {}) is False
+        assert _category_matches_filter("lib", ["seaborn"], "s", "matplotlib", "python", {}, {}) is False
 
     def test_one_of_multiple_values_matches(self) -> None:
-        assert _category_matches_filter("lib", ["seaborn", "matplotlib"], "s", "matplotlib", {}, {}) is True
+        assert _category_matches_filter("lib", ["seaborn", "matplotlib"], "s", "matplotlib", "python", {}, {}) is True
 
     def test_matching_spec_tag(self) -> None:
         spec_tags = {"plot_type": ["scatter"]}
-        assert _category_matches_filter("plot", ["scatter"], "s", "m", spec_tags, {}) is True
+        assert _category_matches_filter("plot", ["scatter"], "s", "m", "python", spec_tags, {}) is True
 
     def test_matching_impl_tag(self) -> None:
         impl_tags = {"techniques": ["annotations"]}
-        assert _category_matches_filter("tech", ["annotations"], "s", "m", {}, impl_tags) is True
+        assert _category_matches_filter("tech", ["annotations"], "s", "m", "python", {}, impl_tags) is True
+
+    def test_matching_lang(self) -> None:
+        assert _category_matches_filter("lang", ["r"], "s", "ggplot2", "r", {}, {}) is True
+
+    def test_non_matching_lang(self) -> None:
+        assert _category_matches_filter("lang", ["r"], "s", "matplotlib", "python", {}, {}) is False
 
 
 class TestImageMatchesGroups:
@@ -117,40 +135,47 @@ class TestImageMatchesGroups:
     def test_empty_groups_matches_all(self) -> None:
         spec_lookup = {"s1": {"tags": {}}}
         impl_lookup = {}
-        assert _image_matches_groups("s1", "matplotlib", [], spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("s1", "matplotlib", "python", [], spec_lookup, impl_lookup) is True
 
     def test_single_group_match(self) -> None:
         spec_lookup = {"s1": {"tags": {"plot_type": ["scatter"]}}}
         impl_lookup = {}
         groups = [{"category": "plot", "values": ["scatter"]}]
-        assert _image_matches_groups("s1", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("s1", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_single_group_no_match(self) -> None:
         spec_lookup = {"s1": {"tags": {"plot_type": ["bar"]}}}
         impl_lookup = {}
         groups = [{"category": "plot", "values": ["scatter"]}]
-        assert _image_matches_groups("s1", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("s1", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_multiple_groups_and_logic(self) -> None:
         spec_lookup = {"s1": {"tags": {"plot_type": ["scatter"], "domain": ["statistics"]}}}
         impl_lookup = {}
         groups = [{"category": "plot", "values": ["scatter"]}, {"category": "dom", "values": ["statistics"]}]
-        assert _image_matches_groups("s1", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("s1", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_multiple_groups_one_fails(self) -> None:
         spec_lookup = {"s1": {"tags": {"plot_type": ["scatter"], "domain": ["finance"]}}}
         impl_lookup = {}
         groups = [{"category": "plot", "values": ["scatter"]}, {"category": "dom", "values": ["statistics"]}]
-        assert _image_matches_groups("s1", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("s1", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_spec_not_in_lookup(self) -> None:
-        assert _image_matches_groups("unknown", "matplotlib", [], {}, {}) is False
+        assert _image_matches_groups("unknown", "matplotlib", "python", [], {}, {}) is False
 
     def test_impl_tags_matching(self) -> None:
         spec_lookup = {"s1": {"tags": {}}}
         impl_lookup = {("s1", "matplotlib"): {"techniques": ["annotations"]}}
         groups = [{"category": "tech", "values": ["annotations"]}]
-        assert _image_matches_groups("s1", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("s1", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
+
+    def test_lang_group_matching(self) -> None:
+        spec_lookup = {"s1": {"tags": {}}}
+        impl_lookup = {}
+        groups = [{"category": "lang", "values": ["r"]}]
+        assert _image_matches_groups("s1", "ggplot2", "r", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("s1", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
 
 class TestCreateEmptyCounts:
@@ -158,7 +183,7 @@ class TestCreateEmptyCounts:
 
     def test_has_all_categories(self) -> None:
         counts = _create_empty_counts()
-        expected = {"lib", "spec", "plot", "data", "dom", "feat", "dep", "tech", "pat", "prep", "style"}
+        expected = {"lang", "lib", "spec", "plot", "data", "dom", "feat", "dep", "tech", "pat", "prep", "style"}
         assert set(counts.keys()) == expected
 
     def test_all_categories_empty(self) -> None:
@@ -174,8 +199,9 @@ class TestIncrementCategoryCounts:
         counts = _create_empty_counts()
         spec_tags = {"plot_type": ["scatter"], "domain": ["statistics"]}
         impl_tags = {"techniques": ["annotations"]}
-        _increment_category_counts(counts, "scatter-basic", "matplotlib", spec_tags, impl_tags)
+        _increment_category_counts(counts, "scatter-basic", "matplotlib", "python", spec_tags, impl_tags)
 
+        assert counts["lang"]["python"] == 1
         assert counts["lib"]["matplotlib"] == 1
         assert counts["spec"]["scatter-basic"] == 1
         assert counts["plot"]["scatter"] == 1
@@ -185,7 +211,7 @@ class TestIncrementCategoryCounts:
     def test_increments_existing_counts(self) -> None:
         counts = _create_empty_counts()
         counts["lib"]["matplotlib"] = 5
-        _increment_category_counts(counts, "s", "matplotlib", {}, {})
+        _increment_category_counts(counts, "s", "matplotlib", "python", {}, {})
         assert counts["lib"]["matplotlib"] == 6
 
 
@@ -382,11 +408,13 @@ class TestCalculateGlobalCounts:
         impl1.library_id = "matplotlib"
         impl1.preview_url = "https://example.com/img.png"
         impl1.impl_tags = {}
+        impl1.library.language = "python"
 
         impl2 = MagicMock()
         impl2.library_id = "seaborn"
         impl2.preview_url = "https://example.com/img2.png"
         impl2.impl_tags = {}
+        impl2.library.language = "python"
 
         spec = MagicMock()
         spec.id = "scatter-basic"
@@ -394,9 +422,32 @@ class TestCalculateGlobalCounts:
         spec.impls = [impl1, impl2]
 
         result = _calculate_global_counts([spec])
+        assert result["lang"]["python"] == 2
         assert result["lib"]["matplotlib"] == 1
         assert result["lib"]["seaborn"] == 1
         assert result["plot"]["scatter"] == 2
+
+    def test_counts_mixed_languages(self) -> None:
+        impl_py = MagicMock()
+        impl_py.library_id = "matplotlib"
+        impl_py.preview_url = "https://example.com/a.png"
+        impl_py.impl_tags = {}
+        impl_py.library.language = "python"
+
+        impl_r = MagicMock()
+        impl_r.library_id = "ggplot2"
+        impl_r.preview_url = "https://example.com/b.png"
+        impl_r.impl_tags = {}
+        impl_r.library.language = "r"
+
+        spec = MagicMock()
+        spec.id = "biplot-pca"
+        spec.tags = {"plot_type": ["biplot"]}
+        spec.impls = [impl_py, impl_r]
+
+        result = _calculate_global_counts([spec])
+        assert result["lang"]["python"] == 1
+        assert result["lang"]["r"] == 1
 
     def test_empty_specs(self) -> None:
         result = _calculate_global_counts([])

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -1042,6 +1042,7 @@ class TestPlotsRouter:
         # Add a second impl to have 2 images
         mock_impl2 = MagicMock()
         mock_impl2.library_id = "seaborn"
+        mock_impl2.library.language = "python"
         mock_impl2.preview_url = TEST_IMAGE_URL
         mock_impl2.preview_html = None
         mock_impl2.quality_score = 85.0
@@ -1068,6 +1069,7 @@ class TestPlotsRouter:
         """Filter with offset should skip images."""
         mock_impl2 = MagicMock()
         mock_impl2.library_id = "seaborn"
+        mock_impl2.library.language = "python"
         mock_impl2.preview_url = TEST_IMAGE_URL
         mock_impl2.preview_html = None
         mock_impl2.quality_score = 85.0
@@ -1093,12 +1095,14 @@ class TestPlotsRouter:
         """Filter with limit and offset combined."""
         mock_impl2 = MagicMock()
         mock_impl2.library_id = "seaborn"
+        mock_impl2.library.language = "python"
         mock_impl2.preview_url = TEST_IMAGE_URL
         mock_impl2.preview_html = None
         mock_impl2.quality_score = 85.0
         mock_impl2.impl_tags = {}
         mock_impl3 = MagicMock()
         mock_impl3.library_id = "plotly"
+        mock_impl3.library.language = "python"
         mock_impl3.preview_url = TEST_IMAGE_URL
         mock_impl3.preview_html = None
         mock_impl3.quality_score = 80.0
@@ -1145,103 +1149,103 @@ class TestPlotsHelperFunctions:
     def test_image_matches_groups_empty(self) -> None:
         """Empty groups should match any image."""
         spec_lookup = {"scatter-basic": {"tags": {"plot_type": ["scatter"]}}}
-        assert _image_matches_groups("scatter-basic", "matplotlib", [], spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", [], spec_lookup, {}) is True
 
     def test_image_matches_groups_lib_match(self) -> None:
         """Library filter should match correct library."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         groups = [{"category": "lib", "values": ["matplotlib"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is True
 
     def test_image_matches_groups_lib_no_match(self) -> None:
         """Library filter should not match wrong library."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         groups = [{"category": "lib", "values": ["seaborn"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is False
 
     def test_image_matches_groups_spec_match(self) -> None:
         """Spec filter should match correct spec."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         groups = [{"category": "spec", "values": ["scatter-basic"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is True
 
     def test_image_matches_groups_plot_type_match(self) -> None:
         """Plot type filter should match correct tag."""
         spec_lookup = {"scatter-basic": {"tags": {"plot_type": ["scatter"]}}}
         groups = [{"category": "plot", "values": ["scatter"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is True
 
     def test_image_matches_groups_data_type_match(self) -> None:
         """Data type filter should match correct tag."""
         spec_lookup = {"scatter-basic": {"tags": {"data_type": ["numeric"]}}}
         groups = [{"category": "data", "values": ["numeric"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is True
 
     def test_image_matches_groups_domain_match(self) -> None:
         """Domain filter should match correct tag."""
         spec_lookup = {"scatter-basic": {"tags": {"domain": ["statistics"]}}}
         groups = [{"category": "dom", "values": ["statistics"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is True
 
     def test_image_matches_groups_features_match(self) -> None:
         """Features filter should match correct tag."""
         spec_lookup = {"scatter-basic": {"tags": {"features": ["basic"]}}}
         groups = [{"category": "feat", "values": ["basic"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is True
 
     def test_image_matches_groups_spec_not_in_lookup(self) -> None:
         """Spec not in lookup should not match."""
         spec_lookup = {}
-        assert _image_matches_groups("unknown", "matplotlib", [], spec_lookup, {}) is False
+        assert _image_matches_groups("unknown", "matplotlib", "python", [], spec_lookup, {}) is False
 
     def test_image_matches_groups_dep_match(self) -> None:
         """Dependencies filter should match impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"dependencies": ["scipy", "sklearn"]}}
         groups = [{"category": "dep", "values": ["scipy"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_image_matches_groups_dep_no_match(self) -> None:
         """Dependencies filter should not match if not in impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"dependencies": ["scipy"]}}
         groups = [{"category": "dep", "values": ["networkx"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_image_matches_groups_tech_match(self) -> None:
         """Techniques filter should match impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"techniques": ["annotations", "colorbar"]}}
         groups = [{"category": "tech", "values": ["annotations"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_image_matches_groups_pat_match(self) -> None:
         """Patterns filter should match impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"patterns": ["data-generation", "iteration-over-groups"]}}
         groups = [{"category": "pat", "values": ["data-generation"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_image_matches_groups_prep_match(self) -> None:
         """Dataprep filter should match impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"dataprep": ["kde", "binning"]}}
         groups = [{"category": "prep", "values": ["kde"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_image_matches_groups_style_match(self) -> None:
         """Styling filter should match impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"styling": ["alpha-blending", "minimal-chrome"]}}
         groups = [{"category": "style", "values": ["alpha-blending"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is True
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is True
 
     def test_image_matches_groups_impl_not_in_lookup(self) -> None:
         """Impl not in lookup should not match impl-level filters."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {}  # Empty - no impl data
         groups = [{"category": "dep", "values": ["scipy"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_calculate_global_counts(self) -> None:
         """Global counts should tally all implementations."""
@@ -1493,59 +1497,59 @@ class TestPlotsHelperFunctions:
         """Spec filter should not match wrong spec_id."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         groups = [{"category": "spec", "values": ["bar-basic"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is False
 
     def test_image_matches_groups_plot_no_match(self) -> None:
         """Plot type filter should not match wrong type."""
         spec_lookup = {"scatter-basic": {"tags": {"plot_type": ["scatter"]}}}
         groups = [{"category": "plot", "values": ["bar"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is False
 
     def test_image_matches_groups_data_no_match(self) -> None:
         """Data type filter should not match wrong type."""
         spec_lookup = {"scatter-basic": {"tags": {"data_type": ["numeric"]}}}
         groups = [{"category": "data", "values": ["categorical"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is False
 
     def test_image_matches_groups_dom_no_match(self) -> None:
         """Domain filter should not match wrong domain."""
         spec_lookup = {"scatter-basic": {"tags": {"domain": ["statistics"]}}}
         groups = [{"category": "dom", "values": ["finance"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is False
 
     def test_image_matches_groups_feat_no_match(self) -> None:
         """Features filter should not match wrong feature."""
         spec_lookup = {"scatter-basic": {"tags": {"features": ["basic"]}}}
         groups = [{"category": "feat", "values": ["advanced"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, {}) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, {}) is False
 
     def test_image_matches_groups_tech_no_match(self) -> None:
         """Techniques filter should not match if not in impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"techniques": ["annotations"]}}
         groups = [{"category": "tech", "values": ["colorbar"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_image_matches_groups_pat_no_match(self) -> None:
         """Patterns filter should not match if not in impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"patterns": ["data-generation"]}}
         groups = [{"category": "pat", "values": ["iteration-over-groups"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_image_matches_groups_prep_no_match(self) -> None:
         """Dataprep filter should not match if not in impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"dataprep": ["kde"]}}
         groups = [{"category": "prep", "values": ["binning"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
     def test_image_matches_groups_style_no_match(self) -> None:
         """Styling filter should not match if not in impl_tags."""
         spec_lookup = {"scatter-basic": {"tags": {}}}
         impl_lookup = {("scatter-basic", "matplotlib"): {"styling": ["alpha-blending"]}}
         groups = [{"category": "style", "values": ["minimal-chrome"]}]
-        assert _image_matches_groups("scatter-basic", "matplotlib", groups, spec_lookup, impl_lookup) is False
+        assert _image_matches_groups("scatter-basic", "matplotlib", "python", groups, spec_lookup, impl_lookup) is False
 
 
 class TestInsightsRouter:


### PR DESCRIPTION
## Summary

Makes language (Python / R) a first-class concept across the site, now that R/ggplot2 implementations sit next to the Python libraries. The data layer already supports it; the UI didn't. Companion to #7141 (image-title change for issue #6958).

- **Plot cards** — normal mode shows `spec-id · {Language} · {library}`; compact mode encodes language as a file-extension suffix on the abbreviation (`mpl.py`, `ggplot2.r`) to stay two tokens wide.
- **Library cards** — small uppercase chip (`[PYTHON]` / `[R]`) next to the library name. Stale "nine Python plotting libraries" meta-copy also fixed.
- **SpecPage** — `<title>` + og:title + breadcrumb JSON-LD surface language. Detail mode also gets a small muted `Python · matplotlib` row near the report-issue link.
- **`lang` filter** — new spec-level FilterCategory; FilterBar picks it up via the existing data-driven dispatch. Backend `/plots/filter` accepts `?lang=python` (or `r`) and returns `lang` in counts/globalCounts.
- **Carousel scope** — the impl-detail carousel now walks **all** impls of the spec by default, flipping the URL's language path segment as it cycles. The user can pin a scope via `?language=python`, in which case the carousel stays language-locked **and** the query param is preserved across prev/next. PlotsPage card-click propagates `?language=…` when an active `lang` filter is in effect, so clicking through from filtered plots preserves the scope. This is also what makes a future `python.anyplot.ai`-style subdomain expressible as URL state.

## Files touched

- `app/src/constants/index.ts` — new `LANG_DISPLAY`, `LANG_EXT` helpers (mirror the existing `LIB_TO_LANG` pattern).
- `app/src/types/index.ts` — `lang` added to `FilterCategory`, `FILTER_LABELS`, `FILTER_TOOLTIPS`, `FILTER_CATEGORIES`.
- `app/src/components/ImageCard.tsx`, `LibraryCard.tsx`, `LibraryPills.tsx` — display + props.
- `app/src/pages/LibrariesPage.tsx`, `PlotsPage.tsx`, `SpecPage.tsx` — title, breadcrumb, carousel scope, filter-preserving navigation.
- `api/routers/plots.py` — `_get_category_values` + friends grow a `language` parameter; threaded through every call site.
- `tests/unit/api/test_plots_helpers.py`, `test_routers.py` — signature updates + new `lang` cases.

## Test plan

- [x] `cd app && yarn type-check` clean
- [x] `cd app && yarn build` succeeds
- [x] `cd app && yarn test --run` — 459 / 459 pass
- [x] `uv run pytest tests/unit/api/` — 511 / 511 pass (including new `lang` filter cases)
- [ ] **Visual walkthrough deferred** — no local DB to bring up the full stack. Please eyeball on the deploy preview:
  - `/plots` cards (normal + compact)
  - `/libraries` chips
  - `/biplot-pca` title (unfiltered)
  - `/biplot-pca?language=python` title + grid + carousel
  - `/biplot-pca/r/ggplot2` — carousel cycles cross-language; pressing → flips both URL path segments
  - `/biplot-pca/python/altair?language=python` — carousel locked to Python; `?language=` preserved across prev/next
  - Click a card on `/plots?lang=python` — lands on `/{spec}/python/{lib}?language=python`
  - Click a card on `/plots` (unfiltered) — lands on `/{spec}/{lang}/{lib}` (no query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)