### PR TITLE
feat(feedback): in-app quick feedback widget (#5662)

### DIFF
--- a/alembic/versions/c5d7e9f1a3b2_add_feedback_table.py
+++ b/alembic/versions/c5d7e9f1a3b2_add_feedback_table.py
@@ -1,0 +1,55 @@
+"""add_feedback_table
+
+Add `feedback` table for the in-app quick feedback widget (issue #5662).
+Stores lightweight user remarks submitted via the floating widget on
+anyplot.ai. Entries are immutable once written; triage is manual.
+
+Revision ID: c5d7e9f1a3b2
+Revises: 3a7e1b5c0c4f
+Create Date: 2026-05-17
+
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c5d7e9f1a3b2"
+down_revision: str | None = "3a7e1b5c0c4f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the feedback table plus indexes for recent-first browsing and rate-limit lookups."""
+    op.create_table(
+        "feedback",
+        sa.Column("id", sa.String(36), primary_key=True, nullable=False),
+        sa.Column("message", sa.String(500), nullable=False),
+        sa.Column("reaction", sa.String(20), nullable=True),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column("path", sa.String(500), nullable=True),
+        sa.Column("spec_id", sa.String(100), nullable=True),
+        sa.Column("user_agent", sa.String(500), nullable=True),
+        sa.Column("viewport", sa.String(20), nullable=True),
+        sa.Column("session_id", sa.String(64), nullable=True),
+        sa.Column("ip_hash", sa.String(64), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint(
+            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea','heart')",
+            name="ck_feedback_reaction_valid",
+        ),
+    )
+    op.create_index("ix_feedback_created_at", "feedback", [sa.text("created_at DESC")])
+    op.create_index("ix_feedback_ip_hash_created_at", "feedback", ["ip_hash", sa.text("created_at DESC")])
+
+
+def downgrade() -> None:
+    """Drop the feedback table and its indexes."""
+    op.drop_index("ix_feedback_ip_hash_created_at", table_name="feedback")
+    op.drop_index("ix_feedback_created_at", table_name="feedback")
+    op.drop_table("feedback")

--- a/alembic/versions/d4e8a1f2c937_feedback_rename_email_to_contact.py
+++ b/alembic/versions/d4e8a1f2c937_feedback_rename_email_to_contact.py
@@ -1,0 +1,46 @@
+"""feedback_rename_email_to_contact
+
+Rename `feedback.email` to `feedback.contact`, drop the `heart` reaction from
+the CHECK constraint, and make `message` nullable so a reaction-only entry is
+accepted. The contact column is now free-form (name, email, handle, …)
+instead of strictly an email address.
+
+Revision ID: d4e8a1f2c937
+Revises: c5d7e9f1a3b2
+Create Date: 2026-05-18
+
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision: str = "d4e8a1f2c937"
+down_revision: str | None = "c5d7e9f1a3b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("feedback") as batch_op:
+        batch_op.alter_column("email", new_column_name="contact", existing_type=sa.String(255))
+        batch_op.alter_column("message", existing_type=sa.String(500), nullable=True)
+        batch_op.drop_constraint("ck_feedback_reaction_valid", type_="check")
+        batch_op.create_check_constraint(
+            "ck_feedback_reaction_valid",
+            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea')",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("feedback") as batch_op:
+        batch_op.drop_constraint("ck_feedback_reaction_valid", type_="check")
+        batch_op.create_check_constraint(
+            "ck_feedback_reaction_valid",
+            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea','heart')",
+        )
+        batch_op.alter_column("message", existing_type=sa.String(500), nullable=False)
+        batch_op.alter_column("contact", new_column_name="email", existing_type=sa.String(255))

--- a/alembic/versions/d4e8a1f2c937_feedback_rename_email_to_contact.py
+++ b/alembic/versions/d4e8a1f2c937_feedback_rename_email_to_contact.py
@@ -30,8 +30,7 @@ def upgrade() -> None:
         batch_op.alter_column("message", existing_type=sa.String(500), nullable=True)
         batch_op.drop_constraint("ck_feedback_reaction_valid", type_="check")
         batch_op.create_check_constraint(
-            "ck_feedback_reaction_valid",
-            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea')",
+            "ck_feedback_reaction_valid", "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea')"
         )
 
 

--- a/alembic/versions/e5b1c9d4a7f2_feedback_uuid_and_status.py
+++ b/alembic/versions/e5b1c9d4a7f2_feedback_uuid_and_status.py
@@ -39,12 +39,9 @@ def upgrade() -> None:
         op.execute("ALTER TABLE feedback ALTER COLUMN id TYPE uuid USING id::uuid")
 
     with op.batch_alter_table("feedback") as batch_op:
-        batch_op.add_column(
-            sa.Column("status", sa.String(20), nullable=False, server_default="new")
-        )
+        batch_op.add_column(sa.Column("status", sa.String(20), nullable=False, server_default="new"))
         batch_op.create_check_constraint(
-            "ck_feedback_status_valid",
-            "status IN ('new','in_progress','done','wont_solve')",
+            "ck_feedback_status_valid", "status IN ('new','in_progress','done','wont_solve')"
         )
 
     # Drop the server default after the existing rows are backfilled — new

--- a/alembic/versions/e5b1c9d4a7f2_feedback_uuid_and_status.py
+++ b/alembic/versions/e5b1c9d4a7f2_feedback_uuid_and_status.py
@@ -1,0 +1,63 @@
+"""feedback_uuid_and_status
+
+Two cleanups on the feedback table:
+
+1. Fix `feedback.id` column type. PR #5662 created it as varchar(36), but the
+   model declares `UniversalUUID` which binds parameters as native UUID on
+   Postgres. Result: every read of a freshly-inserted row failed with
+   `operator does not exist: character varying = uuid`. We ALTER the column
+   to UUID on Postgres (SQLite is unaffected — its UniversalUUID impl maps
+   back to String, and these migrations don't run there).
+
+2. Add a `status` column for admin triage from the debug page:
+   `new` (default) → `in_progress` → `done` or `wont_solve`. Constrained to
+   the allow-list via a CHECK constraint.
+
+Revision ID: e5b1c9d4a7f2
+Revises: d4e8a1f2c937
+Create Date: 2026-05-18
+
+"""
+
+from typing import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision: str = "e5b1c9d4a7f2"
+down_revision: str | None = "d4e8a1f2c937"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        # USING-cast is required because PG can't implicitly coerce varchar -> uuid.
+        op.execute("ALTER TABLE feedback ALTER COLUMN id TYPE uuid USING id::uuid")
+
+    with op.batch_alter_table("feedback") as batch_op:
+        batch_op.add_column(
+            sa.Column("status", sa.String(20), nullable=False, server_default="new")
+        )
+        batch_op.create_check_constraint(
+            "ck_feedback_status_valid",
+            "status IN ('new','in_progress','done','wont_solve')",
+        )
+
+    # Drop the server default after the existing rows are backfilled — new
+    # writes will set status explicitly through the model default.
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE feedback ALTER COLUMN status DROP DEFAULT")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("feedback") as batch_op:
+        batch_op.drop_constraint("ck_feedback_status_valid", type_="check")
+        batch_op.drop_column("status")
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TABLE feedback ALTER COLUMN id TYPE varchar(36) USING id::varchar")

--- a/api/main.py
+++ b/api/main.py
@@ -26,6 +26,7 @@ from api.mcp.server import mcp_server  # noqa: E402
 from api.routers import (  # noqa: E402
     debug_router,
     download_router,
+    feedback_router,
     health_router,
     insights_router,
     libraries_router,
@@ -151,6 +152,7 @@ app.include_router(seo_router)
 app.include_router(og_images_router)
 app.include_router(proxy_router)
 app.include_router(debug_router)
+app.include_router(feedback_router)
 
 
 # ASGI middleware to handle /mcp without trailing slash

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from api.routers.debug import router as debug_router
 from api.routers.download import router as download_router
+from api.routers.feedback import router as feedback_router
 from api.routers.health import router as health_router
 from api.routers.insights import router as insights_router
 from api.routers.libraries import router as libraries_router
@@ -16,6 +17,7 @@ from api.routers.stats import router as stats_router
 __all__ = [
     "debug_router",
     "download_router",
+    "feedback_router",
     "health_router",
     "insights_router",
     "libraries_router",

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -541,15 +541,9 @@ class FeedbackStatusUpdate(BaseModel):
     status: str
 
 
-@router.get(
-    "/feedback/top",
-    response_model=list[FeedbackTopPage],
-    dependencies=[Depends(require_admin)],
-)
+@router.get("/feedback/top", response_model=list[FeedbackTopPage], dependencies=[Depends(require_admin)])
 async def feedback_top_pages(
-    reaction: str,
-    limit: int = 20,
-    db: AsyncSession = Depends(require_db),
+    reaction: str, limit: int = 20, db: AsyncSession = Depends(require_db)
 ) -> list[FeedbackTopPage]:
     """Top pages by reaction count (thumbs_up / thumbs_down / idea / bug)."""
     if reaction not in FEEDBACK_REACTIONS:
@@ -560,15 +554,9 @@ async def feedback_top_pages(
     return [FeedbackTopPage(**row) for row in rows]
 
 
-@router.get(
-    "/feedback/messages",
-    response_model=list[FeedbackMessageItem],
-    dependencies=[Depends(require_admin)],
-)
+@router.get("/feedback/messages", response_model=list[FeedbackMessageItem], dependencies=[Depends(require_admin)])
 async def feedback_messages(
-    status: str | None = None,
-    limit: int = 50,
-    db: AsyncSession = Depends(require_db),
+    status: str | None = None, limit: int = 50, db: AsyncSession = Depends(require_db)
 ) -> list[FeedbackMessageItem]:
     """List feedback entries that carry a free-text message, newest first.
 
@@ -605,15 +593,9 @@ async def feedback_messages(
     ]
 
 
-@router.patch(
-    "/feedback/{entry_id}",
-    response_model=FeedbackMessageItem,
-    dependencies=[Depends(require_admin)],
-)
+@router.patch("/feedback/{entry_id}", response_model=FeedbackMessageItem, dependencies=[Depends(require_admin)])
 async def update_feedback_status(
-    entry_id: str,
-    payload: FeedbackStatusUpdate,
-    db: AsyncSession = Depends(require_db),
+    entry_id: str, payload: FeedbackStatusUpdate, db: AsyncSession = Depends(require_db)
 ) -> FeedbackMessageItem:
     """Set the triage status on one feedback entry."""
     if payload.status not in FEEDBACK_STATUSES:

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -16,9 +16,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.cache import clear_cache, get_cache_stats
 from api.dependencies import require_db
+from api.exceptions import raise_validation_error
 from core.config import settings
 from core.constants import SUPPORTED_LIBRARIES
-from core.database import SpecRepository
+from core.database import FEEDBACK_REACTIONS, FEEDBACK_STATUSES, FeedbackRepository, SpecRepository
 
 
 router = APIRouter(prefix="/debug", tags=["debug"])
@@ -504,4 +505,130 @@ async def invalidate_cache(x_cache_token: str | None = Header(default=None)) -> 
     clear_cache()
     return CacheInvalidateResponse(
         cleared=stats_before["size"], maxsize=stats_before["maxsize"], ttl=stats_before["ttl"]
+    )
+
+
+# ============================================================================
+# Feedback analytics + triage (issue #5662 follow-up)
+# ============================================================================
+
+
+class FeedbackTopPage(BaseModel):
+    """Aggregated count of one reaction per page path."""
+
+    path: str
+    count: int
+    last_seen: str | None  # ISO timestamp of the most recent entry on this path
+
+
+class FeedbackMessageItem(BaseModel):
+    """A feedback entry with free-text message — surfaced to admins for triage."""
+
+    id: str
+    message: str
+    reaction: str | None
+    contact: str | None
+    path: str | None
+    spec_id: str | None
+    viewport: str | None
+    status: str
+    created_at: str  # ISO timestamp
+
+
+class FeedbackStatusUpdate(BaseModel):
+    """Body of the PATCH endpoint."""
+
+    status: str
+
+
+@router.get(
+    "/feedback/top",
+    response_model=list[FeedbackTopPage],
+    dependencies=[Depends(require_admin)],
+)
+async def feedback_top_pages(
+    reaction: str,
+    limit: int = 20,
+    db: AsyncSession = Depends(require_db),
+) -> list[FeedbackTopPage]:
+    """Top pages by reaction count (thumbs_up / thumbs_down / idea / bug)."""
+    if reaction not in FEEDBACK_REACTIONS:
+        raise_validation_error(f"reaction must be one of {FEEDBACK_REACTIONS}")
+    if not 1 <= limit <= 100:
+        raise_validation_error("limit must be between 1 and 100")
+    rows = await FeedbackRepository(db).top_paths_by_reaction(reaction, limit)
+    return [FeedbackTopPage(**row) for row in rows]
+
+
+@router.get(
+    "/feedback/messages",
+    response_model=list[FeedbackMessageItem],
+    dependencies=[Depends(require_admin)],
+)
+async def feedback_messages(
+    status: str | None = None,
+    limit: int = 50,
+    db: AsyncSession = Depends(require_db),
+) -> list[FeedbackMessageItem]:
+    """List feedback entries that carry a free-text message, newest first.
+
+    `status="open"` is a pseudo-value mapping to `('new', 'in_progress')` — the
+    default view on /debug only shows the unresolved triage states.
+    """
+    if not 1 <= limit <= 200:
+        raise_validation_error("limit must be between 1 and 200")
+    if status == "open":
+        repo_status: str | tuple[str, ...] | None = ("new", "in_progress")
+    elif status is None:
+        repo_status = None
+    elif status in FEEDBACK_STATUSES:
+        repo_status = status
+    else:
+        raise_validation_error(f"status must be one of {FEEDBACK_STATUSES} or 'open'")
+    entries = await FeedbackRepository(db).list_with_message(repo_status, limit)
+    return [
+        FeedbackMessageItem(
+            id=str(e.id),
+            message=e.message or "",
+            reaction=e.reaction,
+            contact=e.contact,
+            path=e.path,
+            spec_id=e.spec_id,
+            viewport=e.viewport,
+            status=e.status,
+            # feedback.created_at is TIMESTAMP WITHOUT TIME ZONE in UTC — tag with Z
+            # so the browser parses it as UTC, not local time (otherwise "just now"
+            # entries render as "Nh ago" depending on the user's offset).
+            created_at=e.created_at.replace(tzinfo=timezone.utc).isoformat(),
+        )
+        for e in entries
+    ]
+
+
+@router.patch(
+    "/feedback/{entry_id}",
+    response_model=FeedbackMessageItem,
+    dependencies=[Depends(require_admin)],
+)
+async def update_feedback_status(
+    entry_id: str,
+    payload: FeedbackStatusUpdate,
+    db: AsyncSession = Depends(require_db),
+) -> FeedbackMessageItem:
+    """Set the triage status on one feedback entry."""
+    if payload.status not in FEEDBACK_STATUSES:
+        raise_validation_error(f"status must be one of {FEEDBACK_STATUSES}")
+    updated = await FeedbackRepository(db).update_status(entry_id, payload.status)
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="feedback entry not found")
+    return FeedbackMessageItem(
+        id=str(updated.id),
+        message=updated.message or "",
+        reaction=updated.reaction,
+        contact=updated.contact,
+        path=updated.path,
+        spec_id=updated.spec_id,
+        viewport=updated.viewport,
+        status=updated.status,
+        created_at=updated.created_at.replace(tzinfo=timezone.utc).isoformat(),
     )

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -1,12 +1,14 @@
 """Feedback endpoint — in-app quick feedback widget (issue #5662).
 
-Accepts a single POST with a short free-text message plus optional reaction,
-email, and page context. Guards against spam with a honeypot field, hard
-length cap, reaction allow-list, and per-IP rate limit.
+Accepts a single POST with an optional short free-text message and/or
+reaction, free-form contact handle, and page context. At least one of
+message or reaction must be present. Guards against spam with a honeypot
+field, hard length caps, reaction allow-list, and per-IP rate limit.
 """
 
 import hashlib
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -23,9 +25,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["feedback"])
 
 MAX_MESSAGE_LENGTH = 500
-MAX_EMAIL_LENGTH = 255
+MAX_CONTACT_LENGTH = 255
 RATE_LIMIT_WINDOW = timedelta(minutes=1)
 RATE_LIMIT_MAX = 5
+
+# Anti-spam heuristics — see _is_link_stuffed and the duplicate check below.
+# Both branches return 200 silently (mirroring the honeypot) so bots can't
+# distinguish accepted from suppressed submissions and adapt their payloads.
+_URL_RE = re.compile(r"https?://", re.IGNORECASE)
+MAX_URLS_IN_MESSAGE = 1  # 2+ links treated as link-stuffing SEO spam
+DUPLICATE_LOOKBACK = timedelta(minutes=10)
 
 
 def _client_ip(request: Request) -> str:
@@ -42,6 +51,13 @@ def _hash_ip(ip: str) -> str:
     return hashlib.sha256(ip.encode("utf-8")).hexdigest() if ip else ""
 
 
+def _is_link_stuffed(message: str | None) -> bool:
+    """True if the message reads as link-bait spam (≥2 http(s) URLs)."""
+    if not message:
+        return False
+    return len(_URL_RE.findall(message)) > MAX_URLS_IN_MESSAGE
+
+
 @router.post("/feedback", response_model=FeedbackResponse)
 async def submit_feedback(
     payload: FeedbackRequest, request: Request, db: AsyncSession = Depends(require_db)
@@ -52,29 +68,49 @@ async def submit_feedback(
     if payload.website:
         return FeedbackResponse(status="ok")
 
-    message = (payload.message or "").strip()
-    if not message:
-        raise_validation_error("message must not be empty")
-    if len(message) > MAX_MESSAGE_LENGTH:
+    message = (payload.message or "").strip() or None
+    if message is not None and len(message) > MAX_MESSAGE_LENGTH:
         raise_validation_error(f"message must be {MAX_MESSAGE_LENGTH} characters or fewer")
 
     reaction = payload.reaction
     if reaction is not None and reaction not in FEEDBACK_REACTIONS:
         raise_validation_error(f"reaction must be one of {FEEDBACK_REACTIONS}")
 
-    email = (payload.email or "").strip() or None
-    if email is not None:
-        if "@" not in email or len(email) > MAX_EMAIL_LENGTH:
-            raise_validation_error("email is not valid")
+    if message is None and reaction is None:
+        raise_validation_error("message or reaction must be provided")
+
+    contact = (payload.contact or "").strip() or None
+    if contact is not None and len(contact) > MAX_CONTACT_LENGTH:
+        raise_validation_error(f"contact must be {MAX_CONTACT_LENGTH} characters or fewer")
+
+    # Link-stuffing spam: drop silently with 200 so the bot can't tell its
+    # payload was rejected (same idea as the honeypot above).
+    if _is_link_stuffed(message):
+        return FeedbackResponse(status="ok")
 
     ip_hash = _hash_ip(_client_ip(request))
     repo = FeedbackRepository(db)
 
+    # `feedback.created_at` is TIMESTAMP WITHOUT TIME ZONE (UTC) in Postgres,
+    # so any cutoff used in WHERE clauses must be tz-naive UTC too.
+    now_utc_naive = datetime.now(timezone.utc).replace(tzinfo=None)
+
     if ip_hash:
-        since = datetime.now(timezone.utc) - RATE_LIMIT_WINDOW
+        since = now_utc_naive - RATE_LIMIT_WINDOW
         recent = await repo.count_recent_by_ip(ip_hash, since)
         if recent >= RATE_LIMIT_MAX:
             raise HTTPException(status_code=429, detail="Too many feedback submissions, please slow down")
+
+    # Silent duplicate suppression: same message text from the same IP or
+    # session id within DUPLICATE_LOOKBACK is dropped without an error — keeps
+    # repeated bot copy-paste out of the DB without revealing the filter.
+    if message and await repo.has_recent_duplicate(
+        message,
+        ip_hash or None,
+        (payload.session_id or None) and payload.session_id[:64],
+        now_utc_naive - DUPLICATE_LOOKBACK,
+    ):
+        return FeedbackResponse(status="ok")
 
     user_agent = request.headers.get("user-agent", "")[:500] or None
 
@@ -82,7 +118,7 @@ async def submit_feedback(
         {
             "message": message,
             "reaction": reaction,
-            "email": email,
+            "contact": contact,
             "path": (payload.path or None) and payload.path[:500],
             "spec_id": (payload.spec_id or None) and payload.spec_id[:100],
             "viewport": (payload.viewport or None) and payload.viewport[:20],

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -1,0 +1,95 @@
+"""Feedback endpoint — in-app quick feedback widget (issue #5662).
+
+Accepts a single POST with a short free-text message plus optional reaction,
+email, and page context. Guards against spam with a honeypot field, hard
+length cap, reaction allow-list, and per-IP rate limit.
+"""
+
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.dependencies import require_db
+from api.exceptions import raise_validation_error
+from api.schemas import FeedbackRequest, FeedbackResponse
+from core.database import FEEDBACK_REACTIONS, FeedbackRepository
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["feedback"])
+
+MAX_MESSAGE_LENGTH = 500
+MAX_EMAIL_LENGTH = 255
+RATE_LIMIT_WINDOW = timedelta(minutes=1)
+RATE_LIMIT_MAX = 5
+
+
+def _client_ip(request: Request) -> str:
+    """Resolve the client IP, preferring x-forwarded-for (Cloud Run + CF)."""
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        # x-forwarded-for can be a comma-separated chain; the first entry is the original client.
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else ""
+
+
+def _hash_ip(ip: str) -> str:
+    """SHA-256 of the IP, hex. Used for rate-limit lookups only — never reversed."""
+    return hashlib.sha256(ip.encode("utf-8")).hexdigest() if ip else ""
+
+
+@router.post("/feedback", response_model=FeedbackResponse)
+async def submit_feedback(
+    payload: FeedbackRequest, request: Request, db: AsyncSession = Depends(require_db)
+) -> FeedbackResponse:
+    """Accept a feedback entry from the in-app widget."""
+    # Honeypot: bots auto-fill every input. Real users never see this field.
+    # Return 200 silently so bots can't probe for the guard.
+    if payload.website:
+        return FeedbackResponse(status="ok")
+
+    message = (payload.message or "").strip()
+    if not message:
+        raise_validation_error("message must not be empty")
+    if len(message) > MAX_MESSAGE_LENGTH:
+        raise_validation_error(f"message must be {MAX_MESSAGE_LENGTH} characters or fewer")
+
+    reaction = payload.reaction
+    if reaction is not None and reaction not in FEEDBACK_REACTIONS:
+        raise_validation_error(f"reaction must be one of {FEEDBACK_REACTIONS}")
+
+    email = (payload.email or "").strip() or None
+    if email is not None:
+        if "@" not in email or len(email) > MAX_EMAIL_LENGTH:
+            raise_validation_error("email is not valid")
+
+    ip_hash = _hash_ip(_client_ip(request))
+    repo = FeedbackRepository(db)
+
+    if ip_hash:
+        since = datetime.now(timezone.utc) - RATE_LIMIT_WINDOW
+        recent = await repo.count_recent_by_ip(ip_hash, since)
+        if recent >= RATE_LIMIT_MAX:
+            raise HTTPException(status_code=429, detail="Too many feedback submissions, please slow down")
+
+    user_agent = request.headers.get("user-agent", "")[:500] or None
+
+    await repo.create(
+        {
+            "message": message,
+            "reaction": reaction,
+            "email": email,
+            "path": (payload.path or None) and payload.path[:500],
+            "spec_id": (payload.spec_id or None) and payload.spec_id[:100],
+            "viewport": (payload.viewport or None) and payload.viewport[:20],
+            "session_id": (payload.session_id or None) and payload.session_id[:64],
+            "user_agent": user_agent,
+            "ip_hash": ip_hash or None,
+        }
+    )
+
+    return FeedbackResponse(status="ok")

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -157,9 +157,9 @@ class StatsResponse(BaseModel):
 class FeedbackRequest(BaseModel):
     """In-app quick feedback submission (issue #5662)."""
 
-    message: str
+    message: str | None = None
     reaction: str | None = None
-    email: str | None = None
+    contact: str | None = None
     path: str | None = None
     spec_id: str | None = None
     viewport: str | None = None

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -152,3 +152,24 @@ class StatsResponse(BaseModel):
     libraries: int
     languages: int = 0
     lines_of_code: int = 0
+
+
+class FeedbackRequest(BaseModel):
+    """In-app quick feedback submission (issue #5662)."""
+
+    message: str
+    reaction: str | None = None
+    email: str | None = None
+    path: str | None = None
+    spec_id: str | None = None
+    viewport: str | None = None
+    session_id: str | None = None
+    # Honeypot field — real users never fill this in. Bots auto-fill all
+    # text inputs and trip the guard server-side.
+    website: str | None = None
+
+
+class FeedbackResponse(BaseModel):
+    """Response confirming feedback was accepted (no entry id is returned)."""
+
+    status: str

--- a/app/src/components/FeedbackWidget.test.tsx
+++ b/app/src/components/FeedbackWidget.test.tsx
@@ -113,6 +113,66 @@ describe('FeedbackWidget', () => {
     expect(textarea).toHaveValue('try me');
   });
 
+  it('a second FAB click closes the mini-stack', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(<FeedbackWidget />);
+
+    const fab = screen.getByRole('button', { name: /open feedback/i });
+    await user.click(fab);
+    expect(await screen.findByRole('button', { name: /quick thumbs up/i })).toBeInTheDocument();
+
+    await user.click(fab);
+    expect(screen.queryByRole('button', { name: /quick thumbs up/i })).toBeNull();
+  });
+
+  it('clicking outside the mini-stack closes it via ClickAwayListener', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(
+      <div>
+        <button type="button">outside</button>
+        <FeedbackWidget />
+      </div>
+    );
+
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    expect(await screen.findByRole('button', { name: /quick thumbs up/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /outside/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /quick thumbs up/i })).toBeNull()
+    );
+  });
+
+  it('quick-submit does not show Thanks when the server returns 500', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    render(<FeedbackWidget />);
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /quick thumbs up/i }));
+
+    // Wait for the fetch to resolve, then assert no Thanks toast appeared.
+    await waitFor(() => expect(screen.queryByText(/^Thanks!/)).toBeNull());
+  });
+
+  it('full-dialog submit sends the chosen reaction in the payload', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    render(<FeedbackWidget />);
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /open detailed feedback/i }));
+    await user.click(screen.getByRole('button', { name: /^bug$/i }));
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.reaction).toBe('bug');
+    expect(body.message).toBeNull();
+  });
+
   it('honeypot input is hidden from assistive tech', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
     render(<FeedbackWidget />);

--- a/app/src/components/FeedbackWidget.test.tsx
+++ b/app/src/components/FeedbackWidget.test.tsx
@@ -18,27 +18,19 @@ describe('FeedbackWidget', () => {
     expect(screen.getByRole('button', { name: /open feedback/i })).toBeInTheDocument();
   });
 
-  it('opens the popover when the FAB is clicked', async () => {
+  it('opens the mini-stack of quick actions when the FAB is clicked', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
     render(<FeedbackWidget />);
 
     await user.click(screen.getByRole('button', { name: /open feedback/i }));
-    expect(await screen.findByRole('textbox', { name: /feedback message/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /quick thumbs up/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /quick thumbs down/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open detailed feedback/i })).toBeInTheDocument();
+    // The full dialog should NOT be open yet.
+    expect(screen.queryByRole('textbox', { name: /feedback message/i })).toBeNull();
   });
 
-  it('disables the send button until a message is typed', async () => {
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
-    render(<FeedbackWidget />);
-
-    await user.click(screen.getByRole('button', { name: /open feedback/i }));
-    const send = await screen.findByRole('button', { name: /^send$/i });
-    expect(send).toBeDisabled();
-
-    await user.type(screen.getByRole('textbox', { name: /feedback message/i }), 'Hi');
-    expect(send).toBeEnabled();
-  });
-
-  it('POSTs to /feedback and shows a thank-you on success', async () => {
+  it('submits a reaction-only entry when 👍 is clicked in the mini-stack', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ status: 'ok' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
     );
@@ -46,6 +38,53 @@ describe('FeedbackWidget', () => {
 
     render(<FeedbackWidget />);
     await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /quick thumbs up/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.message).toBeNull();
+    expect(body.reaction).toBe('thumbs_up');
+    expect(typeof body.path).toBe('string'); // current URL is sent along
+
+    // Thanks toast appears, mini-stack collapses.
+    expect(await screen.findByText(/^Thanks!/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /quick thumbs up/i })).toBeNull();
+  });
+
+  it('expands the full dialog when 💬 is clicked', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(<FeedbackWidget />);
+
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /open detailed feedback/i }));
+
+    expect(await screen.findByRole('textbox', { name: /feedback message/i })).toBeInTheDocument();
+    expect(screen.getByText(/^Page:/)).toBeInTheDocument();
+  });
+
+  it('disables Send in the full dialog until message or reaction is provided', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(<FeedbackWidget />);
+
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /open detailed feedback/i }));
+
+    const send = await screen.findByRole('button', { name: /^send$/i });
+    expect(send).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /^idea$/i }));
+    expect(send).toBeEnabled();
+  });
+
+  it('POSTs full-form fields to /feedback and shows a thank-you on success', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    render(<FeedbackWidget />);
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /open detailed feedback/i }));
     await user.type(screen.getByRole('textbox', { name: /feedback message/i }), 'Looks great');
     await user.click(screen.getByRole('button', { name: /^send$/i }));
 
