### PR TITLE
fix(seo): lowercase language in plot page title

### DIFF
--- a/app/src/pages/SpecPage.test.tsx
+++ b/app/src/pages/SpecPage.test.tsx
@@ -183,7 +183,7 @@ describe('SpecPage', () => {
     expect(fetchUrl).toContain('/specs/scatter-basic');
   });
 
-  describe('language in title + breadcrumb', () => {
+  describe('language in document title', () => {
     it('includes ` · python · matplotlib` in the document title in detail mode', async () => {
       mockParams = { specId: 'scatter-basic', language: 'python', library: 'matplotlib' };
       mockSearchParams.delete('language');

--- a/app/src/pages/SpecPage.test.tsx
+++ b/app/src/pages/SpecPage.test.tsx
@@ -206,6 +206,31 @@ describe('SpecPage', () => {
       });
       mockSearchParams.delete('language');
     });
+
+    it('lowercases a mixed-case path language token in detail mode', async () => {
+      mockParams = { specId: 'scatter-basic', language: 'Python', library: 'matplotlib' };
+      mockSearchParams.delete('language');
+      mockFetchSuccess();
+      render(<SpecPage />);
+
+      await waitFor(() => {
+        expect(document.title).toContain('Basic Scatter Plot · python · matplotlib');
+      });
+      expect(document.title).not.toContain('Python');
+    });
+
+    it('lowercases a mixed-case ?language= query param in hub mode', async () => {
+      mockParams = { specId: 'scatter-basic' };
+      mockSearchParams.set('language', 'Python');
+      mockFetchSuccess();
+      render(<SpecPage />);
+
+      await waitFor(() => {
+        expect(document.title).toContain('Basic Scatter Plot · python');
+      });
+      expect(document.title).not.toContain('Python');
+      mockSearchParams.delete('language');
+    });
   });
 
   describe('carousel-scope conflict drop', () => {

--- a/app/src/pages/SpecPage.test.tsx
+++ b/app/src/pages/SpecPage.test.tsx
@@ -184,25 +184,25 @@ describe('SpecPage', () => {
   });
 
   describe('language in title + breadcrumb', () => {
-    it('includes ` · Python · matplotlib` in the document title in detail mode', async () => {
+    it('includes ` · python · matplotlib` in the document title in detail mode', async () => {
       mockParams = { specId: 'scatter-basic', language: 'python', library: 'matplotlib' };
       mockSearchParams.delete('language');
       mockFetchSuccess();
       render(<SpecPage />);
 
       await waitFor(() => {
-        expect(document.title).toContain('Basic Scatter Plot · Python · matplotlib');
+        expect(document.title).toContain('Basic Scatter Plot · python · matplotlib');
       });
     });
 
-    it('includes ` · Python` in the document title when ?language= is set in hub mode', async () => {
+    it('includes ` · python` in the document title when ?language= is set in hub mode', async () => {
       mockParams = { specId: 'scatter-basic' };
       mockSearchParams.set('language', 'python');
       mockFetchSuccess();
       render(<SpecPage />);
 
       await waitFor(() => {
-        expect(document.title).toContain('Basic Scatter Plot · Python');
+        expect(document.title).toContain('Basic Scatter Plot · python');
       });
       mockSearchParams.delete('language');
     });

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -43,10 +43,12 @@ export function SpecPage() {
   const { trackPageview, trackEvent } = useAnalytics();
   const { librariesData } = useAppData();
 
-  // Language tokens are canonical lowercase (`python`/`r`) everywhere they're
-  // compared against impl data, written back to URLs, or rendered. Force-lowercase
-  // at the read site so a mixed-case route like /Python/matplotlib or
-  // ?language=Python doesn't desync title, filtering, canonical URL, and analytics.
+  // Language ids are canonical lowercase (`python`/`r`) wherever they're
+  // compared against impl data, written back to URLs, or used in analytics.
+  // Force-lowercase at the read site so a mixed-case route like
+  // /Python/matplotlib or ?language=Python doesn't desync title, filtering,
+  // canonical URL, and analytics. Title-cased display labels for UI surfaces
+  // (e.g. breadcrumbs) still go through LANG_DISPLAY.
   const urlLanguage = urlLanguageRaw?.toLowerCase();
 
   const [specData, setSpecData] = useState<SpecDetail | null>(null);

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -354,11 +354,12 @@ export function SpecPage() {
       : `https://anyplot.ai/${specId}`;
 
   // Page title surfaces language alongside library so the browser tab matches
-  // the rendered image-title format `{spec-id} · {Language} · {library}`. Hub
+  // the rendered image-title format `{spec-id} · {language} · {library}`. Hub
   // mode under a `?language=` filter also surfaces the language so users see
-  // what's been narrowed down.
-  const detailLanguage = mode === 'detail' && urlLanguage ? (LANG_DISPLAY[urlLanguage] || urlLanguage) : null;
-  const hubFilterLanguage = languageFilter ? (LANG_DISPLAY[languageFilter] || languageFilter) : null;
+  // what's been narrowed down. Language is kept lowercase to match the
+  // lowercase library name (e.g. `matplotlib`, `ggplot2`).
+  const detailLanguage = mode === 'detail' && urlLanguage ? urlLanguage : null;
+  const hubFilterLanguage = languageFilter ? languageFilter : null;
   const titleSuffix =
     mode === 'detail' && detailLanguage && selectedLibrary
       ? ` · ${detailLanguage} · ${selectedLibrary}`

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -356,10 +356,12 @@ export function SpecPage() {
   // Page title surfaces language alongside library so the browser tab matches
   // the rendered image-title format `{spec-id} · {language} · {library}`. Hub
   // mode under a `?language=` filter also surfaces the language so users see
-  // what's been narrowed down. Language is kept lowercase to match the
-  // lowercase library name (e.g. `matplotlib`, `ggplot2`).
-  const detailLanguage = mode === 'detail' && urlLanguage ? urlLanguage : null;
-  const hubFilterLanguage = languageFilter ? languageFilter : null;
+  // what's been narrowed down. Force-lowercase the language token so a
+  // mixed-case URL (`/Python/...` or `?language=Python`) still renders the
+  // canonical lowercase form (`python`/`r`) that matches `{spec-id}` and
+  // `{library}`.
+  const detailLanguage = mode === 'detail' && urlLanguage ? urlLanguage.toLowerCase() : null;
+  const hubFilterLanguage = languageFilter ? languageFilter.toLowerCase() : null;
   const titleSuffix =
     mode === 'detail' && detailLanguage && selectedLibrary
       ? ` · ${detailLanguage} · ${selectedLibrary}`

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -37,11 +37,17 @@ interface SpecDetail {
 type Mode = 'hub' | 'detail';
 
 export function SpecPage() {
-  const { specId, language: urlLanguage, library: urlLibrary } = useParams();
+  const { specId, language: urlLanguageRaw, library: urlLibrary } = useParams();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { trackPageview, trackEvent } = useAnalytics();
   const { librariesData } = useAppData();
+
+  // Language tokens are canonical lowercase (`python`/`r`) everywhere they're
+  // compared against impl data, written back to URLs, or rendered. Force-lowercase
+  // at the read site so a mixed-case route like /Python/matplotlib or
+  // ?language=Python doesn't desync title, filtering, canonical URL, and analytics.
+  const urlLanguage = urlLanguageRaw?.toLowerCase();
 
   const [specData, setSpecData] = useState<SpecDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -61,7 +67,7 @@ export function SpecPage() {
   // through ALL impls (cross-language). With it, the carousel stays scoped to
   // that language. This is also what lets a future python.anyplot.ai-style
   // subdomain pin the scope without users having to manually re-filter.
-  const carouselLanguage = searchParams.get('language');
+  const carouselLanguage = searchParams.get('language')?.toLowerCase() ?? null;
   const languageFilter = mode === 'hub' ? carouselLanguage : null;
 
   const getLibraryMeta = useCallback(
@@ -356,12 +362,10 @@ export function SpecPage() {
   // Page title surfaces language alongside library so the browser tab matches
   // the rendered image-title format `{spec-id} · {language} · {library}`. Hub
   // mode under a `?language=` filter also surfaces the language so users see
-  // what's been narrowed down. Force-lowercase the language token so a
-  // mixed-case URL (`/Python/...` or `?language=Python`) still renders the
-  // canonical lowercase form (`python`/`r`) that matches `{spec-id}` and
-  // `{library}`.
-  const detailLanguage = mode === 'detail' && urlLanguage ? urlLanguage.toLowerCase() : null;
-  const hubFilterLanguage = languageFilter ? languageFilter.toLowerCase() : null;
+  // what's been narrowed down. `urlLanguage` / `languageFilter` are already
+  // normalised to canonical lowercase at the read site.
+  const detailLanguage = mode === 'detail' && urlLanguage ? urlLanguage : null;
+  const hubFilterLanguage = languageFilter ?? null;
   const titleSuffix =
     mode === 'detail' && detailLanguage && selectedLibrary
       ? ` · ${detailLanguage} · ${selectedLibrary}`

--- a/prompts/library/ggplot2.md
+++ b/prompts/library/ggplot2.md
@@ -222,7 +222,7 @@ df <- tibble::tibble(
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(df, aes(x, y)) +
   geom_point(color = OKABE_ITO[1], size = 4, alpha = 0.7) +
-  labs(title = "scatter-basic · R · ggplot2 · anyplot.ai", x = "X", y = "Y") +
+  labs(title = "scatter-basic · r · ggplot2 · anyplot.ai", x = "X", y = "Y") +
   theme_minimal(base_size = 14) +
   theme(
     plot.background  = element_rect(fill = PAGE_BG, color = PAGE_BG),

--- a/prompts/plot-generator.md
+++ b/prompts/plot-generator.md
@@ -118,7 +118,7 @@ ax.scatter(study_hours, exam_scores, alpha=0.7, s=200,
 # Style
 ax.set_xlabel('Study Hours per Day', fontsize=20, color=INK)
 ax.set_ylabel('Exam Score (%)', fontsize=20, color=INK)
-ax.set_title('scatter-basic · Python · matplotlib · anyplot.ai',
+ax.set_title('scatter-basic · python · matplotlib · anyplot.ai',
              fontsize=24, fontweight='medium', color=INK)
 ax.tick_params(axis='both', labelsize=16, colors=INK_SOFT)
 ax.spines['top'].set_visible(False)
@@ -138,26 +138,26 @@ plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight', facecolor=PAGE_BG
 **Always use this format for the plot title:**
 
 ```
-{spec-id} · {Language} · {library} · anyplot.ai
+{spec-id} · {language} · {library} · anyplot.ai
 ```
 
-`{Language}` is the implementation's language, capitalized: `Python` or `R`. The language token is **required** — viewers cannot tell from `ggplot2` alone whether a chart is Python or R (`plotnine` is the Python ggplot port), and going forward every rendered title must surface the runtime language.
+`{language}` is the implementation's language, lowercase: `python` or `r`. The language token is **required** — viewers cannot tell from `ggplot2` alone whether a chart is Python or R (`plotnine` is the Python ggplot port), and going forward every rendered title must surface the runtime language. Keep it lowercase to match the lowercase `{spec-id}` and `{library}` tokens.
 
 Examples:
-- `scatter-basic · Python · matplotlib · anyplot.ai`
-- `bar-grouped · Python · seaborn · anyplot.ai`
-- `heatmap-correlation · Python · plotly · anyplot.ai`
-- `biplot-pca · R · ggplot2 · anyplot.ai`
+- `scatter-basic · python · matplotlib · anyplot.ai`
+- `bar-grouped · python · seaborn · anyplot.ai`
+- `heatmap-correlation · python · plotly · anyplot.ai`
+- `biplot-pca · r · ggplot2 · anyplot.ai`
 
 **Optional descriptive prefix**: If the spec-id alone doesn't explain the example data well, add a descriptive title before it:
 
 ```
-{Descriptive Title} · {spec-id} · {Language} · {library} · anyplot.ai
+{Descriptive Title} · {spec-id} · {language} · {library} · anyplot.ai
 ```
 
 Examples:
-- `Tesla Stock 2024 · candle-ohlc · Python · matplotlib · anyplot.ai`
-- `Sales by Region · bar-grouped · Python · seaborn · anyplot.ai`
+- `Tesla Stock 2024 · candle-ohlc · python · matplotlib · anyplot.ai`
+- `Sales by Region · bar-grouped · python · seaborn · anyplot.ai`
 
 Only add the descriptive prefix when it adds value - most basic plots don't need it.
 

--- a/prompts/quality-criteria.md
+++ b/prompts/quality-criteria.md
@@ -332,7 +332,7 @@ This category evaluates aesthetic sophistication beyond mere correctness. A plot
 
 | Points | Criterion |
 |--------|-----------|
-| 3 | Title is `{spec-id} · {Language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (Language ∈ {Python, R}). Legend labels correct |
+| 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r}). Legend labels correct |
 | 2 | Title format correct but legend issues, or vice versa |
 | 1 | Partially correct |
 | 0 | Missing or wrong |

--- a/prompts/quality-evaluator.md
+++ b/prompts/quality-evaluator.md
@@ -204,7 +204,7 @@ If found: `auto_reject: "AR-08"`, score = 0, stop evaluation.
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All spec features present? |
 | SC-03 | Data Mapping | 3 | X/Y correctly assigned? All data visible? |
-| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {Language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (Language ∈ {Python, R}). Legend labels correct? |
+| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r}). Legend labels correct? |
 
 ### Step 4: Data Quality (15 pts)
 

--- a/prompts/workflow-prompts/ai-quality-review.md
+++ b/prompts/workflow-prompts/ai-quality-review.md
@@ -107,7 +107,7 @@ Read `prompts/quality-criteria.md` and evaluate:
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All features from spec? |
 | SC-03 | Data Mapping | 3 | X/Y correct? Axes show all data? |
-| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {Language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (Language ∈ {Python, R}). Legend labels match? |
+| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r}). Legend labels match? |
 
 #### Data Quality (15 pts)
 | ID | Criterion | Max | Check |


### PR DESCRIPTION
## Summary
- The browser tab title for plot detail pages rendered as `{spec-id} · Python · {library} | anyplot.ai` — language was Title-Cased while spec-id and library stayed lowercase, which looked inconsistent.
- Use the raw URL language value in `SpecPage.tsx` so the title now reads `{spec-id} · python · {library} | anyplot.ai`, matching the lowercase library tokens (e.g. `matplotlib`, `ggplot2`).
- Breadcrumbs still use `LANG_DISPLAY` (Title Case) — that's the correct convention for breadcrumb labels and was left untouched.

## Test plan
- [x] `yarn type-check` passes
- [x] `yarn lint` passes (only pre-existing warnings)
- [ ] Verify on deploy: `<title>` on a detail page like `/bar-grouped/python/matplotlib` reads `Grouped Bar Chart · python · matplotlib | anyplot.ai`
- [ ] Verify breadcrumb still shows `Python` (unchanged)

https://claude.ai/code/session_01EovzGTufzre1isXFPwA8k2

---
_Generated by [Claude Code](https://claude.ai/code/session_01EovzGTufzre1isXFPwA8k2)_