### PR TITLE
fix(db): merge feedback + language alembic heads

### DIFF
--- a/alembic/versions/7efe9fc8bde1_merge_feedback_language_migration_heads.py
+++ b/alembic/versions/7efe9fc8bde1_merge_feedback_language_migration_heads.py
@@ -1,0 +1,34 @@
+"""merge feedback + language migration heads
+
+The feedback-widget branch (#7143) and the language-descriptions branch
+(#7142) both descended from `3a7e1b5c0c4f` and merged to main
+independently, leaving two alembic heads (`e5b1c9d4a7f2`,
+`c5f9a3d72be1`). That broke `Sync: PostgreSQL` on every push to main
+with "Multiple head revisions are present for given argument 'head'".
+
+This is a no-op merge revision that joins both heads into a single
+head (`7efe9fc8bde1`) so `alembic upgrade head` resolves again.
+
+Revision ID: 7efe9fc8bde1
+Revises: c5f9a3d72be1, e5b1c9d4a7f2
+Create Date: 2026-05-18
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7efe9fc8bde1"
+down_revision: tuple[str, str] = ("c5f9a3d72be1", "e5b1c9d4a7f2")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Problem

`Sync: PostgreSQL` has been failing on every push to `main` since ~17:55 with:

```
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
FAILED: Multiple head revisions are present...
```

PRs #7142 (language descriptions) and #7143 (feedback widget) both branched from \`3a7e1b5c0c4f\` and merged independently, leaving two alembic heads:

- `c5f9a3d72be1` — update_language_descriptions
- `e5b1c9d4a7f2` — feedback_uuid_and_status

No merge revision was added, so `alembic upgrade head` is ambiguous. Production DB is stuck on whatever was the last successful sync.

## Fix

Add a no-op merge revision \`7efe9fc8bde1\` joining both heads. Verified locally:

- \`alembic heads\` → single head \`7efe9fc8bde1\`
- \`alembic upgrade head --sql\` produces a clean transactional plan

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `Sync: PostgreSQL` workflow goes green on the next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)