@@ -59,13 +98,14 @@ describe('FeedbackWidget', () => {
     expect(await screen.findByText(/thanks/i)).toBeInTheDocument();
   });
 
-  it('shows an error and keeps the form populated on failure', async () => {
+  it('shows an error and keeps the full-form populated on failure', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 429 }));
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
 
     render(<FeedbackWidget />);
     await user.click(screen.getByRole('button', { name: /open feedback/i }));
-    const textarea = screen.getByRole('textbox', { name: /feedback message/i });
+    await user.click(await screen.findByRole('button', { name: /open detailed feedback/i }));
+    const textarea = await screen.findByRole('textbox', { name: /feedback message/i });
     await user.type(textarea, 'try me');
     await user.click(screen.getByRole('button', { name: /^send$/i }));
 
@@ -77,6 +117,7 @@ describe('FeedbackWidget', () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
     render(<FeedbackWidget />);
     await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.click(await screen.findByRole('button', { name: /open detailed feedback/i }));
 
     // The honeypot lives inside an aria-hidden wrapper, so it must not be discoverable
     // as a labelled form control to screen-reader queries.

--- a/app/src/components/FeedbackWidget.test.tsx
+++ b/app/src/components/FeedbackWidget.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, userEvent, waitFor } from '../test-utils';
+import { FeedbackWidget } from './FeedbackWidget';
+
+describe('FeedbackWidget', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('renders the floating button', () => {
+    render(<FeedbackWidget />);
+    expect(screen.getByRole('button', { name: /open feedback/i })).toBeInTheDocument();
+  });
+
+  it('opens the popover when the FAB is clicked', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(<FeedbackWidget />);
+
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    expect(await screen.findByRole('textbox', { name: /feedback message/i })).toBeInTheDocument();
+  });
+
+  it('disables the send button until a message is typed', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(<FeedbackWidget />);
+
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    const send = await screen.findByRole('button', { name: /^send$/i });
+    expect(send).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox', { name: /feedback message/i }), 'Hi');
+    expect(send).toBeEnabled();
+  });
+
+  it('POSTs to /feedback and shows a thank-you on success', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ok' }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    );
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    render(<FeedbackWidget />);
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    await user.type(screen.getByRole('textbox', { name: /feedback message/i }), 'Looks great');
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toMatch(/\/feedback$/);
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.message).toBe('Looks great');
+    expect(body.website).toBe(''); // honeypot must be empty for real users
+
+    expect(await screen.findByText(/thanks/i)).toBeInTheDocument();
+  });
+
+  it('shows an error and keeps the form populated on failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('boom', { status: 429 }));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+
+    render(<FeedbackWidget />);
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+    const textarea = screen.getByRole('textbox', { name: /feedback message/i });
+    await user.type(textarea, 'try me');
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't send/i);
+    expect(textarea).toHaveValue('try me');
+  });
+
+  it('honeypot input is hidden from assistive tech', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
+    render(<FeedbackWidget />);
+    await user.click(screen.getByRole('button', { name: /open feedback/i }));
+
+    // The honeypot lives inside an aria-hidden wrapper, so it must not be discoverable
+    // as a labelled form control to screen-reader queries.
+    expect(screen.queryByLabelText(/website/i)).toBeNull();
+  });
+});

