### PR TITLE
fix(analytics): track /plots?lang= in Plausible + missing test coverage

### DIFF
--- a/app/src/components/LibrariesSection.tsx
+++ b/app/src/components/LibrariesSection.tsx
@@ -16,10 +16,11 @@ export function LibrariesSection({
   onLibraryClick,
   widthTier = 'paper',
 }: LibrariesSectionProps) {
-  // Use known library order, with counts from stats if available
+  // Use known library order; surface the language so LibraryCard can render
+  // the corner chip. (Counts are not currently piped through this section.)
   const libList = LIBRARIES.map(name => {
     const info = libraries.find(l => l.id === name);
-    return { name, language: info?.language, count: info ? undefined : undefined }; // counts come from API if available
+    return { name, language: info?.language };
   });
 
   const maxWidth = widthTier === 'catalog' ? 'var(--max-catalog)' : 'var(--max)';

--- a/app/src/hooks/useAnalytics.test.ts
+++ b/app/src/hooks/useAnalytics.test.ts
@@ -169,6 +169,50 @@ describe('useAnalytics', () => {
       // The call should have gone through with buildPlausibleUrl(), not the invalid URL
       expect(window.plausible).toHaveBeenCalled();
     });
+
+    it('converts ?lang=python on /plots to a /lang/python path segment for Plausible', () => {
+      // `/plots` is a reserved top-level route so the path prefix is stripped
+      // and filter segments are appended directly to the domain — matching
+      // how the other `/plots?lib=…` filters are already tracked.
+      Object.defineProperty(window, 'location', {
+        value: { ...originalLocation, hostname: 'anyplot.ai', pathname: '/plots', search: '?lang=python' },
+        writable: true,
+        configurable: true,
+      });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackPageview();
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('pageview', {
+        url: 'https://anyplot.ai/lang/python',
+      });
+    });
+
+    it('converts ?language=python on a spec hub to a /{spec}/language/python path segment', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...originalLocation,
+          hostname: 'anyplot.ai',
+          pathname: '/biplot-pca',
+          search: '?language=python',
+        },
+        writable: true,
+        configurable: true,
+      });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackPageview();
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('pageview', {
+        url: 'https://anyplot.ai/biplot-pca/language/python',
+      });
+    });
   });
 
   describe('ambient props', () => {

--- a/app/src/hooks/useAnalytics.ts
+++ b/app/src/hooks/useAnalytics.ts
@@ -53,10 +53,13 @@ function buildPlausibleUrl(): string {
     parts.length > 0 && !RESERVED_TOP_LEVEL.has(parts[0]) ? `/${parts.join("/")}` : "";
 
   // Definierte Reihenfolge der Filter-Kategorien (inkl. impl-level tags).
-  // `language` is included so the hub's ?language= filter is tracked as a
-  // distinct pageview path (/{spec}/language/python), matching the path-segment
-  // convention used for all other filter params.
+  // - `language` covers the spec-hub carousel scope (`/{spec}?language=python`)
+  //   that pre-dates the FilterBar lang category.
+  // - `lang` covers the new FilterBar category on `/plots?lang=python` —
+  //   without it, the lang filter would never show up as a distinct pageview
+  //   path in Plausible.
   const orderedKeys = [
+    "lang",
     "lib",
     "spec",
     "plot",

--- a/app/src/utils/filters-extended.test.ts
+++ b/app/src/utils/filters-extended.test.ts
@@ -7,6 +7,7 @@ import {
 import type { FilterCounts, ActiveFilters } from '../types';
 
 const mockFilterCounts: FilterCounts = {
+  lang: { python: 28, r: 0 },
   lib: { matplotlib: 10, seaborn: 8, plotly: 7, bokeh: 3 },
   spec: { 'scatter-basic': 5, 'heatmap-correlation': 4 },
   plot: { scatter: 8, heatmap: 4, bar: 6 },

--- a/app/src/utils/filters.test.ts
+++ b/app/src/utils/filters.test.ts
@@ -4,6 +4,7 @@ import type { FilterCounts, ActiveFilters } from '../types';
 
 describe('getSearchResults', () => {
   const mockFilterCounts: FilterCounts = {
+    lang: { python: 25, r: 0 },
     spec: {
       'scatter-basic': 5,
       'scatter-color-mapped': 3,

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -131,6 +131,19 @@ def mock_lib():
     return mock_lib
 
 
+@pytest.fixture
+def mock_lang():
+    """Create a mock language row (Python)."""
+    mock_lang = MagicMock()
+    mock_lang.id = "python"
+    mock_lang.name = "Python"
+    mock_lang.file_extension = ".py"
+    mock_lang.runtime_version = "3.13"
+    mock_lang.documentation_url = "https://www.python.org"
+    mock_lang.description = "General-purpose programming language."
+    return mock_lang
+
+
 class TestStatsRouter:
     """Tests for stats router."""
 
@@ -184,6 +197,58 @@ class TestStatsRouter:
             data = response.json()
             assert data["specs"] == 5
             assert data["plots"] == 10
+
+
+class TestLanguagesRouter:
+    """Tests for languages router."""
+
+    def test_languages_without_db(self, client: TestClient) -> None:
+        """Languages should return seed data when DB not configured."""
+        with patch(DB_CONFIG_PATCH, return_value=False):
+            response = client.get("/languages")
+            assert response.status_code == 200
+            data = response.json()
+            assert "languages" in data
+            ids = {lang["id"] for lang in data["languages"]}
+            # SUPPORTED_LANGUAGES = {"python", "r"} — both must surface
+            assert {"python", "r"}.issubset(ids)
+
+    def test_languages_with_db(self, db_client, mock_lang) -> None:
+        """Languages should return data from DB when configured."""
+        client, _ = db_client
+
+        mock_lang_repo = MagicMock()
+        mock_lang_repo.get_all = AsyncMock(return_value=[mock_lang])
+
+        with (
+            patch("api.routers.languages.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.languages.LanguageRepository", return_value=mock_lang_repo),
+        ):
+            response = client.get("/languages")
+            assert response.status_code == 200
+            data = response.json()
+            assert "languages" in data
+            assert len(data["languages"]) == 1
+            lang = data["languages"][0]
+            assert lang["id"] == "python"
+            assert lang["documentation_url"] == "https://www.python.org"
+            assert lang["runtime_version"] == "3.13"
+            assert lang["description"] == "General-purpose programming language."
+
+    def test_languages_cache_hit(self, db_client) -> None:
+        """Languages should return cached data when available."""
+        client, _ = db_client
+
+        cached_data = {"languages": [{"id": "cached_lang", "name": "Cached"}]}
+
+        async def _return_cached(key, factory, **kwargs):
+            return cached_data
+
+        with patch("api.routers.languages.get_or_set_cache", side_effect=_return_cached):
+            response = client.get("/languages")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["languages"][0]["id"] == "cached_lang"
 
 
 class TestLibrariesRouter:
@@ -1014,6 +1079,42 @@ class TestPlotsRouter:
             assert response.status_code == 200
             data = response.json()
             assert data["total"] == 1
+
+    def test_filter_with_lang_param_includes_python(self, client: TestClient, mock_spec) -> None:
+        """`?lang=python` should pass through the filter dispatch and surface in the counts."""
+        mock_spec_repo = MagicMock()
+        mock_spec_repo.get_all = AsyncMock(return_value=[mock_spec])
+
+        with (
+            patch(DB_CONFIG_PATCH, return_value=True),
+            patch("api.routers.plots.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.plots.SpecRepository", return_value=mock_spec_repo),
+        ):
+            response = client.get("/plots/filter?lang=python")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 1
+            # The lang category is populated in the counts dict so the
+            # frontend FilterBar can render it as a chip.
+            assert "lang" in data["globalCounts"]
+            assert data["globalCounts"]["lang"].get("python") == 1
+
+    def test_filter_with_lang_param_excludes_other_languages(self, client: TestClient, mock_spec) -> None:
+        """`?lang=r` against a Python-only impl should yield zero matches but still report counts."""
+        mock_spec_repo = MagicMock()
+        mock_spec_repo.get_all = AsyncMock(return_value=[mock_spec])
+
+        with (
+            patch(DB_CONFIG_PATCH, return_value=True),
+            patch("api.routers.plots.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.plots.SpecRepository", return_value=mock_spec_repo),
+        ):
+            response = client.get("/plots/filter?lang=r")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["total"] == 0
+            # globalCounts still reports the one Python impl under lang=python
+            assert data["globalCounts"]["lang"].get("python") == 1
 
     def test_filter_cached(self, client: TestClient) -> None:
         """Filter should return cached response when available."""

--- a/tests/unit/core/database/test_repositories.py
+++ b/tests/unit/core/database/test_repositories.py
@@ -10,9 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from core.database.models import Library, Spec
 from core.database.repositories import (
     IMPL_UPDATABLE_FIELDS,
+    LANGUAGE_UPDATABLE_FIELDS,
     LIBRARY_UPDATABLE_FIELDS,
     SPEC_UPDATABLE_FIELDS,
     ImplRepository,
+    LanguageRepository,
     LibraryRepository,
     SpecRepository,
 )
@@ -36,6 +38,14 @@ class TestUpdatableFieldConstants:
         assert "name" in LIBRARY_UPDATABLE_FIELDS
         assert "version" in LIBRARY_UPDATABLE_FIELDS
         assert "id" not in LIBRARY_UPDATABLE_FIELDS
+
+    def test_language_fields(self) -> None:
+        assert "name" in LANGUAGE_UPDATABLE_FIELDS
+        assert "file_extension" in LANGUAGE_UPDATABLE_FIELDS
+        assert "runtime_version" in LANGUAGE_UPDATABLE_FIELDS
+        assert "documentation_url" in LANGUAGE_UPDATABLE_FIELDS
+        assert "description" in LANGUAGE_UPDATABLE_FIELDS
+        assert "id" not in LANGUAGE_UPDATABLE_FIELDS
 
     def test_impl_fields_includes_review(self) -> None:
         assert "quality_score" in IMPL_UPDATABLE_FIELDS
@@ -176,6 +186,52 @@ class TestLibraryRepository:
     @pytest.mark.asyncio
     async def test_upsert_without_id_raises(self, test_session: AsyncSession) -> None:
         repo = LibraryRepository(test_session)
+        with pytest.raises(ValueError, match="must include 'id'"):
+            await repo.upsert({"name": "No ID"})
+
+
+class TestLanguageRepository:
+    """Tests for LanguageRepository."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_get_all_ordered_by_name(self, test_session: AsyncSession) -> None:
+        repo = LanguageRepository(test_session)
+        await repo.create({"id": "python", "name": "Python", "file_extension": ".py"})
+        await repo.create({"id": "r", "name": "R", "file_extension": ".R"})
+
+        langs = await repo.get_all()
+        assert [lang.id for lang in langs] == ["python", "r"]
+
+    @pytest.mark.asyncio
+    async def test_upsert_creates_with_all_fields(self, test_session: AsyncSession) -> None:
+        repo = LanguageRepository(test_session)
+        lang = await repo.upsert(
+            {
+                "id": "python",
+                "name": "Python",
+                "file_extension": ".py",
+                "runtime_version": "3.13",
+                "documentation_url": "https://www.python.org",
+                "description": "General-purpose language.",
+            }
+        )
+        assert lang.id == "python"
+        assert lang.runtime_version == "3.13"
+        assert lang.documentation_url == "https://www.python.org"
+
+    @pytest.mark.asyncio
+    async def test_upsert_updates_existing(self, test_session: AsyncSession) -> None:
+        repo = LanguageRepository(test_session)
+        await repo.create({"id": "python", "name": "Python", "file_extension": ".py", "runtime_version": "3.12"})
+        updated = await repo.upsert(
+            {"id": "python", "name": "Python", "runtime_version": "3.13", "description": "Updated."}
+        )
+        assert updated.runtime_version == "3.13"
+        assert updated.description == "Updated."
+
+    @pytest.mark.asyncio
+    async def test_upsert_without_id_raises(self, test_session: AsyncSession) -> None:
+        repo = LanguageRepository(test_session)
         with pytest.raises(ValueError, match="must include 'id'"):
             await repo.upsert({"name": "No ID"})
 


### PR DESCRIPTION
## Summary

Follow-up to #7142, which merged before this commit landed on the branch. Addresses Copilot's second-pass review on that PR.

The headline fix is **analytics** — `/plots?lang=python` was falling through `buildPlausibleUrl` and was never recorded as a Plausible pageview (only `?language=` on spec hubs was wired up).

## Changes

- **`app/src/hooks/useAnalytics.ts`** — `lang` added to `orderedKeys` so the new FilterBar `lang` filter on `/plots` is converted into a path segment (`/lang/python`) the same way every other filter category is. Two new tests in `useAnalytics.test.ts` pin both `?lang=` and `?language=` conversions.
- **`app/src/utils/filters.test.ts` + `filters-extended.test.ts`** — added the now-required `lang` key to the `FilterCounts` mock fixtures (since `lang` was added to the `FilterCategory` union).
- **`app/src/components/LibrariesSection.tsx`** — dropped the dead `count: info ? undefined : undefined` ternary and stale comment.
- **`tests/unit/core/database/test_repositories.py`** — new `TestLanguageRepository` mirroring `TestLibraryRepository` (ordered `get_all`, upsert-creates, upsert-updates, raises on missing id) and a `LANGUAGE_UPDATABLE_FIELDS` assertion.
- **`tests/unit/api/test_routers.py`** — new `TestLanguagesRouter` (no-DB seed fallback, DB-backed serialize, cache hit) and two new `TestPlotsRouter` cases pinning `/plots/filter?lang=python` and `/plots/filter?lang=r` behavior through the public HTTP path.

No production behavior change other than the analytics bug fix; everything else is test-coverage hygiene that Copilot flagged as missing on #7142.

## Test plan

- [x] `cd app && yarn type-check` clean
- [x] `cd app && yarn test --run` (45 in touched files; full suite green)
- [x] `uv run pytest tests/unit/api/ tests/unit/core/database/` (170 pass)
- [x] `uv run ruff check . && ruff format --check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)