### PR TITLE
feat(impl-generate): overlay prompts/ from trigger ref for branch testing

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -369,6 +369,13 @@ jobs:
       # overlaid prompts/ never end up in the resulting PR. The later "Create
       # library metadata file" step re-checks out origin/$BRANCH, which discards
       # the overlay automatically. No-op on main + on label triggers.
+      #
+      # FETCH_HEAD is used instead of origin/<name> so the step also works for
+      # tag and SHA refs (where origin/<name> isn't created). The existence
+      # check for prompts/ guards refs without that tree. impl-generate-claude.md
+      # is always restored from the implementation branch (= main) after the
+      # overlay, so a branch can't override Claude's `git add plots/...` safety
+      # contract by editing that one file.
       - name: Overlay prompts/ from trigger ref (branch-level prompt iteration)
         if: github.ref_name != 'main' && github.event_name == 'workflow_dispatch'
         env:
@@ -378,8 +385,17 @@ jobs:
             echo "::notice::Trigger ref $TRIGGER_REF not found on origin — skipping overlay (workflow runs against main's prompts)"
             exit 0
           fi
-          git checkout "origin/$TRIGGER_REF" -- prompts/
-          echo "::notice::Overlaid prompts/ from $TRIGGER_REF — Claude will read these instead of main's prompts"
+          if ! git ls-tree FETCH_HEAD -- prompts/ 2>/dev/null | grep -q .; then
+            echo "::notice::Trigger ref $TRIGGER_REF has no prompts/ tree — skipping overlay"
+            exit 0
+          fi
+          git checkout FETCH_HEAD -- prompts/
+          # Always restore impl-generate-claude.md from main: it tells Claude
+          # `git add plots/.../{LIBRARY}{EXT}` (Step 7), which is what keeps
+          # the overlaid prompts/ out of the resulting PR. Letting a feature
+          # branch override that instruction defeats the safety contract above.
+          git checkout HEAD -- prompts/workflow-prompts/impl-generate-claude.md
+          echo "::notice::Overlaid prompts/ from $TRIGGER_REF (impl-generate-claude.md kept from main for safety)"
 
       - name: Run Claude Code to generate implementation
         id: claude

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -361,6 +361,26 @@ jobs:
           printf '%s\n' "$CHANGE_REQUEST" > /tmp/anyplot-change-request.txt
           echo "::notice::Change request staged: ${CHANGE_REQUEST}"
 
+      # When triggered from a non-main branch via workflow_dispatch (typical for
+      # iterative prompt-change testing), overlay the trigger branch's prompts/
+      # directory onto the implementation branch (which was just created from
+      # main). Claude commits only the implementation file (see Step 7 of
+      # impl-generate-claude.md → `git add plots/.../{LIBRARY}{EXT}`), so the
+      # overlaid prompts/ never end up in the resulting PR. The later "Create
+      # library metadata file" step re-checks out origin/$BRANCH, which discards
+      # the overlay automatically. No-op on main + on label triggers.
+      - name: Overlay prompts/ from trigger ref (branch-level prompt iteration)
+        if: github.ref_name != 'main' && github.event_name == 'workflow_dispatch'
+        env:
+          TRIGGER_REF: ${{ github.ref_name }}
+        run: |
+          if ! git fetch origin "$TRIGGER_REF" 2>/dev/null; then
+            echo "::notice::Trigger ref $TRIGGER_REF not found on origin — skipping overlay (workflow runs against main's prompts)"
+            exit 0
+          fi
+          git checkout "origin/$TRIGGER_REF" -- prompts/
+          echo "::notice::Overlaid prompts/ from $TRIGGER_REF — Claude will read these instead of main's prompts"
+
       - name: Run Claude Code to generate implementation
         id: claude
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Adds a small step to `impl-generate.yml` that overlays the trigger branch's `prompts/` directory when triggered with `--ref <feature-branch>` via workflow_dispatch
- Lets prompt iterations be tested through the live pipeline without merging to main first
- No-op on production paths (label trigger from issues, bulk-generate / daily-regen from main)

## Why now
The Claude GitHub App's \`claude-code-action\` refuses to run when the workflow file on the triggering branch differs from main (\"Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.\").

Without this on main, every iteration on the upcoming style/canvas-halve-v1 work would require merging prompt changes to main and triggering from there — slow and noisy.

With this on main, the workflow on style/canvas-halve-v1 matches main → the action accepts → the new overlay step then reads the branch's prompts/ for the run. Claude commits only the implementation file, so the overlay never lands in the generated PR.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: trigger \`gh workflow run impl-generate.yml --ref style/canvas-halve-v1 -f specification_id=timeseries-forecast-uncertainty -f library=matplotlib\` and verify the \"Overlay prompts/\" step shows \`::notice::Overlaid prompts/ from style/canvas-halve-v1\` in the log
- [ ] Verify generated implementation reflects branch's new canvas (3200×1800) rather than main's old defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)