--- a/app/src/components/FeedbackWidget.tsx
+++ b/app/src/components/FeedbackWidget.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Fab from '@mui/material/Fab';
 import IconButton from '@mui/material/IconButton';
 import Popover from '@mui/material/Popover';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import FeedbackIcon from '@mui/icons-material/Feedback';
+import Tooltip from '@mui/material/Tooltip';
+import ForumIcon from '@mui/icons-material/ForumOutlined';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutlineOutlined';
+import ThumbUpIcon from '@mui/icons-material/ThumbUpOutlined';
+import ThumbDownIcon from '@mui/icons-material/ThumbDownOutlined';
 import CloseIcon from '@mui/icons-material/Close';
 import { API_URL } from '../constants';
 import { useAnalytics } from '../hooks';
@@ -16,16 +21,28 @@ import { RESERVED_TOP_LEVEL } from '../utils/paths';
 
 const MAX_MESSAGE_LENGTH = 500;
 const SESSION_KEY = 'anyplot_feedback_session';
+const THANKS_TIMEOUT_MS = 1200;
+
+// Floating quick-action buttons sit on the page background so they read as
+// chips rather than coloured CTAs — the main FAB stays the only primary mark.
+const miniFabSx = {
+  width: 40,
+  height: 40,
+  bgcolor: 'background.default',
+  color: 'text.primary',
+  opacity: 0.85,
+  '&:hover, &:focus-visible': { opacity: 1, bgcolor: 'action.hover' },
+} as const;
 
 const REACTIONS = [
   { value: 'thumbs_up', label: 'thumbs up', glyph: '👍' },
   { value: 'thumbs_down', label: 'thumbs down', glyph: '👎' },
-  { value: 'bug', label: 'bug', glyph: '🐛' },
   { value: 'idea', label: 'idea', glyph: '💡' },
-  { value: 'heart', label: 'love it', glyph: '❤️' },
+  { value: 'bug', label: 'bug', glyph: '🪲' },
 ] as const;
 
 type Reaction = (typeof REACTIONS)[number]['value'];
+type Mode = 'closed' | 'quick' | 'full';
 
 function specIdFromPath(pathname: string): string | undefined {
   const segments = pathname.split('/').filter(Boolean);
@@ -50,23 +67,67 @@ function newSessionId(): string {
 }
 
 /**
- * Floating quick-feedback widget (issue #5662). Always-visible FAB in the
- * bottom-right corner opens a small popover with a free-text field, an optional
- * reaction, and an optional email. Submissions POST to `/feedback`. No GitHub
- * account or page navigation needed — the bar is "type one sentence and send."
+ * Floating quick-feedback widget (issue #5662). The FAB opens a small
+ * vertical stack of 👍 / 👎 / 💬: the thumbs submit a reaction-only entry
+ * (URL liked/disliked) and close immediately; the chat bubble expands the
+ * full popover form with free-text, all reactions, and an optional contact.
  */
 export function FeedbackWidget() {
   const { trackEvent } = useAnalytics();
   const anchorRef = useRef<HTMLButtonElement | null>(null);
-  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<Mode>('closed');
+  const [thanksVisible, setThanksVisible] = useState(false);
   const [message, setMessage] = useState('');
   const [reaction, setReaction] = useState<Reaction | null>(null);
-  const [email, setEmail] = useState('');
+  const [contact, setContact] = useState('');
   // Honeypot — kept in state but rendered off-screen so real users never see it.
   const [website, setWebsite] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Number of pixels the footer currently overlaps the viewport — used to lift
+  // the FAB stack so it cannot drift over the footer's last-line links once the
+  // page is fully scrolled. When the footer is offscreen, lift stays at 0 and
+  // the FAB sits at its normal corner position.
+  const [lift, setLift] = useState(0);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const footer = document.querySelector('footer');
+    if (!footer) return;
+    let rafId = 0;
+    const update = () => {
+      // Only narrow mobile viewports actually collide — at MUI's sm breakpoint
+      // and above the footer's last link sits well left of the FAB column.
+      if (window.innerWidth >= 600) {
+        setLift(0);
+        return;
+      }
+      const r = footer.getBoundingClientRect();
+      setLift(Math.max(0, window.innerHeight - r.top));
+    };
+    const onScroll = () => {
+      if (rafId) return;
+      rafId = window.requestAnimationFrame(() => {
+        rafId = 0;
+        update();
+      });
+    };
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, []);
+  // Default FAB center on xs is 32px from viewport bottom (bottom 12 + half of
+  // 40). Once the footer enters far enough to cross that line, lift the stack
+  // so the footer's top edge runs exactly through the FAB centre.
+  const FAB_CENTER_FROM_BOTTOM_XS = 32;
+  const liftTransform =
+    lift > FAB_CENTER_FROM_BOTTOM_XS ? `translateY(-${lift - FAB_CENTER_FROM_BOTTOM_XS}px)` : 'none';
 
   const [sessionId, setSessionId] = useLocalStorage<string>(SESSION_KEY, '');
 
@@ -79,40 +140,94 @@ export function FeedbackWidget() {
 
   const currentPath = useMemo(
     () => (typeof window !== 'undefined' ? window.location.pathname + window.location.search : ''),
-    [open]
+    [mode]
   );
 
-  // Auto-close after a successful submission so the FAB returns to its quiet state.
+  // Auto-reset the full-form thank-you state and clear inputs.
   useEffect(() => {
     if (!submitted) return;
     const id = window.setTimeout(() => {
-      setOpen(false);
+      setMode('closed');
       setSubmitted(false);
       setMessage('');
       setReaction(null);
-      setEmail('');
+      setContact('');
       setWebsite('');
     }, 1500);
     return () => window.clearTimeout(id);
   }, [submitted]);
 
-  const handleOpen = () => {
-    setOpen(true);
-    setError(null);
-    trackEvent('feedback_opened', { path: currentPath || undefined });
+  // Auto-dismiss the quick-submit "Thanks" toast.
+  useEffect(() => {
+    if (!thanksVisible) return;
+    const id = window.setTimeout(() => setThanksVisible(false), THANKS_TIMEOUT_MS);
+    return () => window.clearTimeout(id);
+  }, [thanksVisible]);
+
+  const handleFabClick = () => {
+    if (mode === 'closed') {
+      setMode('quick');
+      setError(null);
+      trackEvent('feedback_opened', { path: currentPath || undefined });
+    } else {
+      setMode('closed');
+    }
+  };
+
+  const handleExpand = () => {
+    setMode('full');
   };
 
   const handleClose = () => {
     if (submitting) return;
-    setOpen(false);
+    setMode('closed');
     setError(null);
+  };
+
+  const handleQuickAway = () => {
+    if (mode === 'quick') setMode('closed');
+  };
+
+  const buildPayload = (overrides: { message: string | null; reaction: Reaction | null; contact: string | null }) => ({
+    message: overrides.message,
+    reaction: overrides.reaction,
+    contact: overrides.contact,
+    path: currentPath,
+    spec_id: specIdFromPath(window.location.pathname),
+    viewport: `${window.innerWidth}x${window.innerHeight}`,
+    session_id: ensureSessionId(),
+    website,
+  });
+
+  const submitQuickReaction = async (r: Reaction) => {
+    // Optimistic close + toast: the FAB returns to its quiet state immediately,
+    // so the interaction feels instant even if the network is slow.
+    setMode('closed');
+    setThanksVisible(true);
+    try {
+      await fetch(`${API_URL}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildPayload({ message: null, reaction: r, contact: null })),
+      });
+      trackEvent('feedback_submitted', {
+        path: currentPath || undefined,
+        reaction: r,
+        has_contact: 'false',
+        spec_id: specIdFromPath(window.location.pathname),
+        mode: 'quick',
+      });
+    } catch {
+      // The user already saw the toast; we don't undo it. A retried network
+      // failure here is acceptable lossage for a one-tap reaction.
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = message.trim();
-    if (!trimmed) {
-      setError('Please add a short message.');
+    if (!trimmed && !reaction) {
+      setError('Please add a message or pick a reaction.');
       return;
     }
     if (trimmed.length > MAX_MESSAGE_LENGTH) {
@@ -123,23 +238,13 @@ export function FeedbackWidget() {
     setSubmitting(true);
     setError(null);
 
-    const spec_id = specIdFromPath(window.location.pathname);
-    const viewport = `${window.innerWidth}x${window.innerHeight}`;
-
     try {
       const response = await fetch(`${API_URL}/feedback`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: trimmed,
-          reaction,
-          email: email.trim() || null,
-          path: currentPath,
-          spec_id,
-          viewport,
-          session_id: ensureSessionId(),
-          website,
-        }),
+        body: JSON.stringify(
+          buildPayload({ message: trimmed || null, reaction, contact: contact.trim() || null })
+        ),
       });
 
       if (!response.ok) {
@@ -149,8 +254,9 @@ export function FeedbackWidget() {
       trackEvent('feedback_submitted', {
         path: currentPath || undefined,
         reaction: reaction ?? undefined,
-        has_email: email.trim() ? 'true' : 'false',
-        spec_id,
+        has_contact: contact.trim() ? 'true' : 'false',
+        spec_id: specIdFromPath(window.location.pathname),
+        mode: 'full',
       });
       setSubmitted(true);
     } catch {
@@ -165,26 +271,115 @@ export function FeedbackWidget() {
       <Fab
         ref={anchorRef}
         size="medium"
-        color="primary"
-        onClick={handleOpen}
+        color="default"
+        onClick={handleFabClick}
         aria-label="Open feedback"
+        aria-expanded={mode !== 'closed'}
         sx={{
           position: 'fixed',
           bottom: { xs: 12, sm: 16 },
           right: { xs: 12, sm: 16 },
           zIndex: 1300,
+          width: { xs: 40, sm: 48 },
+          height: { xs: 40, sm: 48 },
+          minHeight: { xs: 40, sm: 48 },
+          bgcolor: 'background.default',
+          color: 'primary.main',
+          opacity: { xs: 0.75, sm: 0.85 },
+          transform: liftTransform,
+          transition: 'transform 120ms ease-out',
+          '&:hover, &:focus-visible': { opacity: 1, bgcolor: 'action.hover' },
         }}
       >
-        <FeedbackIcon />
+        <ForumIcon />
       </Fab>
 
+      {mode === 'quick' && (
+        <ClickAwayListener onClickAway={handleQuickAway}>
+          <Box
+            role="menu"
+            aria-label="Quick feedback"
+            sx={{
+              position: 'fixed',
+              right: { xs: 12, sm: 20 },
+              bottom: { xs: 60, sm: 72 },
+              zIndex: 1301,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1,
+              alignItems: 'center',
+              transform: liftTransform,
+            }}
+          >
+            <Tooltip title="Leave detailed feedback" placement="left">
+              <Fab
+                size="small"
+                color="default"
+                onClick={handleExpand}
+                aria-label="Open detailed feedback"
+                sx={miniFabSx}
+              >
+                <ChatBubbleOutlineIcon fontSize="small" />
+              </Fab>
+            </Tooltip>
+            <Tooltip title="I don't like this page" placement="left">
+              <Fab
+                size="small"
+                color="default"
+                onClick={() => submitQuickReaction('thumbs_down')}
+                aria-label="Quick thumbs down"
+                sx={miniFabSx}
+              >
+                <ThumbDownIcon fontSize="small" />
+              </Fab>
+            </Tooltip>
+            <Tooltip title="I like this page" placement="left">
+              <Fab
+                size="small"
+                color="default"
+                onClick={() => submitQuickReaction('thumbs_up')}
+                aria-label="Quick thumbs up"
+                sx={miniFabSx}
+              >
+                <ThumbUpIcon fontSize="small" />
+              </Fab>
+            </Tooltip>
+          </Box>
+        </ClickAwayListener>
+      )}
+
+      {thanksVisible && (
+        <Box
+          role="status"
+          aria-live="polite"
+          sx={{
+            position: 'fixed',
+            right: { xs: 60, sm: 76 },
+            bottom: { xs: 16, sm: 22 },
+            bgcolor: 'background.paper',
+            transform: liftTransform,
+            color: 'text.primary',
+            px: 1.5,
+            py: 0.5,
+            borderRadius: 1,
+            boxShadow: 3,
+            fontSize: 13,
+            fontWeight: 500,
+            zIndex: 1301,
+            pointerEvents: 'none',
+          }}
+        >
+          Thanks!
+        </Box>
+      )}
+
       <Popover
-        open={open}
+        open={mode === 'full'}
         anchorEl={anchorRef.current}
         onClose={handleClose}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-        slotProps={{ paper: { sx: { width: { xs: 'calc(100vw - 24px)', sm: 360 }, maxWidth: 400, p: 2 } } }}
+        slotProps={{ paper: { sx: { width: { xs: 'calc(100vw - 12px)', sm: 360 }, maxWidth: 400, p: 1.5 } } }}
       >
         {submitted ? (
           <Box sx={{ py: 3, textAlign: 'center' }} role="status" aria-live="polite">
@@ -233,16 +428,29 @@ export function FeedbackWidget() {
             </ToggleButtonGroup>
 
             <TextField
-              type="email"
               fullWidth
               size="small"
-              placeholder="Email (optional, for follow-up)"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              slotProps={{ htmlInput: { maxLength: 255, 'aria-label': 'Email (optional)' } }}
+              placeholder="Name or email (optional)"
+              value={contact}
+              onChange={(e) => setContact(e.target.value)}
+              slotProps={{ htmlInput: { maxLength: 255, 'aria-label': 'Contact (optional)' } }}
               disabled={submitting}
-              sx={{ mb: 1.5 }}
+              sx={{ mb: 1 }}
             />
+
+            <Box
+              sx={{
+                fontSize: 11,
+                color: 'text.secondary',
+                mb: 1.5,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+              title={currentPath || undefined}
+            >
+              Page: {currentPath || '/'}
+            </Box>
 
             {/* Honeypot — real users never see this, bots will fill it and trip the server-side guard. */}
             <Box aria-hidden="true" sx={{ position: 'absolute', left: '-9999px', width: 1, height: 1, overflow: 'hidden' }}>
@@ -266,7 +474,12 @@ export function FeedbackWidget() {
               <Box sx={{ fontSize: 12, color: 'text.secondary' }}>
                 {message.length}/{MAX_MESSAGE_LENGTH}
               </Box>
-              <Button type="submit" variant="contained" size="small" disabled={submitting || !message.trim()}>
+              <Button
+                type="submit"
+                variant="contained"
+                size="small"
+                disabled={submitting || (!message.trim() && !reaction)}
+              >
                 {submitting ? 'Sending…' : 'Send'}
               </Button>
             </Box>

--- a/app/src/components/FeedbackWidget.tsx
+++ b/app/src/components/FeedbackWidget.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Fab from '@mui/material/Fab';
+import IconButton from '@mui/material/IconButton';
+import Popover from '@mui/material/Popover';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import FeedbackIcon from '@mui/icons-material/Feedback';
+import CloseIcon from '@mui/icons-material/Close';
+import { API_URL } from '../constants';
+import { useAnalytics } from '../hooks';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { RESERVED_TOP_LEVEL } from '../utils/paths';
+
+const MAX_MESSAGE_LENGTH = 500;
+const SESSION_KEY = 'anyplot_feedback_session';
+
+const REACTIONS = [
+  { value: 'thumbs_up', label: 'thumbs up', glyph: '👍' },
+  { value: 'thumbs_down', label: 'thumbs down', glyph: '👎' },
+  { value: 'bug', label: 'bug', glyph: '🐛' },
+  { value: 'idea', label: 'idea', glyph: '💡' },
+  { value: 'heart', label: 'love it', glyph: '❤️' },
+] as const;
+
+type Reaction = (typeof REACTIONS)[number]['value'];
+
+function specIdFromPath(pathname: string): string | undefined {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return undefined;
+  if (RESERVED_TOP_LEVEL.has(segments[0])) return undefined;
+  return segments[0];
+}
+
+function newSessionId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `s-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Floating quick-feedback widget (issue #5662). Always-visible FAB in the
+ * bottom-right corner opens a small popover with a free-text field, an optional
+ * reaction, and an optional email. Submissions POST to `/feedback`. No GitHub
+ * account or page navigation needed — the bar is "type one sentence and send."
+ */
+export function FeedbackWidget() {
+  const { trackEvent } = useAnalytics();
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState('');
+  const [reaction, setReaction] = useState<Reaction | null>(null);
+  const [email, setEmail] = useState('');
+  // Honeypot — kept in state but rendered off-screen so real users never see it.
+  const [website, setWebsite] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [sessionId, setSessionId] = useLocalStorage<string>(SESSION_KEY, '');
+
+  const ensureSessionId = (): string => {
+    if (sessionId) return sessionId;
+    const fresh = newSessionId();
+    setSessionId(fresh);
+    return fresh;
+  };
+
+  const currentPath = useMemo(
+    () => (typeof window !== 'undefined' ? window.location.pathname + window.location.search : ''),
+    [open]
+  );
+
+  // Auto-close after a successful submission so the FAB returns to its quiet state.
+  useEffect(() => {
+    if (!submitted) return;
+    const id = window.setTimeout(() => {
+      setOpen(false);
+      setSubmitted(false);
+      setMessage('');
+      setReaction(null);
+      setEmail('');
+      setWebsite('');
+    }, 1500);
+    return () => window.clearTimeout(id);
+  }, [submitted]);
+
+  const handleOpen = () => {
+    setOpen(true);
+    setError(null);
+    trackEvent('feedback_opened', { path: currentPath || undefined });
+  };
+
+  const handleClose = () => {
+    if (submitting) return;
+    setOpen(false);
+    setError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = message.trim();
+    if (!trimmed) {
+      setError('Please add a short message.');
+      return;
+    }
+    if (trimmed.length > MAX_MESSAGE_LENGTH) {
+      setError(`Please keep it under ${MAX_MESSAGE_LENGTH} characters.`);
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    const spec_id = specIdFromPath(window.location.pathname);
+    const viewport = `${window.innerWidth}x${window.innerHeight}`;
+
+    try {
+      const response = await fetch(`${API_URL}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: trimmed,
+          reaction,
+          email: email.trim() || null,
+          path: currentPath,
+          spec_id,
+          viewport,
+          session_id: ensureSessionId(),
+          website,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`status ${response.status}`);
+      }
+
+      trackEvent('feedback_submitted', {
+        path: currentPath || undefined,
+        reaction: reaction ?? undefined,
+        has_email: email.trim() ? 'true' : 'false',
+        spec_id,
+      });
+      setSubmitted(true);
+    } catch {
+      setError("Couldn't send — try again in a moment.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Fab
+        ref={anchorRef}
+        size="medium"
+        color="primary"
+        onClick={handleOpen}
+        aria-label="Open feedback"
+        sx={{
+          position: 'fixed',
+          bottom: { xs: 12, sm: 16 },
+          right: { xs: 12, sm: 16 },
+          zIndex: 1300,
+        }}
+      >
+        <FeedbackIcon />
+      </Fab>
+
+      <Popover
+        open={open}
+        anchorEl={anchorRef.current}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { width: { xs: 'calc(100vw - 24px)', sm: 360 }, maxWidth: 400, p: 2 } } }}
+      >
+        {submitted ? (
+          <Box sx={{ py: 3, textAlign: 'center' }} role="status" aria-live="polite">
+            <Box sx={{ fontSize: 28, mb: 1 }}>🙏</Box>
+            <Box sx={{ fontWeight: 600 }}>Thanks!</Box>
+            <Box sx={{ fontSize: 13, color: 'text.secondary', mt: 0.5 }}>
+              We read every note.
+            </Box>
+          </Box>
+        ) : (
+          <Box component="form" onSubmit={handleSubmit} noValidate>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+              <Box sx={{ fontWeight: 600 }}>Quick feedback</Box>
+              <IconButton size="small" onClick={handleClose} aria-label="Close feedback" disabled={submitting}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Box>
+
+            <TextField
+              autoFocus
+              multiline
+              minRows={3}
+              maxRows={6}
+              fullWidth
+              placeholder="Typo, weird chart, feature idea…"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              slotProps={{ htmlInput: { maxLength: MAX_MESSAGE_LENGTH, 'aria-label': 'Feedback message' } }}
+              disabled={submitting}
+              sx={{ mb: 1.5 }}
+            />
+
+            <ToggleButtonGroup
+              value={reaction}
+              exclusive
+              onChange={(_, value: Reaction | null) => setReaction(value)}
+              size="small"
+              aria-label="Reaction"
+              sx={{ display: 'flex', flexWrap: 'wrap', mb: 1.5 }}
+            >
+              {REACTIONS.map((r) => (
+                <ToggleButton key={r.value} value={r.value} aria-label={r.label} sx={{ fontSize: 18, px: 1.5 }}>
+                  {r.glyph}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+
+            <TextField
+              type="email"
+              fullWidth
+              size="small"
+              placeholder="Email (optional, for follow-up)"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              slotProps={{ htmlInput: { maxLength: 255, 'aria-label': 'Email (optional)' } }}
+              disabled={submitting}
+              sx={{ mb: 1.5 }}
+            />
+
+            {/* Honeypot — real users never see this, bots will fill it and trip the server-side guard. */}
+            <Box aria-hidden="true" sx={{ position: 'absolute', left: '-9999px', width: 1, height: 1, overflow: 'hidden' }}>
+              <input
+                type="text"
+                name="website"
+                tabIndex={-1}
+                autoComplete="off"
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+              />
+            </Box>
+
+            {error && (
+              <Box sx={{ color: 'error.main', fontSize: 13, mb: 1 }} role="alert">
+                {error}
+              </Box>
+            )}
+
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <Box sx={{ fontSize: 12, color: 'text.secondary' }}>
+                {message.length}/{MAX_MESSAGE_LENGTH}
+              </Box>
+              <Button type="submit" variant="contained" size="small" disabled={submitting || !message.trim()}>
+                {submitting ? 'Sending…' : 'Send'}
+              </Button>
+            </Box>
+          </Box>
+        )}
+      </Popover>
+    </>
+  );
+}

--- a/app/src/components/FeedbackWidget.tsx
+++ b/app/src/components/FeedbackWidget.tsx
@@ -38,7 +38,15 @@ function newSessionId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
-  return `s-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return `s-${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`;
+  }
+  // Browser without Web Crypto support (e.g. very old, or insecure context). The
+  // session id is an opaque correlation handle, not a credential — a coarse
+  // timestamp-derived id is acceptable here, but we never use Math.random().
+  return `s-${Date.now().toString(36)}`;
 }
 
 /**

--- a/app/src/components/RootLayout.tsx
+++ b/app/src/components/RootLayout.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '../hooks/useLayoutContext';
 import { MastheadRule } from './MastheadRule';
 import { NavBar } from './NavBar';
 import { Footer } from './Footer';
+import { FeedbackWidget } from './FeedbackWidget';
 
 const containerSx = {
   px: { xs: 2, sm: 4, md: 8, lg: 12 },
@@ -90,6 +91,8 @@ export function RootLayout() {
       <Container maxWidth={false} sx={{ ...containerSx, pb: { xs: 4, md: 6 } }}>
         <Footer onTrackEvent={trackEvent} />
       </Container>
+
+      <FeedbackWidget />
     </Box>
   );
 }

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -75,6 +75,32 @@ interface WeaknessCount {
   count: number;
 }
 
+interface FeedbackTopPage {
+  path: string;
+  count: number;
+  last_seen: string | null;
+}
+
+type FeedbackStatus = 'new' | 'in_progress' | 'done' | 'wont_solve';
+const FEEDBACK_STATUS_OPTIONS: FeedbackStatus[] = ['new', 'in_progress', 'done', 'wont_solve'];
+
+// "" → all statuses, "open" → new + in_progress (server-side pseudo-filter).
+// Default view shows the open queue so resolved entries don't drown out triage.
+type FeedbackMessageFilter = '' | 'open' | FeedbackStatus;
+const DEFAULT_MESSAGE_FILTER: FeedbackMessageFilter = 'open';
+
+interface FeedbackMessageItem {
+  id: string;
+  message: string;
+  reaction: string | null;
+  contact: string | null;
+  path: string | null;
+  spec_id: string | null;
+  viewport: string | null;
+  status: FeedbackStatus;
+  created_at: string;
+}
+
 interface DebugStatus {
   total_specs: number;
   total_implementations: number;
@@ -183,11 +209,12 @@ const clearAdminToken = (): void => {
   try { sessionStorage.removeItem(ADMIN_TOKEN_KEY); } catch { /* noop */ }
 };
 
-const adminFetch = (url: string, token: string): Promise<Response> =>
-  fetch(url, {
-    credentials: 'include',
-    headers: token ? { 'X-Admin-Token': token } : undefined,
-  });
+const adminFetch = (url: string, token: string, init: RequestInit = {}): Promise<Response> => {
+  const headers: Record<string, string> = { ...((init.headers as Record<string, string>) || {}) };
+  if (token) headers['X-Admin-Token'] = token;
+  if (init.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
+  return fetch(url, { credentials: 'include', ...init, headers });
+};
 
 export function DebugPage() {
   const [data, setData] = useState<DebugStatus | null>(null);
@@ -207,6 +234,11 @@ export function DebugPage() {
 
   const [pings, setPings] = useState<Array<{ ms: number; ok: boolean }>>([]);
   const [prevFetchKey, setPrevFetchKey] = useState({ adminToken, reloadCounter });
+
+  const [topThumbsUp, setTopThumbsUp] = useState<FeedbackTopPage[]>([]);
+  const [topThumbsDown, setTopThumbsDown] = useState<FeedbackTopPage[]>([]);
+  const [feedbackMessages, setFeedbackMessages] = useState<FeedbackMessageItem[]>([]);
+  const [feedbackStatusFilter, setFeedbackStatusFilter] = useState<FeedbackMessageFilter>(DEFAULT_MESSAGE_FILTER);
 
   // React 19 "adjust state on prop change": reset loading/error when fetch deps change.
   if (prevFetchKey.adminToken !== adminToken || prevFetchKey.reloadCounter !== reloadCounter) {
@@ -287,6 +319,50 @@ export function DebugPage() {
     const id = setInterval(tick, PING_INTERVAL_MS);
     return () => { cancelled = true; clearInterval(id); };
   }, [adminToken, authRequired]);
+
+  useEffect(() => {
+    if (authRequired) return;
+    let cancelled = false;
+    const qs = feedbackStatusFilter ? `?status=${feedbackStatusFilter}&limit=50` : '?limit=50';
+    Promise.all([
+      adminFetch(`${DEBUG_API_URL}/debug/feedback/top?reaction=thumbs_up&limit=15`, adminToken).then(r =>
+        r.ok ? (r.json() as Promise<FeedbackTopPage[]>) : []
+      ),
+      adminFetch(`${DEBUG_API_URL}/debug/feedback/top?reaction=thumbs_down&limit=15`, adminToken).then(r =>
+        r.ok ? (r.json() as Promise<FeedbackTopPage[]>) : []
+      ),
+      adminFetch(`${DEBUG_API_URL}/debug/feedback/messages${qs}`, adminToken).then(r =>
+        r.ok ? (r.json() as Promise<FeedbackMessageItem[]>) : []
+      ),
+    ])
+      .then(([up, down, msgs]) => {
+        if (cancelled) return;
+        setTopThumbsUp(Array.isArray(up) ? up : []);
+        setTopThumbsDown(Array.isArray(down) ? down : []);
+        setFeedbackMessages(Array.isArray(msgs) ? msgs : []);
+      })
+      .catch(() => {
+        /* /debug/status useEffect already surfaces auth/network errors */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [adminToken, authRequired, reloadCounter, feedbackStatusFilter]);
+
+  const updateFeedbackStatus = async (id: string, newStatus: FeedbackStatus) => {
+    // Optimistic update — revert on failure so the dropdown stays truthful.
+    const prev = feedbackMessages;
+    setFeedbackMessages(prev.map(m => (m.id === id ? { ...m, status: newStatus } : m)));
+    try {
+      const r = await adminFetch(`${DEBUG_API_URL}/debug/feedback/${id}`, adminToken, {
+        method: 'PATCH',
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!r.ok) throw new Error(`${r.status}`);
+    } catch {
+      setFeedbackMessages(prev);
+    }
+  };
 
   const handleTokenSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -773,6 +849,111 @@ export function DebugPage() {
         ))}
       </Box>
 
+      {/* Feedback: top pages + messages with triage (issue #5662) */}
+      <Box sx={{ mt: 4 }}>
+        <SectionHeader prompt="❯" title={<em>feedback · top pages</em>} />
+      </Box>
+      <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.xs, color: semanticColors.mutedText, mb: 1 }}>
+        grouped by URL — clickable
+      </Typography>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
+        <FeedbackTopList title="👍 thumbs up" items={topThumbsUp} accent={colors.success} />
+        <FeedbackTopList title="👎 thumbs down" items={topThumbsDown} accent={colors.error} />
+      </Box>
+
+      <Box sx={{ mt: 4, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+        <SectionHeader prompt="❯" title={<em>feedback · messages</em>} />
+        <Box
+          component="select"
+          value={feedbackStatusFilter}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            setFeedbackStatusFilter(e.target.value as FeedbackMessageFilter)
+          }
+          sx={{ ...nativeControlSx, cursor: 'pointer', ml: 'auto' }}
+        >
+          <option value="open">open (new + in progress)</option>
+          <option value="">all statuses</option>
+          {FEEDBACK_STATUS_OPTIONS.map(s => (
+            <option key={s} value={s}>{s.replace('_', ' ')}</option>
+          ))}
+        </Box>
+      </Box>
+      {feedbackMessages.length === 0 ? (
+        <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.xs, color: semanticColors.mutedText, py: 2 }}>
+          no messages{feedbackStatusFilter ? ` with status "${feedbackStatusFilter}"` : ''}
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 4 }}>
+          {feedbackMessages.map(m => (
+            <Box
+              key={m.id}
+              sx={{
+                border: '1px solid var(--rule)', borderRadius: 1, p: 1.5,
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: 'auto 1fr auto' },
+                columnGap: 1.5, rowGap: 0.5,
+                alignItems: 'start',
+                bgcolor: m.status === 'new' ? 'var(--bg-surface)' : 'transparent',
+              }}
+            >
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25, minWidth: 90 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <Box component="span" sx={{ fontSize: 14 }}>
+                    {m.reaction === 'thumbs_up' ? '👍'
+                      : m.reaction === 'thumbs_down' ? '👎'
+                      : m.reaction === 'idea' ? '💡'
+                      : m.reaction === 'bug' ? '🪲'
+                      : '—'}
+                  </Box>
+                  <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.xxs, color: semanticColors.mutedText }}>
+                    {timeAgo(m.created_at)}
+                  </Typography>
+                </Box>
+                {m.path && (
+                  <Link
+                    component={RouterLink}
+                    to={m.path}
+                    sx={{
+                      fontFamily: typography.fontFamily, fontSize: fontSize.xxs,
+                      color: colors.primary, textDecoration: 'none',
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      '&:hover': { textDecoration: 'underline' },
+                    }}
+                  >
+                    {m.path}
+                  </Link>
+                )}
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{
+                  fontFamily: typography.fontFamily, fontSize: fontSize.xs, color: 'var(--ink)',
+                  whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                }}>
+                  {m.message}
+                </Typography>
+                {m.contact && (
+                  <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.xxs, color: semanticColors.mutedText, mt: 0.5 }}>
+                    contact: {m.contact}
+                  </Typography>
+                )}
+              </Box>
+              <Box
+                component="select"
+                value={m.status}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  updateFeedbackStatus(m.id, e.target.value as FeedbackStatus)
+                }
+                sx={{ ...nativeControlSx, cursor: 'pointer', alignSelf: 'start' }}
+              >
+                {FEEDBACK_STATUS_OPTIONS.map(s => (
+                  <option key={s} value={s}>{s.replace('_', ' ')}</option>
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      )}
+
       {/* Spec Matrix */}
       <Box sx={{ mt: 4 }}>
         <SectionHeader prompt="❯" title={<em>specs</em>} />
@@ -1022,6 +1203,58 @@ export function DebugPage() {
 // ============================================================================
 // Sortable header helpers
 // ============================================================================
+
+function FeedbackTopList({ title, items, accent }: { title: string; items: FeedbackTopPage[]; accent: string }) {
+  return (
+    <Box sx={{ border: '1px solid var(--rule)', borderRadius: 1, p: 1.5 }}>
+      <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.xs, fontWeight: 600, color: 'var(--ink-soft)', mb: 1 }}>
+        {title}
+      </Typography>
+      {items.length === 0 ? (
+        <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.xxs, color: semanticColors.mutedText }}>
+          no entries yet
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+          {items.map(it => (
+            <Box
+              key={it.path}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '32px 1fr auto',
+                gap: 1, alignItems: 'baseline',
+                py: 0.4, borderBottom: '1px solid var(--rule)',
+                '&:last-of-type': { borderBottom: 'none' },
+              }}
+            >
+              <Typography sx={{
+                fontFamily: typography.fontFamily, fontSize: fontSize.xxs,
+                color: accent, fontWeight: 600, textAlign: 'right',
+              }}>
+                {it.count}
+              </Typography>
+              <Link
+                component={RouterLink}
+                to={it.path}
+                sx={{
+                  fontFamily: typography.fontFamily, fontSize: fontSize.xs,
+                  color: colors.primary, textDecoration: 'none',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  '&:hover': { textDecoration: 'underline' },
+                }}
+              >
+                {it.path}
+              </Link>
+              <Typography sx={{ fontFamily: typography.fontFamily, fontSize: fontSize.micro, color: semanticColors.mutedText }}>
+                {it.last_seen ? timeAgo(it.last_seen) : ''}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
 
 function HeaderCell({ children, center }: { children: React.ReactNode; center?: boolean }) {
   return (

--- a/app/src/router.tsx
+++ b/app/src/router.tsx
@@ -28,6 +28,10 @@ function SpecLanguageRedirect() {
 const router = createBrowserRouter([
   {
     element: <RootLayout />,
+    // Surface a small spinner while a lazy() route is resolving during initial
+    // hydration; without this React Router 6.4+ logs a noisy "No HydrateFallback
+    // element provided" warning on every load.
+    hydrateFallbackElement: <LazyFallback />,
     children: [
       {
         errorElement: <RouteErrorBoundary />,

--- a/core/database/__init__.py
+++ b/core/database/__init__.py
@@ -16,6 +16,7 @@ from core.database.connection import (
 )
 from core.database.models import (
     FEEDBACK_REACTIONS,
+    FEEDBACK_STATUSES,
     LANGUAGES_SEED,
     LIBRARIES_SEED,
     Feedback,
@@ -50,6 +51,7 @@ __all__ = [
     "Impl",
     "Feedback",
     "FEEDBACK_REACTIONS",
+    "FEEDBACK_STATUSES",
     "LIBRARIES_SEED",
     "LANGUAGES_SEED",
     # Repositories

--- a/core/database/__init__.py
+++ b/core/database/__init__.py
@@ -14,8 +14,23 @@ from core.database.connection import (
     init_db,
     is_db_configured,
 )
-from core.database.models import LANGUAGES_SEED, LIBRARIES_SEED, Impl, Language, Library, Spec
-from core.database.repositories import BaseRepository, ImplRepository, LibraryRepository, SpecRepository
+from core.database.models import (
+    FEEDBACK_REACTIONS,
+    LANGUAGES_SEED,
+    LIBRARIES_SEED,
+    Feedback,
+    Impl,
+    Language,
+    Library,
+    Spec,
+)
+from core.database.repositories import (
+    BaseRepository,
+    FeedbackRepository,
+    ImplRepository,
+    LibraryRepository,
+    SpecRepository,
+)
 
 
 __all__ = [
@@ -33,6 +48,8 @@ __all__ = [
     "Library",
     "Language",
     "Impl",
+    "Feedback",
+    "FEEDBACK_REACTIONS",
     "LIBRARIES_SEED",
     "LANGUAGES_SEED",
     # Repositories
@@ -40,4 +57,5 @@ __all__ = [
     "SpecRepository",
     "LibraryRepository",
     "ImplRepository",
+    "FeedbackRepository",
 ]

--- a/core/database/models.py
+++ b/core/database/models.py
@@ -243,10 +243,7 @@ class Feedback(Base):
             "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea')",
             name="ck_feedback_reaction_valid",
         ),
-        CheckConstraint(
-            "status IN ('new','in_progress','done','wont_solve')",
-            name="ck_feedback_status_valid",
-        ),
+        CheckConstraint("status IN ('new','in_progress','done','wont_solve')", name="ck_feedback_status_valid"),
     )
 
 

--- a/core/database/models.py
+++ b/core/database/models.py
@@ -203,7 +203,11 @@ class Impl(Base):
 
 
 # Allowed reactions for in-app feedback widget (issue #5662).
-FEEDBACK_REACTIONS = ("thumbs_up", "thumbs_down", "bug", "idea", "heart")
+FEEDBACK_REACTIONS = ("thumbs_up", "thumbs_down", "bug", "idea")
+
+# Triage states for feedback entries — admins move them through these on
+# /debug as they read incoming feedback.
+FEEDBACK_STATUSES = ("new", "in_progress", "done", "wont_solve")
 
 
 class Feedback(Base):
@@ -216,9 +220,9 @@ class Feedback(Base):
     __tablename__ = "feedback"
 
     id: Mapped[str] = mapped_column(UniversalUUID, primary_key=True, default=lambda: str(uuid4()))
-    message: Mapped[str] = mapped_column(String(500), nullable=False)
+    message: Mapped[str | None] = mapped_column(String(500), nullable=True)
     reaction: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    contact: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Context captured automatically with the message
     path: Mapped[str | None] = mapped_column(String(500), nullable=True)
@@ -229,12 +233,19 @@ class Feedback(Base):
     # SHA-256 of the client IP — used for rate limiting, not user identification.
     ip_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
+    # Triage state — see FEEDBACK_STATUSES above. Updated from /debug.
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="new")
+
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
 
     __table_args__ = (
         CheckConstraint(
-            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea','heart')",
+            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea')",
             name="ck_feedback_reaction_valid",
+        ),
+        CheckConstraint(
+            "status IN ('new','in_progress','done','wont_solve')",
+            name="ck_feedback_status_valid",
         ),
     )
 

--- a/core/database/models.py
+++ b/core/database/models.py
@@ -202,6 +202,43 @@ class Impl(Base):
     )
 
 
+# Allowed reactions for in-app feedback widget (issue #5662).
+FEEDBACK_REACTIONS = ("thumbs_up", "thumbs_down", "bug", "idea", "heart")
+
+
+class Feedback(Base):
+    """Lightweight in-app feedback entry (issue #5662).
+
+    Submitted via the floating widget on anyplot.ai by users without GitHub
+    accounts. Entries are immutable once written; triage happens manually.
+    """
+
+    __tablename__ = "feedback"
+
+    id: Mapped[str] = mapped_column(UniversalUUID, primary_key=True, default=lambda: str(uuid4()))
+    message: Mapped[str] = mapped_column(String(500), nullable=False)
+    reaction: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Context captured automatically with the message
+    path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    spec_id: Mapped[str | None] = mapped_column(String(MAX_SPEC_ID_LENGTH), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    viewport: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    session_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # SHA-256 of the client IP — used for rate limiting, not user identification.
+    ip_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "reaction IS NULL OR reaction IN ('thumbs_up','thumbs_down','bug','idea','heart')",
+            name="ck_feedback_reaction_valid",
+        ),
+    )
+
+
 # Seed data for libraries + languages (re-exported from core.constants)
 LIBRARIES_SEED = LIBRARIES_METADATA
 LANGUAGES_SEED = LANGUAGES_METADATA

--- a/core/database/repositories.py
+++ b/core/database/repositories.py
@@ -379,9 +379,7 @@ class FeedbackRepository(BaseRepository[Feedback]):
         """
         result = await self.session.execute(
             select(
-                Feedback.path,
-                func.count(Feedback.id).label("count"),
-                func.max(Feedback.created_at).label("last_seen"),
+                Feedback.path, func.count(Feedback.id).label("count"), func.max(Feedback.created_at).label("last_seen")
             )
             .where(Feedback.reaction == reaction, Feedback.path.is_not(None))
             .group_by(Feedback.path)
@@ -394,19 +392,13 @@ class FeedbackRepository(BaseRepository[Feedback]):
                 "count": row.count,
                 # created_at is TIMESTAMP WITHOUT TIME ZONE in UTC — tag with Z so
                 # the browser doesn't interpret the naive ISO as local time.
-                "last_seen": (
-                    row.last_seen.replace(tzinfo=timezone.utc).isoformat() if row.last_seen else None
-                ),
+                "last_seen": (row.last_seen.replace(tzinfo=timezone.utc).isoformat() if row.last_seen else None),
             }
             for row in result.all()
         ]
 
     async def has_recent_duplicate(
-        self,
-        message: str,
-        ip_hash: str | None,
-        session_id: str | None,
-        since: datetime,
+        self, message: str, ip_hash: str | None, session_id: str | None, since: datetime
     ) -> bool:
         """True iff the same message text was submitted since `since` AND matches
         either the same IP hash or the same session id. The router uses this for
@@ -421,18 +413,12 @@ class FeedbackRepository(BaseRepository[Feedback]):
             return False
         result = await self.session.execute(
             select(func.count(Feedback.id)).where(
-                Feedback.message == message,
-                Feedback.created_at >= since,
-                or_(*identity_filters),
+                Feedback.message == message, Feedback.created_at >= since, or_(*identity_filters)
             )
         )
         return (result.scalar_one() or 0) > 0
 
-    async def list_with_message(
-        self,
-        status: str | tuple[str, ...] | None = None,
-        limit: int = 50,
-    ) -> list[Feedback]:
+    async def list_with_message(self, status: str | tuple[str, ...] | None = None, limit: int = 50) -> list[Feedback]:
         """List entries that carry a free-text message, filtered optionally by status.
 
         `status` may be a single value, a tuple of values (matched with IN), or None

--- a/core/database/repositories.py
+++ b/core/database/repositories.py
@@ -4,6 +4,7 @@ Repository classes for database access.
 Provides abstraction layer between API and database models.
 """
 
+from datetime import timezone
 from typing import Generic, TypeVar
 
 from sqlalchemy import String, cast, func, or_, select
@@ -322,10 +323,12 @@ class ImplRepository(BaseRepository[Impl]):
 
 
 class FeedbackRepository(BaseRepository[Feedback]):
-    """Repository for in-app feedback entries (issue #5662). Entries are immutable."""
+    """Repository for in-app feedback entries (issue #5662). Message/reaction/contact
+    are immutable once written; only `status` can change as admins triage entries.
+    """
 
     model = Feedback
-    updatable_fields = frozenset()
+    updatable_fields = frozenset({"status"})
 
     async def count_recent_by_ip(self, ip_hash: str, since) -> int:
         """Count entries from this IP hash since the given UTC datetime — used for rate limiting."""
@@ -338,3 +341,84 @@ class FeedbackRepository(BaseRepository[Feedback]):
         """List most recent entries first — for admin/triage tooling."""
         result = await self.session.execute(select(Feedback).order_by(Feedback.created_at.desc()).limit(limit))
         return list(result.scalars().all())
+
+    async def top_paths_by_reaction(self, reaction: str, limit: int = 20) -> list[dict]:
+        """Group entries by path for one reaction and return path + count + last seen.
+
+        Used by the debug dashboard's "top thumbs-up / thumbs-down pages" sections.
+        Entries with no path are skipped — they can't be navigated to.
+        """
+        result = await self.session.execute(
+            select(
+                Feedback.path,
+                func.count(Feedback.id).label("count"),
+                func.max(Feedback.created_at).label("last_seen"),
+            )
+            .where(Feedback.reaction == reaction, Feedback.path.is_not(None))
+            .group_by(Feedback.path)
+            .order_by(func.count(Feedback.id).desc(), func.max(Feedback.created_at).desc())
+            .limit(limit)
+        )
+        return [
+            {
+                "path": row.path,
+                "count": row.count,
+                # created_at is TIMESTAMP WITHOUT TIME ZONE in UTC — tag with Z so
+                # the browser doesn't interpret the naive ISO as local time.
+                "last_seen": (
+                    row.last_seen.replace(tzinfo=timezone.utc).isoformat() if row.last_seen else None
+                ),
+            }
+            for row in result.all()
+        ]
+
+    async def has_recent_duplicate(
+        self,
+        message: str,
+        ip_hash: str | None,
+        session_id: str | None,
+        since,
+    ) -> bool:
+        """True iff the same message text was submitted since `since` AND matches
+        either the same IP hash or the same session id. The router uses this for
+        silent spam-drop so bots can't tell the difference between accepted and
+        suppressed submissions."""
+        identity_filters = []
+        if ip_hash:
+            identity_filters.append(Feedback.ip_hash == ip_hash)
+        if session_id:
+            identity_filters.append(Feedback.session_id == session_id)
+        if not identity_filters:
+            return False
+        result = await self.session.execute(
+            select(func.count(Feedback.id)).where(
+                Feedback.message == message,
+                Feedback.created_at >= since,
+                or_(*identity_filters),
+            )
+        )
+        return (result.scalar_one() or 0) > 0
+
+    async def list_with_message(
+        self,
+        status: str | tuple[str, ...] | None = None,
+        limit: int = 50,
+    ) -> list[Feedback]:
+        """List entries that carry a free-text message, filtered optionally by status.
+
+        `status` may be a single value, a tuple of values (matched with IN), or None
+        for all statuses. The router uses the tuple form for the "open" pseudo-filter
+        on /debug.
+        """
+        stmt = select(Feedback).where(Feedback.message.is_not(None))
+        if isinstance(status, str):
+            stmt = stmt.where(Feedback.status == status)
+        elif status:
+            stmt = stmt.where(Feedback.status.in_(status))
+        stmt = stmt.order_by(Feedback.created_at.desc()).limit(limit)
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def update_status(self, entry_id: str, new_status: str) -> Feedback | None:
+        """Update only the triage status of one entry. Returns None if not found."""
+        return await self.update(entry_id, {"status": new_status})

--- a/core/database/repositories.py
+++ b/core/database/repositories.py
@@ -10,7 +10,7 @@ from sqlalchemy import String, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, undefer
 
-from core.database.models import Impl, Library, Spec
+from core.database.models import Feedback, Impl, Library, Spec
 
 
 T = TypeVar("T")
@@ -319,3 +319,22 @@ class ImplRepository(BaseRepository[Impl]):
             return existing
         full_data = {**impl_data, "spec_id": spec_id, "library_id": library_id, "language_id": language_id}
         return await self.create(full_data)
+
+
+class FeedbackRepository(BaseRepository[Feedback]):
+    """Repository for in-app feedback entries (issue #5662). Entries are immutable."""
+
+    model = Feedback
+    updatable_fields = frozenset()
+
+    async def count_recent_by_ip(self, ip_hash: str, since) -> int:
+        """Count entries from this IP hash since the given UTC datetime — used for rate limiting."""
+        result = await self.session.execute(
+            select(func.count(Feedback.id)).where(Feedback.ip_hash == ip_hash, Feedback.created_at >= since)
+        )
+        return result.scalar_one() or 0
+
+    async def list_recent(self, limit: int = 100) -> list[Feedback]:
+        """List most recent entries first — for admin/triage tooling."""
+        result = await self.session.execute(select(Feedback).order_by(Feedback.created_at.desc()).limit(limit))
+        return list(result.scalars().all())

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -138,8 +138,8 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `map_node_click` | `spec` | MapPage.tsx | User clicks a node on `/map` (or, on touch, second tap on an already-pinned node) to navigate to its spec detail. |
 | `map_node_pin` | `spec` | MapPage.tsx | Touch device only: first tap on a node opens the preview panel + pin marker without navigating. A second tap on the same node fires `map_node_click` and navigates. |
 | `map_search_select` | `spec` | MapPage.tsx | User picks a result from the `/map` search dropdown (`⌘K` / `Ctrl+K` opens it). The camera flies to the node and the preview panel opens. |
-| `feedback_opened` | `path` | FeedbackWidget.tsx | User opens the floating in-app feedback widget (issue #5662). `path` is `window.location.pathname + search` at open time. |
-| `feedback_submitted` | `path`, `reaction`?, `has_email`, `spec_id`? | FeedbackWidget.tsx | User submits the feedback form. `reaction` ∈ `thumbs_up`, `thumbs_down`, `bug`, `idea`, `heart` (omitted if none selected). `has_email` is `"true"`/`"false"`. `spec_id` is set when the current route resolves to a spec page. |
+| `feedback_opened` | `path` | FeedbackWidget.tsx | User clicks the floating feedback FAB and the quick mini-stack of 👍 / 👎 / 💬 appears (issue #5662). `path` is `window.location.pathname + search` at open time. |
+| `feedback_submitted` | `path`, `reaction`?, `has_contact`, `spec_id`?, `mode` | FeedbackWidget.tsx | User submits a feedback entry. `reaction` ∈ `thumbs_up`, `thumbs_down`, `bug`, `idea` (omitted if none selected). `mode` is `"quick"` for a one-tap 👍/👎 from the mini-stack, `"full"` for a submit from the detailed dialog. `has_contact` is `"true"`/`"false"` — the contact field is now a free-form name/email/handle, not strictly an email. `spec_id` is set when the current route resolves to a spec page. |
 
 ### Landing Page Navigation (`nav_click`)
 

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -138,6 +138,8 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `map_node_click` | `spec` | MapPage.tsx | User clicks a node on `/map` (or, on touch, second tap on an already-pinned node) to navigate to its spec detail. |
 | `map_node_pin` | `spec` | MapPage.tsx | Touch device only: first tap on a node opens the preview panel + pin marker without navigating. A second tap on the same node fires `map_node_click` and navigates. |
 | `map_search_select` | `spec` | MapPage.tsx | User picks a result from the `/map` search dropdown (`⌘K` / `Ctrl+K` opens it). The camera flies to the node and the preview panel opens. |
+| `feedback_opened` | `path` | FeedbackWidget.tsx | User opens the floating in-app feedback widget (issue #5662). `path` is `window.location.pathname + search` at open time. |
+| `feedback_submitted` | `path`, `reaction`?, `has_email`, `spec_id`? | FeedbackWidget.tsx | User submits the feedback form. `reaction` ∈ `thumbs_up`, `thumbs_down`, `bug`, `idea`, `heart` (omitted if none selected). `has_email` is `"true"`/`"false"`. `spec_id` is set when the current route resolves to a spec page. |
 
 ### Landing Page Navigation (`nav_click`)
 

--- a/tests/integration/api/test_api_endpoints.py
+++ b/tests/integration/api/test_api_endpoints.py
@@ -240,3 +240,96 @@ class TestHealthEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert data["message"] == "Hello, World!"
+
+
+class TestFeedbackEndpoint:
+    """Integration tests for POST /feedback (issue #5662)."""
+
+    async def test_submit_minimal(self, client, test_db_with_data):
+        """Should accept a minimal feedback entry and persist it."""
+        response = await client.post("/feedback", json={"message": "Looks great!"})
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+        from sqlalchemy import select
+
+        from core.database.models import Feedback
+
+        result = await test_db_with_data.execute(select(Feedback))
+        rows = list(result.scalars().all())
+        assert len(rows) == 1
+        assert rows[0].message == "Looks great!"
+        assert rows[0].reaction is None
+
+    async def test_submit_with_context(self, client, test_db_with_data):
+        """Should persist all optional context fields."""
+        payload = {
+            "message": "Bug on mobile",
+            "reaction": "bug",
+            "email": "user@example.com",
+            "path": "/scatter-basic",
+            "spec_id": "scatter-basic",
+            "viewport": "375x812",
+            "session_id": "abc-123",
+        }
+        response = await client.post("/feedback", json=payload)
+
+        assert response.status_code == 200
+
+        from sqlalchemy import select
+
+        from core.database.models import Feedback
+
+        result = await test_db_with_data.execute(select(Feedback))
+        row = result.scalars().one()
+        assert row.message == "Bug on mobile"
+        assert row.reaction == "bug"
+        assert row.email == "user@example.com"
+        assert row.spec_id == "scatter-basic"
+        assert row.viewport == "375x812"
+        assert row.session_id == "abc-123"
+
+    async def test_honeypot_silently_dropped(self, client, test_db_with_data):
+        """Should return 200 but write nothing when the honeypot field is filled."""
+        response = await client.post("/feedback", json={"message": "spam", "website": "http://spam.example"})
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+        from sqlalchemy import select
+
+        from core.database.models import Feedback
+
+        result = await test_db_with_data.execute(select(Feedback))
+        assert list(result.scalars().all()) == []
+
+    async def test_empty_message_rejected(self, client):
+        """Should reject whitespace-only message with 400."""
+        response = await client.post("/feedback", json={"message": "   "})
+        assert response.status_code == 400
+
+    async def test_message_too_long_rejected(self, client):
+        """Should reject messages over 500 chars with 400."""
+        response = await client.post("/feedback", json={"message": "x" * 501})
+        assert response.status_code == 400
+
+    async def test_invalid_reaction_rejected(self, client):
+        """Should reject reactions outside the allow-list with 400."""
+        response = await client.post("/feedback", json={"message": "hello", "reaction": "fire"})
+        assert response.status_code == 400
+
+    async def test_invalid_email_rejected(self, client):
+        """Should reject obviously malformed emails with 400."""
+        response = await client.post("/feedback", json={"message": "hello", "email": "not-an-email"})
+        assert response.status_code == 400
+
+    async def test_rate_limit_triggers_after_threshold(self, client):
+        """Should return 429 once a single IP exceeds the per-minute limit."""
+        headers = {"x-forwarded-for": "203.0.113.42"}
+        for _ in range(5):
+            ok = await client.post("/feedback", json={"message": "spam"}, headers=headers)
+            assert ok.status_code == 200
+
+        blocked = await client.post("/feedback", json={"message": "spam"}, headers=headers)
+        assert blocked.status_code == 429

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -368,10 +368,10 @@ class TestFeedbackRepository:
         """Should persist an entry and return it via list_recent."""
         repo = FeedbackRepository(test_session)
 
-        entry = await repo.create({"message": "Hello", "reaction": "heart", "ip_hash": "deadbeef"})
+        entry = await repo.create({"message": "Hello", "reaction": "thumbs_up", "ip_hash": "deadbeef"})
         assert entry.id is not None
         assert entry.message == "Hello"
-        assert entry.reaction == "heart"
+        assert entry.reaction == "thumbs_up"
 
         recent = await repo.list_recent()
         assert len(recent) == 1

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -7,7 +7,7 @@ Tests Repository layer interaction with database (no HTTP layer).
 
 import pytest
 
-from core.database.repositories import ImplRepository, LibraryRepository, SpecRepository
+from core.database.repositories import FeedbackRepository, ImplRepository, LibraryRepository, SpecRepository
 
 
 pytestmark = pytest.mark.integration
@@ -359,3 +359,35 @@ class TestImplRepository:
         assert impl.spec_id == "scatter-basic"
         assert impl.library_id == "matplotlib"
         assert impl.quality_score == 98.0
+
+
+class TestFeedbackRepository:
+    """Integration tests for FeedbackRepository (issue #5662)."""
+
+    async def test_create_and_list_recent(self, test_session):
+        """Should persist an entry and return it via list_recent."""
+        repo = FeedbackRepository(test_session)
+
+        entry = await repo.create({"message": "Hello", "reaction": "heart", "ip_hash": "deadbeef"})
+        assert entry.id is not None
+        assert entry.message == "Hello"
+        assert entry.reaction == "heart"
+
+        recent = await repo.list_recent()
+        assert len(recent) == 1
+        assert recent[0].id == entry.id
+
+    async def test_count_recent_by_ip(self, test_session):
+        """Should count entries within the time window per ip_hash."""
+        from datetime import datetime, timedelta, timezone
+
+        repo = FeedbackRepository(test_session)
+
+        await repo.create({"message": "one", "ip_hash": "aaa"})
+        await repo.create({"message": "two", "ip_hash": "aaa"})
+        await repo.create({"message": "three", "ip_hash": "bbb"})
+
+        since = datetime.now(timezone.utc) - timedelta(minutes=1)
+        assert await repo.count_recent_by_ip("aaa", since) == 2
+        assert await repo.count_recent_by_ip("bbb", since) == 1
+        assert await repo.count_recent_by_ip("ccc", since) == 0

--- a/tests/unit/api/test_debug.py
+++ b/tests/unit/api/test_debug.py
@@ -639,3 +639,108 @@ class TestAdminAllowedEmailsParsing:
 
         s = Settings()
         assert s.admin_allowed_emails == []
+
+
+class TestFeedbackDebugEndpoints:
+    """Coverage for /debug/feedback/* — analytics + triage (issue #5662 follow-up)."""
+
+    def test_top_pages_rejects_invalid_reaction(self, db_client) -> None:
+        client, _ = db_client
+        response = client.get("/debug/feedback/top?reaction=fire")
+        assert response.status_code == 400
+
+    def test_top_pages_rejects_out_of_range_limit(self, db_client) -> None:
+        client, _ = db_client
+        response = client.get("/debug/feedback/top?reaction=thumbs_up&limit=999")
+        assert response.status_code == 400
+
+    def test_top_pages_returns_grouped_counts(self, db_client) -> None:
+        client, _ = db_client
+        repo = MagicMock()
+        repo.top_paths_by_reaction = AsyncMock(
+            return_value=[
+                {"path": "/scatter-basic", "count": 7, "last_seen": "2026-05-18T12:00:00"},
+                {"path": "/heatmap-basic", "count": 3, "last_seen": "2026-05-17T08:30:00"},
+            ]
+        )
+        with patch("api.routers.debug.FeedbackRepository", return_value=repo):
+            response = client.get("/debug/feedback/top?reaction=thumbs_up&limit=5")
+        assert response.status_code == 200
+        body = response.json()
+        assert [entry["path"] for entry in body] == ["/scatter-basic", "/heatmap-basic"]
+        assert body[0]["count"] == 7
+        repo.top_paths_by_reaction.assert_awaited_once_with("thumbs_up", 5)
+
+    def test_messages_filters_by_status(self, db_client) -> None:
+        client, _ = db_client
+        entry = MagicMock()
+        entry.id = "abc-123"
+        entry.message = "broken plot"
+        entry.reaction = "bug"
+        entry.contact = None
+        entry.path = "/scatter-basic"
+        entry.spec_id = "scatter-basic"
+        entry.viewport = "1920x1080"
+        entry.status = "new"
+        entry.created_at = datetime(2026, 5, 18, 12, 0, 0)
+
+        repo = MagicMock()
+        repo.list_with_message = AsyncMock(return_value=[entry])
+        with patch("api.routers.debug.FeedbackRepository", return_value=repo):
+            response = client.get("/debug/feedback/messages?status=new&limit=10")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["status"] == "new"
+        assert body[0]["message"] == "broken plot"
+        repo.list_with_message.assert_awaited_once_with("new", 10)
+
+    def test_messages_rejects_invalid_status(self, db_client) -> None:
+        client, _ = db_client
+        response = client.get("/debug/feedback/messages?status=archived")
+        assert response.status_code == 400
+
+    def test_messages_open_maps_to_new_and_in_progress(self, db_client) -> None:
+        """`status=open` is the default debug-page filter — server-side pseudo
+        value that expands to ('new', 'in_progress')."""
+        client, _ = db_client
+        repo = MagicMock()
+        repo.list_with_message = AsyncMock(return_value=[])
+        with patch("api.routers.debug.FeedbackRepository", return_value=repo):
+            response = client.get("/debug/feedback/messages?status=open&limit=10")
+        assert response.status_code == 200
+        repo.list_with_message.assert_awaited_once_with(("new", "in_progress"), 10)
+
+    def test_patch_status_happy_path(self, db_client) -> None:
+        client, _ = db_client
+        updated = MagicMock()
+        updated.id = "abc-123"
+        updated.message = "broken plot"
+        updated.reaction = "bug"
+        updated.contact = None
+        updated.path = "/scatter-basic"
+        updated.spec_id = "scatter-basic"
+        updated.viewport = None
+        updated.status = "done"
+        updated.created_at = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+        repo = MagicMock()
+        repo.update_status = AsyncMock(return_value=updated)
+        with patch("api.routers.debug.FeedbackRepository", return_value=repo):
+            response = client.patch("/debug/feedback/abc-123", json={"status": "done"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "done"
+        repo.update_status.assert_awaited_once_with("abc-123", "done")
+
+    def test_patch_status_rejects_unknown_value(self, db_client) -> None:
+        client, _ = db_client
+        response = client.patch("/debug/feedback/abc-123", json={"status": "archived"})
+        assert response.status_code == 400
+
+    def test_patch_status_returns_404_when_missing(self, db_client) -> None:
+        client, _ = db_client
+        repo = MagicMock()
+        repo.update_status = AsyncMock(return_value=None)
+        with patch("api.routers.debug.FeedbackRepository", return_value=repo):
+            response = client.patch("/debug/feedback/unknown", json={"status": "done"})
+        assert response.status_code == 404

--- a/tests/unit/api/test_feedback_router.py
+++ b/tests/unit/api/test_feedback_router.py
@@ -81,8 +81,7 @@ class TestFeedbackRouter:
         """Messages with 2+ URLs return 200 but never reach the repository."""
         with patch("api.routers.feedback.FeedbackRepository") as repo_cls:
             response = client.post(
-                "/feedback",
-                json={"message": "check https://buy.example and https://promo.example now"},
+                "/feedback", json={"message": "check https://buy.example and https://promo.example now"}
             )
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
@@ -96,10 +95,7 @@ class TestFeedbackRouter:
         instance.create = AsyncMock(return_value=None)
 
         with patch("api.routers.feedback.FeedbackRepository", return_value=instance):
-            response = client.post(
-                "/feedback",
-                json={"message": "spam", "session_id": "abc"},
-            )
+            response = client.post("/feedback", json={"message": "spam", "session_id": "abc"})
 
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}

--- a/tests/unit/api/test_feedback_router.py
+++ b/tests/unit/api/test_feedback_router.py
@@ -49,9 +49,25 @@ class TestFeedbackRouter:
         assert response.json() == {"status": "ok"}
         repo_cls.assert_not_called()
 
-    def test_empty_message_returns_400(self, client):
+    def test_empty_message_and_no_reaction_returns_400(self, client):
         response = client.post("/feedback", json={"message": "   "})
         assert response.status_code == 400
+
+    def test_reaction_only_is_accepted(self, client):
+        """Submitting just a reaction (no message) is allowed."""
+        instance = AsyncMock()
+        instance.count_recent_by_ip = AsyncMock(return_value=0)
+        instance.has_recent_duplicate = AsyncMock(return_value=False)
+        instance.create = AsyncMock(return_value=None)
+
+        with patch("api.routers.feedback.FeedbackRepository", return_value=instance):
+            response = client.post("/feedback", json={"reaction": "thumbs_up"})
+
+        assert response.status_code == 200
+        instance.create.assert_awaited_once()
+        kwargs = instance.create.await_args.args[0]
+        assert kwargs["message"] is None
+        assert kwargs["reaction"] == "thumbs_up"
 
     def test_message_over_500_chars_returns_400(self, client):
         response = client.post("/feedback", json={"message": "x" * 501})
@@ -61,14 +77,44 @@ class TestFeedbackRouter:
         response = client.post("/feedback", json={"message": "hello", "reaction": "fire"})
         assert response.status_code == 400
 
-    def test_invalid_email_returns_400(self, client):
-        response = client.post("/feedback", json={"message": "hello", "email": "no-at-symbol"})
+    def test_link_stuffing_message_is_silently_dropped(self, client):
+        """Messages with 2+ URLs return 200 but never reach the repository."""
+        with patch("api.routers.feedback.FeedbackRepository") as repo_cls:
+            response = client.post(
+                "/feedback",
+                json={"message": "check https://buy.example and https://promo.example now"},
+            )
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        repo_cls.assert_not_called()
+
+    def test_duplicate_message_is_silently_dropped(self, client):
+        """Same message from the same session within the lookback window is suppressed."""
+        instance = AsyncMock()
+        instance.count_recent_by_ip = AsyncMock(return_value=0)
+        instance.has_recent_duplicate = AsyncMock(return_value=True)
+        instance.create = AsyncMock(return_value=None)
+
+        with patch("api.routers.feedback.FeedbackRepository", return_value=instance):
+            response = client.post(
+                "/feedback",
+                json={"message": "spam", "session_id": "abc"},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        instance.create.assert_not_awaited()
+
+    def test_heart_reaction_is_now_rejected(self, client):
+        """`heart` was removed from the allow-list — it should 400 now."""
+        response = client.post("/feedback", json={"message": "hi", "reaction": "heart"})
         assert response.status_code == 400
 
     def test_happy_path_calls_repo_create(self, client):
         """Valid payload should sanitize fields and forward them to FeedbackRepository.create."""
         instance = AsyncMock()
         instance.count_recent_by_ip = AsyncMock(return_value=0)
+        instance.has_recent_duplicate = AsyncMock(return_value=False)
         instance.create = AsyncMock(return_value=None)
 
         with patch("api.routers.feedback.FeedbackRepository", return_value=instance):
@@ -76,8 +122,8 @@ class TestFeedbackRouter:
                 "/feedback",
                 json={
                     "message": "  Looks great!  ",
-                    "reaction": "heart",
-                    "email": "user@example.com",
+                    "reaction": "thumbs_up",
+                    "contact": "  @someone  ",
                     "path": "/scatter-basic",
                     "spec_id": "scatter-basic",
                     "viewport": "1920x1080",
@@ -91,8 +137,8 @@ class TestFeedbackRouter:
         instance.create.assert_awaited_once()
         kwargs = instance.create.await_args.args[0]
         assert kwargs["message"] == "Looks great!"  # trimmed
-        assert kwargs["reaction"] == "heart"
-        assert kwargs["email"] == "user@example.com"
+        assert kwargs["reaction"] == "thumbs_up"
+        assert kwargs["contact"] == "@someone"  # trimmed
         assert kwargs["spec_id"] == "scatter-basic"
         assert kwargs["ip_hash"]  # sha256 hex, not raw IP
         assert "198.51.100.7" not in kwargs["ip_hash"]

--- a/tests/unit/api/test_feedback_router.py
+++ b/tests/unit/api/test_feedback_router.py
@@ -1,0 +1,110 @@
+"""Unit tests for the /feedback router (issue #5662).
+
+Uses dependency overrides + mock repository to exercise guard logic in isolation
+from the database. Integration coverage (real persistence, rate limiting against
+SQLite) lives in tests/integration/api/test_api_endpoints.py.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.cache import clear_cache
+from api.main import app, fastapi_app
+from core.database import get_db
+
+
+DB_CONFIG_PATCH = "api.dependencies.is_db_configured"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_cache()
+
+
+@pytest.fixture
+def client():
+    """TestClient with a mocked DB session injected via dependency_overrides."""
+    mock_session = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_session
+
+    fastapi_app.dependency_overrides[get_db] = mock_get_db
+
+    with patch(DB_CONFIG_PATCH, return_value=True):
+        yield TestClient(app)
+
+    fastapi_app.dependency_overrides.clear()
+
+
+class TestFeedbackRouter:
+    def test_honeypot_returns_ok_without_persisting(self, client):
+        """Should silently 200 when the hidden honeypot field is populated, and never touch the repo."""
+        with patch("api.routers.feedback.FeedbackRepository") as repo_cls:
+            response = client.post("/feedback", json={"message": "spam", "website": "http://evil.example"})
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        repo_cls.assert_not_called()
+
+    def test_empty_message_returns_400(self, client):
+        response = client.post("/feedback", json={"message": "   "})
+        assert response.status_code == 400
+
+    def test_message_over_500_chars_returns_400(self, client):
+        response = client.post("/feedback", json={"message": "x" * 501})
+        assert response.status_code == 400
+
+    def test_invalid_reaction_returns_400(self, client):
+        response = client.post("/feedback", json={"message": "hello", "reaction": "fire"})
+        assert response.status_code == 400
+
+    def test_invalid_email_returns_400(self, client):
+        response = client.post("/feedback", json={"message": "hello", "email": "no-at-symbol"})
+        assert response.status_code == 400
+
+    def test_happy_path_calls_repo_create(self, client):
+        """Valid payload should sanitize fields and forward them to FeedbackRepository.create."""
+        instance = AsyncMock()
+        instance.count_recent_by_ip = AsyncMock(return_value=0)
+        instance.create = AsyncMock(return_value=None)
+
+        with patch("api.routers.feedback.FeedbackRepository", return_value=instance):
+            response = client.post(
+                "/feedback",
+                json={
+                    "message": "  Looks great!  ",
+                    "reaction": "heart",
+                    "email": "user@example.com",
+                    "path": "/scatter-basic",
+                    "spec_id": "scatter-basic",
+                    "viewport": "1920x1080",
+                    "session_id": "abc-123",
+                },
+                headers={"x-forwarded-for": "198.51.100.7"},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        instance.create.assert_awaited_once()
+        kwargs = instance.create.await_args.args[0]
+        assert kwargs["message"] == "Looks great!"  # trimmed
+        assert kwargs["reaction"] == "heart"
+        assert kwargs["email"] == "user@example.com"
+        assert kwargs["spec_id"] == "scatter-basic"
+        assert kwargs["ip_hash"]  # sha256 hex, not raw IP
+        assert "198.51.100.7" not in kwargs["ip_hash"]
+
+    def test_rate_limit_returns_429(self, client):
+        """Should return 429 when the rate-limit query reports too many recent entries."""
+        instance = AsyncMock()
+        instance.count_recent_by_ip = AsyncMock(return_value=5)
+        instance.create = AsyncMock(return_value=None)
+
+        with patch("api.routers.feedback.FeedbackRepository", return_value=instance):
+            response = client.post("/feedback", json={"message": "hi"}, headers={"x-forwarded-for": "198.51.100.8"})
+
+        assert response.status_code == 429
+        instance.create.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Add a global floating Feedback button (FAB, bottom-right) wired into `RootLayout`. Clicking opens a compact popover with a 500-char message field, optional reaction (👍 👎 🐛 💡 ❤️), optional email, and a "Send" button. After submit users see a "Thanks!" state that auto-closes.
- New backend route `POST /feedback` persists entries to a new `feedback` table via `FeedbackRepository`. Guards: honeypot field, message length cap, reaction allow-list, per-IP rate limit (5/min using a SHA-256 IP hash).
- Add Plausible events `feedback_opened` and `feedback_submitted` via the existing `useAnalytics` hook; documented in `docs/reference/plausible.md`.

Resolves the three open questions in the issue:
- **Where**: global (visible on every page).
- **Persistence/triage**: dedicated DB table, manual triage. No auto-issue and no Slack/Discord webhook in this PR.
- **Analytics**: yes — open + submit fire Plausible events.

## Files

- Backend: `core/database/models.py` (`Feedback` model + `FEEDBACK_REACTIONS`), `core/database/repositories.py` (`FeedbackRepository`), `core/database/__init__.py` (exports), `alembic/versions/c5d7e9f1a3b2_add_feedback_table.py` (new migration off the current head `3a7e1b5c0c4f`), `api/schemas.py` (`FeedbackRequest`/`Response`), `api/routers/feedback.py`, `api/routers/__init__.py`, `api/main.py`.
- Frontend: `app/src/components/FeedbackWidget.tsx`, `app/src/components/RootLayout.tsx` (mounts widget).
- Tests: unit `tests/unit/api/test_feedback_router.py` (7), integration `tests/integration/api/test_api_endpoints.py::TestFeedbackEndpoint` (8) and `tests/integration/test_repositories.py::TestFeedbackRepository` (2), frontend `app/src/components/FeedbackWidget.test.tsx` (6).
- Docs: `docs/reference/plausible.md` adds the two new events.

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run pytest tests/unit tests/integration` — 1505 passed
- [x] `yarn tsc --noEmit` (clean)
- [x] `yarn test` — 465 passed across 53 files
- [ ] Manual smoke (against a deployed env): open the FAB, send feedback, verify a row lands in the `feedback` table; trigger 6 submissions in a row from one IP and confirm the 6th returns 429; verify the honeypot path doesn't write.
- [ ] Run the alembic migration round-trip against Postgres before the first deploy (`alembic upgrade head` then `downgrade -1` then `upgrade head`).

https://claude.ai/code/session_01D5QExULwc4wAGZyHeTiC89

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5QExULwc4wAGZyHeTiC89)_