### PR TITLE
feat(style): canvas 3200x1800 + proportional review rules

### DIFF
--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -187,10 +187,10 @@ Three library families with different sizing controls:
 | Axis labels | 14pt | 16px | '16pt' |
 | Tick labels | 12pt | 14px | '14pt' |
 | Legend | 12pt | 14px | '14pt' |
-| Marker size | `s=100` | 10 | 10 |
-| Line width | 2.5 | 2.5 | 2.5 |
 
-All three families produce the same 3200×1800 (or 2400×2400) output, so the resulting text/marker pixel sizes are comparable across libraries.
+All three families produce the same 3200×1800 (or 2400×2400) output, so text pixel sizes are comparable across libraries.
+
+**Marker and line sizes** vary by library API and aren't directly comparable as a single number — matplotlib's `s=` is in points², plotly's `marker.size` is a pixel diameter, altair's `mark_point(size=...)` is an area, plotnine / lets-plot / ggplot2's `geom_point(size=...)` uses a smaller ggplot scale. See each library's own prompt (`prompts/library/<lib>.md` → "Sizing" section) for the canonical starting values, and adapt to data density per the heuristic below.
 
 ### Data-density Heuristic
 

--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -1,30 +1,32 @@
 # AnyPlot.ai Default Style Guide
 
-Style requirements for consistent, beautiful visualizations at large canvas sizes.
+Style requirements for consistent, beautiful visualizations at a mid-sized canvas.
 
-## Important: Large Canvas Size
+## Standard Canvas Size
 
-anyplot renders at high resolution (~13 million pixels). All element sizes must be scaled for visibility!
+anyplot renders at ~5.76 million pixels — a mid-sized canvas that balances Hi-Res sharpness for desktop monitors with mobile readability and reasonable file sizes.
 
-**Common Mistake:** Using default/standard sizes results in tiny, hard-to-see elements.
+**Common Mistake:** Using library defaults (e.g. matplotlib `fontsize=10`, plotly `marker.size=6`) still produces elements that are too small. Use the "Visual Sizing Defaults" table below as a starting point — the AI may adjust if the plot context demands it, and the review step checks proportions.
 
 ---
 
 ## Dimensions
 
-Two formats are allowed (similar pixel count for consistent font sizing):
+Two formats are allowed (same pixel count for consistent font sizing across both):
 
 | Format | Size | Aspect Ratio | Use Case |
 |--------|------|--------------|----------|
-| **Landscape** | 4800 × 2700 px | 16:9 | Default, most plots |
-| **Square** | 3600 × 3600 px | 1:1 | Symmetric plots (pie, radar, heatmaps, grid-based) |
+| **Landscape** | 3200 × 1800 px | 16:9 | Default, most plots |
+| **Square** | 2400 × 2400 px | 1:1 | Symmetric plots (pie, radar, heatmaps, grid-based) |
 
 **AI decides freely** which format is best for each specific plot.
 
 **Why these sizes?**
-- Landscape: 4800 × 2700 = 12.96 million pixels
-- Square: 3600 × 3600 = 12.96 million pixels
-- Same pixel area → same font sizes work for both
+- Landscape: 3200 × 1800 = 5.76 million pixels
+- Square: 2400 × 2400 = 5.76 million pixels
+- Same pixel area → the same font sizes work for both formats
+- Big enough to stay sharp at typical 1920–2560 px desktop widths
+- Small enough that mobile loads (and the `400w` / `800w` srcset variants) stay snappy
 
 ---
 
@@ -171,32 +173,53 @@ Before finalizing any plot, consider removing:
 
 ---
 
-## Visual Sizing Principles
+## Visual Sizing Defaults
 
-Since we render at ~13 million pixels, elements must be **visually prominent**:
+**These are starting values — the AI may adjust if the plot context demands it.** The review step then checks proportions (see "Proportional Sizing" below) and the repair loop tunes any element that's off.
 
-### Text
+Three library families with different sizing controls:
 
-Two font size groups exist due to how libraries render (DPI-based vs. pixel-based):
+| Element | DPI-based (matplotlib, seaborn, plotnine) | Scale-based (plotly, altair, lets-plot) | Native-pixel (bokeh, highcharts, pygal) |
+|---------|--------------------------------------------|------------------------------------------|------------------------------------------|
+| Canvas (16:9) | `figsize=(8, 4.5)` `dpi=400` | `width=800 height=450 scale=4` | `width=3200 height=1800` |
+| Canvas (1:1) | `figsize=(6, 6)` `dpi=400` | `width=600 height=600 scale=4` | `width=2400 height=2400` |
+| Title | 18pt | 22px | '22pt' |
+| Axis labels | 14pt | 16px | '16pt' |
+| Tick labels | 12pt | 14px | '14pt' |
+| Legend | 12pt | 14px | '14pt' |
+| Marker size | `s=100` | 10 | 10 |
+| Line width | 2.5 | 2.5 | 2.5 |
 
-| Element | DPI-based (matplotlib, seaborn, plotnine, letsplot) | Pixel-based (plotly, bokeh, altair, highcharts, pygal) |
-|---------|------------------------------------------------------|--------------------------------------------------------|
-| Title | 24pt | 28px |
-| Axis labels | 20pt | 22px |
-| Tick labels | 16pt | 18px |
-| Legend | 16pt | 16px |
+All three families produce the same 3200×1800 (or 2400×2400) output, so the resulting text/marker pixel sizes are comparable across libraries.
 
-DPI-based libraries use `figsize=(16, 9)` + `dpi=300` = 4800x2700px. Pixel-based libraries set dimensions directly.
+### Data-density Heuristic
 
-### Data Elements
-- **Points/Markers**: Clearly visible, not tiny dots
-- **Lines**: Thick enough to see clearly
-- **Bars**: With subtle edges for definition
+Marker and line sizes should adapt to how dense the data is — no fixed values:
+
+- **Few datapoints (< 50)** → larger, prominent markers; thicker lines.
+- **Medium density (50–500)** → defaults from the table above.
+- **High density (> 500)** → smaller markers + `alpha < 1` to combat overplotting; consider hex-bin / 2D-histogram alternatives.
+- **Few series (1–3)** → thicker lines for prominence.
+- **Many series (> 5)** → thinner lines so all stay visible.
 
 ### General Rules
-- Elements should be **~3-4x larger** than standard defaults
-- When in doubt, make it bigger
-- Test: Would this be readable on a 4K monitor?
+- Elements should be **~2-3× larger** than the library's standard defaults.
+- When in doubt, make it bigger.
+- Test: Would this be readable on a typical 1920–2560 px desktop monitor, AND on a 400 px mobile width?
+
+---
+
+## Proportional Sizing
+
+The review step checks these proportions visually from the source PNG. There are no hard pixel thresholds — violations cost points in the existing VQ-01 (Text Legibility), VQ-02 (No Overlap), VQ-05 (Layout & Canvas) categories rather than triggering a separate pass/fail. This keeps the contract holistic: a single visual problem (oversized short axis label, overlapping ticks) can reduce points in multiple categories.
+
+- **Title proportion:** Title takes ~50–70% of the plot width. Too narrow → fontsize probably too small. Too wide / overflowing → fontsize probably too big or title too verbose.
+- **Axis label proportionality:** Short labels ("Date", "Year") should not dominate the axis with oversized fontsizes. Long descriptive labels ("Fläche von Häusern in Quadratmetern") are fine as long as they don't overflow — the "no overflow" rule covers that case.
+- **Axis label balance:** X-axis label and Y-axis label are visually similar in size — one much larger than the other without semantic reason is a violation.
+- **Tick label balance:** X-axis and Y-axis tick labels are visually similar in size (exception: rotated long categorical labels).
+- **No overlap:** Text never overlaps with other text or with data elements.
+- **No overflow:** No text extends beyond axis bounds, plot bounds, or frame.
+- **Marker / line density appropriateness:** Element sizes match the data-density heuristic above (sparse → prominent; dense → smaller + alpha).
 
 ---
 

--- a/prompts/library/altair.md
+++ b/prompts/library/altair.md
@@ -9,18 +9,20 @@ import altair as alt
 ## Create Chart
 
 ```python
-chart = alt.Chart(df).mark_point(size=150).encode(  # size ~3-4x default
+chart = alt.Chart(df).mark_point(size=60).encode(  # size ~2-3x default, density-aware
     x='col_x:Q',
     y='col_y:Q'
 ).properties(
-    width=1600,
-    height=900,
-    title=alt.Title(title, fontSize=28)
+    width=800,
+    height=450,
+    title=alt.Title(title, fontSize=22)
 ).configure_axis(
-    labelFontSize=18,
-    titleFontSize=22
+    labelFontSize=14,
+    titleFontSize=16
 )
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Encoding Types
 
@@ -52,9 +54,9 @@ x='date:T'
 ## Save (PNG)
 
 ```python
-# Target: 4800 × 2700 px (see default-style-guide.md)
-# 1600 × 3 = 4800, 900 × 3 = 2700
-chart.save(f'plot-{THEME}.png', scale_factor=3.0)
+# Target: 3200 × 1800 px (see default-style-guide.md)
+# 800 × scale_factor=4 = 3200, 450 × 4 = 1800
+chart.save(f'plot-{THEME}.png', scale_factor=4.0)
 ```
 
 **Note**: Requires `vl-convert-python` for PNG export.
@@ -105,7 +107,7 @@ INK_SOFT    = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 chart = (
     base_chart
-    .properties(background=PAGE_BG, width=1600, height=900)
+    .properties(background=PAGE_BG, width=800, height=450)
     .configure_view(fill=PAGE_BG, stroke=INK_SOFT)
     .configure_axis(
         domainColor=INK_SOFT, tickColor=INK_SOFT,
@@ -119,7 +121,7 @@ chart = (
     )
 )
 
-chart.save(f'plot-{THEME}.png')
+chart.save(f'plot-{THEME}.png', scale_factor=4.0)
 chart.save(f'plot-{THEME}.html')
 ```
 

--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -11,10 +11,10 @@ from bokeh.io import output_file, save
 ## Create Figure
 
 ```python
-# Target: 4800 × 2700 px (see default-style-guide.md)
+# Target: 3200 × 1800 px (see default-style-guide.md)
 p = figure(
-    width=4800,
-    height=2700,
+    width=3200,
+    height=1800,
     title=title,
     x_axis_label=x_label,
     y_axis_label=y_label
@@ -65,7 +65,9 @@ save(p)
 
 # Screenshot it with headless Chrome — Selenium 4 / Selenium Manager
 # auto-resolves a working driver for the system Chrome.
-W, H = 4800, 2700
+# IMPORTANT: W,H must match the figure's width/height above, otherwise the
+# bokeh canvas paints into the upper-left corner with white space around it.
+W, H = 3200, 1800
 opts = Options()
 for arg in (
     "--headless=new",
@@ -84,20 +86,22 @@ driver.save_screenshot(f"plot-{THEME}.png")
 driver.quit()
 ```
 
-## Sizing for 4800×2700 px
+## Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ```python
 # Text sizes
-p.title.text_font_size = '28pt'
-p.xaxis.axis_label_text_font_size = '22pt'
-p.yaxis.axis_label_text_font_size = '22pt'
-p.xaxis.major_label_text_font_size = '18pt'
-p.yaxis.major_label_text_font_size = '18pt'
+p.title.text_font_size = '22pt'
+p.xaxis.axis_label_text_font_size = '16pt'
+p.yaxis.axis_label_text_font_size = '16pt'
+p.xaxis.major_label_text_font_size = '14pt'
+p.yaxis.major_label_text_font_size = '14pt'
 
-# Element sizes
-p.scatter(..., size=15)        # ~3-4x default
-p.line(..., line_width=3)
+# Element sizes (density-aware — see default-style-guide.md)
+p.scatter(..., size=10)        # ~2-3x default
+p.line(..., line_width=2.5)
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Colors
 

--- a/prompts/library/ggplot2.md
+++ b/prompts/library/ggplot2.md
@@ -62,10 +62,10 @@ set.seed(42)
 p <- ggplot(df, aes(x = col_x, y = col_y)) +
   geom_point() +
   labs(x = x_label, y = y_label, title = plot_title) +
-  theme_minimal(base_size = 14)
+  theme_minimal(base_size = 10)
 ```
 
-## Figure Size & Sizing for 4800×2700 px
+## Figure Size & Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ggplot2 inherits sizes via `theme(... base_size = ...)`. Override individual
 elements for the anyplot canvas:
@@ -73,19 +73,20 @@ elements for the anyplot canvas:
 ```r
 p <- p +
   theme(
-    text             = element_text(size = 14),  # base text
-    axis.title       = element_text(size = 20),  # axis labels
-    axis.text        = element_text(size = 16),  # tick labels
-    plot.title       = element_text(size = 24),
-    legend.text      = element_text(size = 16),
-    legend.title     = element_text(size = 18)
+    text             = element_text(size = 10),  # base text
+    axis.title       = element_text(size = 14),  # axis labels
+    axis.text        = element_text(size = 12),  # tick labels
+    plot.title       = element_text(size = 18),
+    legend.text      = element_text(size = 12),
+    legend.title     = element_text(size = 14)
   )
 
-# Element sizes inside geoms (~3-4× ggplot2 defaults so they survive the
-# 4800×2700 canvas):
-# geom_point(size = 4)
-# geom_line(linewidth = 1.5)
+# Element sizes inside geoms (~2-3× ggplot2 defaults, density-aware):
+# geom_point(size = 2.5)
+# geom_line(linewidth = 1.0)
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Save (PNG, both themes)
 
@@ -97,10 +98,10 @@ ggsave(
   filename = sprintf("plot-%s.png", THEME),
   plot     = p,
   device   = ragg::agg_png,
-  width    = 16,
-  height   = 9,
+  width    = 8,
+  height   = 4.5,
   units    = "in",
-  dpi      = 300
+  dpi      = 400
 )
 ```
 
@@ -148,7 +149,7 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
-anyplot_theme <- theme_minimal(base_size = 14) +
+anyplot_theme <- theme_minimal(base_size = 10) +
   theme(
     plot.background   = element_rect(fill = PAGE_BG, color = PAGE_BG),
     panel.background  = element_rect(fill = PAGE_BG, color = NA),
@@ -170,7 +171,7 @@ anyplot_theme <- theme_minimal(base_size = 14) +
 # contrast against PAGE_BG instead.
 
 p <- ggplot(df, aes(x, y)) +
-  geom_point(color = OKABE_ITO[1], size = 4) +
+  geom_point(color = OKABE_ITO[1], size = 2.5) +
   anyplot_theme
 ```
 
@@ -221,17 +222,17 @@ df <- tibble::tibble(
 
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(df, aes(x, y)) +
-  geom_point(color = OKABE_ITO[1], size = 4, alpha = 0.7) +
+  geom_point(color = OKABE_ITO[1], size = 2.5, alpha = 0.7) +
   labs(title = "scatter-basic · r · ggplot2 · anyplot.ai", x = "X", y = "Y") +
-  theme_minimal(base_size = 14) +
+  theme_minimal(base_size = 10) +
   theme(
     plot.background  = element_rect(fill = PAGE_BG, color = PAGE_BG),
     panel.background = element_rect(fill = PAGE_BG, color = NA),
     panel.grid.major = element_line(color = INK, linewidth = 0.3),
     panel.grid.minor = element_line(color = INK, linewidth = 0.2),
-    axis.title       = element_text(color = INK,      size = 20),
-    axis.text        = element_text(color = INK_SOFT, size = 16),
-    plot.title       = element_text(color = INK,      size = 24)
+    axis.title       = element_text(color = INK,      size = 14),
+    axis.text        = element_text(color = INK_SOFT, size = 12),
+    plot.title       = element_text(color = INK,      size = 18)
   )
 
 # --- Save -------------------------------------------------------------------
@@ -239,10 +240,10 @@ ggsave(
   filename = sprintf("plot-%s.png", THEME),
   plot     = p,
   device   = ragg::agg_png,
-  width    = 16,
-  height   = 9,
+  width    = 8,
+  height   = 4.5,
   units    = "in",
-  dpi      = 300
+  dpi      = 400
 )
 ```
 

--- a/prompts/library/highcharts.md
+++ b/prompts/library/highcharts.md
@@ -88,7 +88,7 @@ html_content = f"""<!DOCTYPE html>
     <script>{highcharts_js}</script>
 </head>
 <body style="margin:0; background:{PAGE_BG};">
-    <div id="container" style="width: 4800px; height: 2700px;"></div>
+    <div id="container" style="width: 3200px; height: 1800px;"></div>
     <script>{html_str}</script>
 </body>
 </html>"""
@@ -107,7 +107,7 @@ chrome_options.add_argument("--headless")
 chrome_options.add_argument("--no-sandbox")
 chrome_options.add_argument("--disable-dev-shm-usage")
 chrome_options.add_argument("--disable-gpu")
-chrome_options.add_argument("--window-size=4800,2700")
+chrome_options.add_argument("--window-size=3200,1800")
 
 driver = webdriver.Chrome(options=chrome_options)
 driver.get(f"file://{temp_path}")
@@ -118,17 +118,24 @@ driver.quit()
 Path(temp_path).unlink()  # Clean up temp file
 ```
 
-## Sizing for 4800×2700 px
+## Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 Size + text sizes + marker sizes (the theme/color concerns are covered in the "Theme-adaptive Chrome" section below — do not duplicate):
 
 ```python
-# Marker sizes (in plotOptions)
+# Marker sizes (in plotOptions) — density-aware, see default-style-guide.md
 chart.options.plot_options = {
-    'scatter': {'marker': {'radius': 8}},  # ~3-4x default
-    'line': {'lineWidth': 3}
+    'scatter': {'marker': {'radius': 6}},  # ~2-3x default
+    'line': {'lineWidth': 2.5}
 }
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
+
+**IMPORTANT:** Three places encode the canvas size — keep them in sync:
+1. Selenium `--window-size=3200,1800`
+2. HTML `<div id="container" style="width: 3200px; height: 1800px;">`
+3. `chart.options.chart = {'width': 3200, 'height': 1800, ...}` (see below)
 
 ## Output Files
 
@@ -143,9 +150,9 @@ chart.options.plot_options = {
 4. **Screenshot timing**: Use `time.sleep(5)` for reliable rendering
 5. **Encoding errors**: Always use `encoding="utf-8"` in NamedTemporaryFile (Highcharts JS contains special Unicode characters)
 6. **X-axis labels cut off in PNG**: Category labels may be clipped at the bottom. Fix by:
-   - Increase bottom margin: `chart.options.chart = {'marginBottom': 150, ...}`
-   - Or add spacingBottom: `chart.options.chart = {'spacingBottom': 80, ...}`
-   - Ensure labels have `style: {'fontSize': '24px'}` for visibility at 4800x2700
+   - Increase bottom margin: `chart.options.chart = {'marginBottom': 100, ...}`
+   - Or add spacingBottom: `chart.options.chart = {'spacingBottom': 60, ...}`
+   - Ensure labels have `style: {'fontSize': '14px'}` for visibility at 3200x1800
 
 ## Colors
 
@@ -184,23 +191,23 @@ GRID        = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0
 
 chart.options.chart = {
     'type': 'column',
-    'width': 4800, 'height': 2700,
+    'width': 3200, 'height': 1800,
     'backgroundColor': PAGE_BG,
     'style': {'color': INK},
 }
-chart.options.title = {'text': title, 'style': {'fontSize': '28px', 'color': INK}}
+chart.options.title = {'text': title, 'style': {'fontSize': '22px', 'color': INK}}
 chart.options.x_axis = {
-    'title': {'text': x_label, 'style': {'fontSize': '22px', 'color': INK}},
-    'labels': {'style': {'fontSize': '18px', 'color': INK_SOFT}},
+    'title': {'text': x_label, 'style': {'fontSize': '16px', 'color': INK}},
+    'labels': {'style': {'fontSize': '14px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.y_axis = {
-    'title': {'text': y_label, 'style': {'fontSize': '22px', 'color': INK}},
-    'labels': {'style': {'fontSize': '18px', 'color': INK_SOFT}},
+    'title': {'text': y_label, 'style': {'fontSize': '16px', 'color': INK}},
+    'labels': {'style': {'fontSize': '14px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.legend = {
-    'itemStyle': {'color': INK_SOFT},
+    'itemStyle': {'color': INK_SOFT, 'fontSize': '14px'},
     'backgroundColor': ELEVATED_BG, 'borderColor': INK_SOFT, 'borderWidth': 1,
 }
 ```

--- a/prompts/library/letsplot.md
+++ b/prompts/library/letsplot.md
@@ -19,24 +19,26 @@ plot = (
 )
 ```
 
-## Figure Size & Sizing for 4800×2700 px
+## Figure Size & Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ```python
-# Base size (scaled 3x on export = 4800 × 2700 px)
-plot = plot + ggsize(1600, 900)
+# Base size (scaled 4x on export = 3200 × 1800 px)
+plot = plot + ggsize(800, 450)
 
 # Text and element sizes
 plot = plot + theme(
-    axis_title=element_text(size=20),
-    axis_text=element_text(size=16),
-    plot_title=element_text(size=24),
-    legend_text=element_text(size=16)
+    axis_title=element_text(size=16),
+    axis_text=element_text(size=14),
+    plot_title=element_text(size=22),
+    legend_text=element_text(size=14)
 )
 
-# Element sizes in geoms
-+ geom_point(size=4)    # ~3-4x default
-+ geom_line(size=1.5)   # line width
+# Element sizes in geoms (density-aware — see default-style-guide.md)
++ geom_point(size=2.5)   # ~2-3x default
++ geom_line(size=1.0)    # line width
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Save (PNG + HTML)
 
@@ -46,8 +48,8 @@ from lets_plot import ggsave
 
 THEME = os.getenv("ANYPLOT_THEME", "light")
 
-# PNG: scale 3x to get 4800 × 2700 px
-ggsave(plot, f'plot-{THEME}.png', scale=3)
+# PNG: scale 4x to get 3200 × 1800 px
+ggsave(plot, f'plot-{THEME}.png', scale=4)
 
 # HTML (interactive)
 ggsave(plot, f'plot-{THEME}.html')

--- a/prompts/library/matplotlib.md
+++ b/prompts/library/matplotlib.md
@@ -21,7 +21,8 @@ from matplotlib.figure import Figure
 ## Create Figure
 
 ```python
-fig, ax = plt.subplots(figsize=(16, 9))
+# Target: 3200 × 1800 px (8 × 400dpi). See default-style-guide.md "Visual Sizing Defaults".
+fig, ax = plt.subplots(figsize=(8, 4.5), dpi=400)
 ```
 
 ## Plot Methods
@@ -41,22 +42,22 @@ plt.scatter(x, y)
 ## Save
 
 ```python
-plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight')
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ```
 
-## Sizing for 4800×2700 px
+## Sizing for 3200×1800 px (starting values — adjust per plot, review-loop tunes)
 
 ```python
 # Text sizes
-ax.set_title(title, fontsize=24, fontweight='medium')
-ax.set_xlabel(x_label, fontsize=20)
-ax.set_ylabel(y_label, fontsize=20)
-ax.tick_params(axis='both', labelsize=16)
-ax.legend(fontsize=16)
+ax.set_title(title, fontsize=18, fontweight='medium')
+ax.set_xlabel(x_label, fontsize=14)
+ax.set_ylabel(y_label, fontsize=14)
+ax.tick_params(axis='both', labelsize=12)
+ax.legend(fontsize=12)
 
 # Element sizes
-ax.scatter(x, y, s=200, edgecolors='white', linewidth=0.5)  # s=150-300
-ax.plot(x, y, linewidth=3)   # linewidth=2-4 (not 1!)
+ax.scatter(x, y, s=100, edgecolors='white', linewidth=0.5)  # s=60-150 (density-aware)
+ax.plot(x, y, linewidth=2.5)   # ~2-3 for primary lines
 
 # Grid (subtle, y-axis preferred)
 ax.yaxis.grid(True, alpha=0.2, linewidth=0.8)
@@ -66,13 +67,15 @@ ax.spines['top'].set_visible(False)
 ax.spines['right'].set_visible(False)
 ```
 
+See `prompts/default-style-guide.md` "Proportional Sizing" for the review-step criteria — short labels at oversized fonts cost points; long descriptive labels at normal fonts are fine.
+
 ## Styling
 
 ```python
-ax.set_xlabel(x_label, fontsize=20)
-ax.set_ylabel(y_label, fontsize=20)
-ax.set_title(title, fontsize=24, fontweight='medium')
-ax.legend(fontsize=16)  # if needed (omit for single-series)
+ax.set_xlabel(x_label, fontsize=14)
+ax.set_ylabel(y_label, fontsize=14)
+ax.set_title(title, fontsize=18, fontweight='medium')
+ax.legend(fontsize=12)  # if needed (omit for single-series)
 plt.tight_layout()
 ```
 
@@ -121,7 +124,7 @@ INK         = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT    = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED   = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-fig, ax = plt.subplots(figsize=(16, 9), facecolor=PAGE_BG)
+fig, ax = plt.subplots(figsize=(8, 4.5), dpi=400, facecolor=PAGE_BG)
 ax.set_facecolor(PAGE_BG)
 
 ax.set_title(..., color=INK)
@@ -140,7 +143,7 @@ if leg:
 ax.annotate(..., color=INK,
             bbox=dict(facecolor=ELEVATED_BG, edgecolor=INK_SOFT, alpha=0.9))
 
-plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight', facecolor=PAGE_BG)
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight', facecolor=PAGE_BG)
 ```
 
 ## Output Files

--- a/prompts/library/plotly.md
+++ b/prompts/library/plotly.md
@@ -19,26 +19,28 @@ fig.add_trace(go.Scatter(x=x, y=y))
 fig = px.scatter(df, x='col_x', y='col_y')
 ```
 
-## Layout & Sizing for 4800×2700 px
+## Layout & Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ```python
 fig.update_layout(
-    title=dict(text=title, font=dict(size=28)),
-    xaxis=dict(title=dict(text=x_label, font=dict(size=22)), tickfont=dict(size=18)),
-    yaxis=dict(title=dict(text=y_label, font=dict(size=22)), tickfont=dict(size=18)),
+    title=dict(text=title, font=dict(size=22)),
+    xaxis=dict(title=dict(text=x_label, font=dict(size=16)), tickfont=dict(size=14)),
+    yaxis=dict(title=dict(text=y_label, font=dict(size=16)), tickfont=dict(size=14)),
     template='plotly_white',
 )
 
-# Marker/line sizes
-fig.update_traces(marker=dict(size=12))   # ~3-4x default
-fig.update_traces(line=dict(width=3))
+# Marker/line sizes (density-aware — see default-style-guide.md)
+fig.update_traces(marker=dict(size=10))
+fig.update_traces(line=dict(width=2.5))
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Save (PNG)
 
 ```python
-# Target: 4800 × 2700 px (see default-style-guide.md)
-fig.write_image(f'plot-{THEME}.png', width=1600, height=900, scale=3)
+# Target: 3200 × 1800 px (800 × scale=4). See default-style-guide.md.
+fig.write_image(f'plot-{THEME}.png', width=800, height=450, scale=4)
 ```
 
 **Note**: Requires `kaleido` for PNG export.
@@ -101,7 +103,7 @@ fig.update_layout(
     ),
 )
 
-fig.write_image(f'plot-{THEME}.png', width=1600, height=900, scale=3)
+fig.write_image(f'plot-{THEME}.png', width=800, height=450, scale=4)
 fig.write_html(f'plot-{THEME}.html', include_plotlyjs='cdn')
 ```
 

--- a/prompts/library/plotnine.md
+++ b/prompts/library/plotnine.md
@@ -44,27 +44,29 @@ plot = (
 )
 ```
 
-## Figure Size & Sizing for 4800×2700 px
+## Figure Size & Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ```python
 plot = plot + theme(
-    figure_size=(16, 9),
-    text=element_text(size=14),           # Base text
-    axis_title=element_text(size=20),     # Axis labels
-    axis_text=element_text(size=16),      # Tick labels
-    plot_title=element_text(size=24),     # Title
-    legend_text=element_text(size=16)
+    figure_size=(8, 4.5),
+    text=element_text(size=10),           # Base text
+    axis_title=element_text(size=14),     # Axis labels
+    axis_text=element_text(size=12),      # Tick labels
+    plot_title=element_text(size=18),     # Title
+    legend_text=element_text(size=12)
 )
 
-# Element sizes in geoms
-+ geom_point(size=4)    # ~3-4x default
-+ geom_line(size=1.5)   # line width
+# Element sizes in geoms (density-aware — see default-style-guide.md)
++ geom_point(size=2.5)   # ~2-3x library default
++ geom_line(size=1.0)    # line width (plotnine scale is finer than matplotlib's)
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Save (PNG)
 
 ```python
-plot.save(f'plot-{THEME}.png', dpi=300)
+plot.save(f'plot-{THEME}.png', dpi=400, width=8, height=4.5, units='in')
 ```
 
 ## Brewer Palettes
@@ -157,7 +159,7 @@ anyplot_theme = theme(
 )
 
 plot = (ggplot(df, aes('x', 'y')) + geom_point(color=OKABE_ITO[0]) + anyplot_theme)
-ggsave(plot, filename=f'plot-{THEME}.png', dpi=300, width=16, height=9)
+ggsave(plot, filename=f'plot-{THEME}.png', dpi=400, width=8, height=4.5)
 ```
 
 ## Output Files

--- a/prompts/library/pygal.md
+++ b/prompts/library/pygal.md
@@ -10,10 +10,10 @@ from pygal.style import Style
 ## Create Chart
 
 ```python
-# Target: 4800 × 2700 px (see default-style-guide.md)
+# Target: 3200 × 1800 px (see default-style-guide.md)
 chart = pygal.Bar(
-    width=4800,
-    height=2700,
+    width=3200,
+    height=1800,
     title=title,
     x_title=x_label,
     y_title=y_label
@@ -56,7 +56,7 @@ with open(f'plot-{THEME}.html', 'wb') as f:
     f.write(chart.render())
 ```
 
-## Sizing + Theme for 4800×2700 px
+## Sizing + Theme for 3200×1800 px (starting values — review-loop tunes)
 
 pygal's `Style` object carries ALL theme tokens. Derive them from `ANYPLOT_THEME`.
 
@@ -79,16 +79,18 @@ custom_style = Style(
     foreground_strong=INK,          # title
     foreground_subtle=INK_MUTED,    # tick labels, grid tone
     colors=OKABE_ITO,               # first series = brand green
-    title_font_size=28,
-    label_font_size=18,
-    major_label_font_size=16,
-    legend_font_size=16,
-    value_font_size=14,
-    stroke_width=3,
+    title_font_size=22,
+    label_font_size=14,
+    major_label_font_size=14,
+    legend_font_size=14,
+    value_font_size=12,
+    stroke_width=2.5,
 )
 
 chart = pygal.Bar(style=custom_style)
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 
 ## Grid
 

--- a/prompts/library/seaborn.md
+++ b/prompts/library/seaborn.md
@@ -22,7 +22,8 @@ from matplotlib.figure import Figure
 ## Create Figure
 
 ```python
-fig, ax = plt.subplots(figsize=(16, 9))
+# Target: 3200 × 1800 px (8 × 400dpi). See default-style-guide.md "Visual Sizing Defaults".
+fig, ax = plt.subplots(figsize=(8, 4.5), dpi=400)
 ```
 
 ## Plot Methods
@@ -39,24 +40,24 @@ fig = g.figure
 ## Save
 
 ```python
-plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight')
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ```
 
-## Sizing for 4800×2700 px
+## Sizing for 3200×1800 px (starting values — adjust per plot, review-loop tunes)
 
 ```python
 # Text sizes (seaborn uses matplotlib underneath)
-ax.set_title(title, fontsize=24, fontweight='medium')
-ax.set_xlabel(x_label, fontsize=20)
-ax.set_ylabel(y_label, fontsize=20)
-ax.tick_params(axis='both', labelsize=16)
+ax.set_title(title, fontsize=18, fontweight='medium')
+ax.set_xlabel(x_label, fontsize=14)
+ax.set_ylabel(y_label, fontsize=14)
+ax.tick_params(axis='both', labelsize=12)
 
 # Or use sns.set_context for global scaling
-sns.set_context("talk", font_scale=1.2)
+sns.set_context("notebook", font_scale=1.0)
 
-# Element sizes in seaborn functions
-sns.scatterplot(..., s=200)           # marker size
-sns.lineplot(..., linewidth=3)        # line width
+# Element sizes in seaborn functions (density-aware — see default-style-guide.md)
+sns.scatterplot(..., s=100)           # marker size, 60-150 typical
+sns.lineplot(..., linewidth=2.5)      # line width
 
 # Spine removal (default: remove top + right)
 ax.spines['top'].set_visible(False)
@@ -65,6 +66,8 @@ ax.spines['right'].set_visible(False)
 # Grid (subtle, y-axis preferred)
 ax.yaxis.grid(True, alpha=0.2, linewidth=0.8)
 ```
+
+See `prompts/default-style-guide.md` "Proportional Sizing" for the review-step criteria.
 
 ## API Compatibility (0.14+)
 
@@ -142,7 +145,7 @@ sns.set_theme(
 )
 
 # After plotting
-plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight', facecolor=PAGE_BG)
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight', facecolor=PAGE_BG)
 ```
 
 ## Output Files

--- a/prompts/workflow-prompts/ai-quality-review.md
+++ b/prompts/workflow-prompts/ai-quality-review.md
@@ -65,6 +65,23 @@ For `plot-dark.png` (background should be `#1A1A17`):
 
 A plot that's perfect in one theme but unreadable in the other still **fails** — both renders must pass. Be strict: a plot that ships to the website broken on dark mode is worse than one that fails review and gets repaired.
 
+### 5d. MANDATORY: Proportional Sizing Check (both renders)
+
+Visually estimate from each PNG — no pixel measurement needed. These are soft proportional checks **without hard thresholds**. Violations cost points in the existing VQ-01 (Text Legibility), VQ-02 (No Overlap), and VQ-05 (Layout & Canvas) categories rather than triggering a separate pass/fail item. A single visual problem can reduce points in multiple categories simultaneously (holistic, not strict).
+
+- **Title proportion:** Title occupies ~50–70% of the plot width. Too narrow → fontsize probably too small (deduct VQ-01). Too wide / overflowing → fontsize probably too big OR title too verbose (deduct VQ-01 + VQ-05).
+- **Axis label proportionality:** Short labels with few words ("Date", "Year") must not dominate the axis with oversized fontsizes. Long descriptive labels ("Fläche von Häusern in Quadratmetern", "Average temperature in °C") are completely fine as long as they don't overflow — the "No overflow" check below covers that. Disproportionately oversized short labels → deduct VQ-05.
+- **Axis label balance:** X-axis and Y-axis labels are visually similar in size. One much larger than the other without semantic reason → deduct VQ-05.
+- **Tick label balance:** X-axis and Y-axis tick labels are visually similar in size. Exception: rotated long categorical labels may legitimately look wider.
+- **No overlap:** No text overlaps with other text, with data elements, or with legend/annotation boxes → deduct VQ-02 (severe overlap = 0).
+- **No overflow:** No text extends beyond axis bounds, plot bounds, or the canvas frame → deduct VQ-05.
+- **Marker / line density appropriateness:** Sparse data (< 50 points) should have prominent markers; dense data (> 500 points) should have smaller markers + `alpha < 1` to combat overplotting → deduct VQ-03 when poorly chosen.
+
+**Required:** Note specific violations in `weaknesses` with enough context for the repair loop to fix them. Examples:
+- "X-axis label 'Date' is oversized at fontsize=24pt, dominates the axis disproportional to its info content — reduce to ~12pt."
+- "Title overflows ~95% of plot width — reduce title fontsize from 22 to 14, or accept that the long mandated anyplot title needs ~14pt at this canvas."
+- "Sparse scatter (32 points) but marker size=6 px makes them barely visible — increase to size=12-16."
+
 ### 6. Check for Auto-Reject (AR-08)
 
 **For static libraries (matplotlib, seaborn, plotnine, ggplot2) only:**
@@ -84,11 +101,11 @@ Read `prompts/quality-criteria.md` and evaluate:
 #### Visual Quality (30 pts)
 | ID | Criterion | Max | Check |
 |----|-----------|-----|-------|
-| VQ-01 | Text Legibility | 8 | Font sizes explicitly set? Readable at full size in BOTH themes? |
-| VQ-02 | No Overlap | 6 | All text readable? No collisions? |
-| VQ-03 | Element Visibility | 6 | Markers/lines adapted to density? |
+| VQ-01 | Text Legibility | 8 | Font sizes explicitly set? Readable at full size in BOTH themes? Mobile-readable when scaled to ~400 px? Apply Proportional Sizing Check (5d). |
+| VQ-02 | No Overlap | 6 | All text readable? No collisions with other text or with data? See 5d. |
+| VQ-03 | Element Visibility | 6 | Markers/lines adapted to density? See 5d data-density appropriateness. |
 | VQ-04 | Color Accessibility | 2 | Adequate contrast + CVD-safe (beyond palette)? No red-green as sole signal? |
-| VQ-05 | Layout & Canvas | 4 | Good proportions? Nothing cut off? |
+| VQ-05 | Layout & Canvas | 4 | Good proportions? Nothing cut off? Title 50–70% width, balanced axis labels, no overflow — see 5d. |
 | VQ-06 | Axis Labels & Title | 2 | Descriptive with units? |
 | VQ-07 | Palette Compliance | 2 | First categorical series = `#009E73`? Multi-series follows Okabe-Ito order? Continuous data uses `viridis`/`cividis`/`BrBG`? Plot backgrounds are `#FAF8F1` (light) / `#1A1A17` (dark)? Both renders theme-correct? |
 

--- a/prompts/workflow-prompts/impl-repair-claude.md
+++ b/prompts/workflow-prompts/impl-repair-claude.md
@@ -25,8 +25,21 @@ Read both sources to understand what needs to be fixed:
 ## Step 2: Read reference files
 
 1. `prompts/library/{LIBRARY}.md` - Library-specific rules + theme-adaptive chrome mapping
-2. `prompts/default-style-guide.md` - Canonical Okabe-Ito palette + theme tokens (re-read if VQ-07 or VQ-04 failed)
+2. `prompts/default-style-guide.md` - Canonical Okabe-Ito palette + theme tokens (re-read if VQ-07 or VQ-04 failed), plus "Visual Sizing Defaults" and "Proportional Sizing" sections (re-read if VQ-01 / VQ-02 / VQ-05 failed)
 3. `plots/{SPEC_ID}/specification.md` - The specification
+
+**Visual-sizing fixes (when VQ-01 / VQ-02 / VQ-05 failed):**
+- Title too big / overflows → reduce fontsize or shorten title text
+- Short axis label disproportionately big ("Date" dominates axis) → reduce that label's fontsize while keeping the other axis-label/tick fontsizes balanced
+- Long descriptive label overflows axis → reduce fontsize OR rotate ticks/labels
+- Text overlaps → adjust margins, rotate ticks, reduce label fontsize, or move legend
+- Sparse data with tiny markers → increase `s=` / `size=` / `marker.size=` / `marker.radius`
+- Dense data with oversized markers / overplotting → reduce marker size + add `alpha=0.5-0.7`
+
+Adjust the canvas-controlling knobs of the relevant library family:
+- DPI-based (matplotlib / seaborn / plotnine): `figsize`, `dpi`, `fontsize=`
+- Scale-based (plotly / altair / lets-plot): `width`/`height`/`scale_factor`, theme font sizes
+- Native-pixel (bokeh / highcharts / pygal): `width`/`height` directly, `text_font_size` / `style.fontSize` / `Style(... _font_size=...)` — for highcharts keep the three canvas-size spots in sync (Selenium `--window-size`, HTML `<div style="width:height:">`, `chart.options.chart = {'width':,'height':}`); for bokeh keep Selenium `W, H` matching `figure(width=, height=)`
 
 **Do NOT re-read `prompts/quality-criteria.md`** — the review already distilled all criteria into `review.criteria_checklist` in the metadata YAML (Step 1). Use that checklist directly: items with `passed: false` are the ones to fix.
 

--- a/scripts/style-experiment.py
+++ b/scripts/style-experiment.py
@@ -496,7 +496,25 @@ def main() -> int:
         if xvfb_display:
             os.environ["DISPLAY"] = xvfb_display
             print(f"[style-experiment] shared Xvfb on {xvfb_display} (pid {xvfb_proc.pid})")
-            atexit.register(lambda: (xvfb_proc.terminate(), xvfb_proc.wait(timeout=3)) if xvfb_proc else None)
+
+            def _stop_xvfb(proc: subprocess.Popen = xvfb_proc) -> None:
+                # Be quiet + tolerant at interpreter shutdown: process may have
+                # already exited, terminate may race, wait may time out — none
+                # of which warrants a noisy atexit traceback.
+                if proc.poll() is not None:
+                    return
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
+
+            atexit.register(_stop_xvfb)
 
     # Auto-detect a real chromedriver for bokeh's export_png (Ubuntu's /usr/bin/chromedriver is a snap stub).
     # Selenium-manager downloads one to ~/.cache/selenium on first selenium.webdriver.Chrome() call.

--- a/scripts/style-experiment.py
+++ b/scripts/style-experiment.py
@@ -35,11 +35,14 @@ import atexit
 import json
 import os
 import re
+import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 import webbrowser
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
@@ -142,10 +145,13 @@ def apply_patches(text: str, patches: list[Patch]) -> tuple[str, int]:
 
 
 _pending_restores: dict[Path, str] = {}
+_restores_lock = threading.Lock()
 
 
 def _restore_all() -> None:
-    for path, original in list(_pending_restores.items()):
+    with _restores_lock:
+        items = list(_pending_restores.items())
+    for path, original in items:
         try:
             path.write_text(original)
         except Exception as exc:
@@ -153,7 +159,8 @@ def _restore_all() -> None:
                   f"will retry on next cleanup hook",
                   file=sys.stderr)
             continue
-        _pending_restores.pop(path, None)
+        with _restores_lock:
+            _pending_restores.pop(path, None)
 
 
 def _signal_handler(signum: int, frame: Any) -> None:
@@ -183,13 +190,15 @@ def patched_in_place(impl_path: Path, patches: list[Patch]):
         yield 0
         return
     patched, n_applied = apply_patches(original, patches)
-    _pending_restores[impl_path] = original
+    with _restores_lock:
+        _pending_restores[impl_path] = original
     try:
         impl_path.write_text(patched)
         yield n_applied
     finally:
         impl_path.write_text(original)
-        _pending_restores.pop(impl_path, None)
+        with _restores_lock:
+            _pending_restores.pop(impl_path, None)
 
 
 def render_one_theme(impl_path: Path, run_dir: Path, theme: str) -> None:
@@ -199,10 +208,20 @@ def render_one_theme(impl_path: Path, run_dir: Path, theme: str) -> None:
     cmd = ["uv", "run", "python", "-P", str(impl_path)]
     log = run_dir / f"run-{theme}.log"
     with log.open("w") as f:
-        f.write(f"$ ANYPLOT_THEME={theme} {' '.join(cmd)}\n\n")
+        f.write(f"$ ANYPLOT_THEME={theme} DISPLAY={env.get('DISPLAY', '')} {' '.join(cmd)}\n\n")
+        # If DISPLAY is already set (shared Xvfb started by main), use it directly.
+        # Otherwise fall back to per-render xvfb-run -a, then native (no X).
+        if env.get("DISPLAY"):
+            subprocess.run(
+                cmd,
+                cwd=run_dir, env=env, check=True,
+                stdout=f, stderr=subprocess.STDOUT,
+                timeout=RENDER_TIMEOUT_SEC,
+            )
+            return
         try:
             subprocess.run(
-                ["xvfb-run"] + cmd,
+                ["xvfb-run", "-a"] + cmd,
                 cwd=run_dir, env=env, check=True,
                 stdout=f, stderr=subprocess.STDOUT,
                 timeout=RENDER_TIMEOUT_SEC,
@@ -214,6 +233,27 @@ def render_one_theme(impl_path: Path, run_dir: Path, theme: str) -> None:
                 stdout=f, stderr=subprocess.STDOUT,
                 timeout=RENDER_TIMEOUT_SEC,
             )
+
+
+def start_shared_xvfb() -> tuple[subprocess.Popen, str] | tuple[None, None]:
+    """Start a single Xvfb for the whole experiment. Returns (proc, ':N')."""
+    if not shutil.which("Xvfb"):
+        return None, None
+    for n in range(99, 200):
+        if Path(f"/tmp/.X{n}-lock").exists():
+            continue
+        proc = subprocess.Popen(
+            ["Xvfb", f":{n}", "-screen", "0", "1920x1080x24", "-nolisten", "tcp"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        time.sleep(0.7)
+        if proc.poll() is None and Path(f"/tmp/.X{n}-lock").exists():
+            return proc, f":{n}"
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    raise RuntimeError("No free Xvfb display in :99..:199")
 
 
 def run_one_combination(
@@ -348,8 +388,10 @@ def write_compare_html(
   <label>Thumbnail width:
     <select onchange="document.documentElement.style.setProperty('--thumb', this.value)">
       <option value="160px">160px (mobile thumbnail)</option>
-      <option value="320px" selected>320px (grid)</option>
+      <option value="320px">320px (grid)</option>
+      <option value="375px" selected>375px (iPhone viewport)</option>
       <option value="640px">640px (detail)</option>
+      <option value="700px">700px (Plot-of-the-Day)</option>
       <option value="1200px">1200px (large)</option>
     </select>
   </label>
@@ -404,6 +446,9 @@ def parse_args() -> argparse.Namespace:
                    help=f"Output directory (default: {DEFAULT_OUTPUT_ROOT}/<timestamp>)")
     p.add_argument("--open", dest="open_browser", action="store_true",
                    help="Open compare.html in the default browser when done")
+    p.add_argument("--parallel", type=int, default=1,
+                   help="Parallel (spec, library) workers. Each worker runs variants "
+                        "serially since they patch the same source file. Default 1.")
     return p.parse_args()
 
 
@@ -439,23 +484,74 @@ def main() -> int:
         print("Patches will still be reverted via try/finally, but verify with `git status` after.\n")
 
     total = len(specs) * len(libraries) * len(variants) * len(themes)
+    parallel = max(1, int(args.parallel))
     print(f"[style-experiment] {total} render(s) -> {output_root}")
-    print(f"[style-experiment] specs={specs} libs={libraries} variants={variant_names} themes={themes}\n")
+    print(f"[style-experiment] specs={specs} libs={libraries} variants={variant_names} themes={themes}")
+    print(f"[style-experiment] parallel workers={parallel} (one per spec,library pair)")
 
+    # Single shared Xvfb avoids xvfb-run display-allocation races with parallel workers.
+    xvfb_proc, xvfb_display = (None, None)
+    if not os.environ.get("DISPLAY"):
+        xvfb_proc, xvfb_display = start_shared_xvfb()
+        if xvfb_display:
+            os.environ["DISPLAY"] = xvfb_display
+            print(f"[style-experiment] shared Xvfb on {xvfb_display} (pid {xvfb_proc.pid})")
+            atexit.register(lambda: (xvfb_proc.terminate(), xvfb_proc.wait(timeout=3)) if xvfb_proc else None)
+
+    # Auto-detect a real chromedriver for bokeh's export_png (Ubuntu's /usr/bin/chromedriver is a snap stub).
+    # Selenium-manager downloads one to ~/.cache/selenium on first selenium.webdriver.Chrome() call.
+    if not os.environ.get("BOKEH_CHROMEDRIVER_PATH"):
+        cache = Path.home() / ".cache" / "selenium" / "chromedriver"
+        candidates = sorted(cache.glob("*/[0-9]*/chromedriver")) if cache.is_dir() else []
+        if candidates:
+            os.environ["BOKEH_CHROMEDRIVER_PATH"] = str(candidates[-1])
+            print(f"[style-experiment] BOKEH_CHROMEDRIVER_PATH={candidates[-1]}")
+        else:
+            print("[style-experiment] WARN: no selenium-managed chromedriver in cache; "
+                  "bokeh's export_png may fail. Run any bokeh impl using selenium.webdriver.Chrome "
+                  "once to populate ~/.cache/selenium, then retry.")
+    print()
+
+    work_units = [(spec, lib) for spec in specs for lib in libraries]
+    print_lock = threading.Lock()
     all_records: list[RunRecord] = []
-    i = 0
-    for spec in specs:
-        for lib in libraries:
-            for variant in variants:
-                i += 1
-                print(f"[{i}/{len(specs)*len(libraries)*len(variants)}] "
-                      f"{spec} / {lib} / {variant.name}")
-                records = run_one_combination(spec, lib, variant, themes, output_root)
-                for r in records:
-                    status = "OK" if r.success else "FAIL"
-                    print(f"    {r.theme:5s}  {status:4s}  {r.duration_sec}s"
-                          + (f"  ({r.error[:80]})" if r.error else ""))
-                all_records.extend(records)
+    records_lock = threading.Lock()
+    counter = {"done": 0}
+    total_units = len(work_units)
+
+    def process_unit(spec_lib: tuple[str, str]) -> list[RunRecord]:
+        spec, lib = spec_lib
+        unit_records: list[RunRecord] = []
+        for variant in variants:
+            recs = run_one_combination(spec, lib, variant, themes, output_root)
+            unit_records.extend(recs)
+        with print_lock:
+            counter["done"] += 1
+            n_ok = sum(1 for r in unit_records if r.success)
+            n_total = len(unit_records)
+            tag = "OK" if n_ok == n_total else f"{n_ok}/{n_total} ok"
+            print(f"[{counter['done']}/{total_units}] {spec} / {lib}: {tag}")
+            for r in unit_records:
+                if not r.success:
+                    print(f"    FAIL  {r.variant} {r.theme}: {(r.error or '')[:100]}")
+        return unit_records
+
+    if parallel == 1:
+        for unit in work_units:
+            recs = process_unit(unit)
+            all_records.extend(recs)
+    else:
+        with ThreadPoolExecutor(max_workers=parallel) as executor:
+            futures = {executor.submit(process_unit, u): u for u in work_units}
+            for fut in as_completed(futures):
+                try:
+                    recs = fut.result()
+                except Exception as exc:
+                    with print_lock:
+                        print(f"[style-experiment] ERROR in {futures[fut]}: {exc}")
+                    continue
+                with records_lock:
+                    all_records.extend(recs)
 
     write_manifest(output_root, all_records, variants)
     write_compare_html(output_root, all_records, variants, specs, libraries, themes)

--- a/scripts/style-variants.yaml
+++ b/scripts/style-variants.yaml
@@ -68,6 +68,202 @@ variants:
         - {find: "width=4800",  replace: "width=2400"}
         - {find: "height=2700", replace: "height=1350"}
 
+  A_canvas_half_dpi_double:
+    description: "Canvas figsize/width halved, DPI/scale doubled. Output stays 4800x2700 px. For DPI/scale libs, fonts/lines/markers (all in pt) auto-double via DPI. For native-px libs (bokeh/highcharts/pygal): explicit ~2x on font/line/marker."
+    patches:
+      matplotlib:
+        - {find: "figsize=(16, 9)", replace: "figsize=(8, 4.5)"}
+        - {find: "dpi=300",         replace: "dpi=600"}
+      seaborn:
+        - {find: "figsize=(16, 9)", replace: "figsize=(8, 4.5)"}
+        - {find: "dpi=300",         replace: "dpi=600"}
+      plotnine:
+        - {find: "figure_size=(16, 9)", replace: "figure_size=(8, 4.5)"}
+        - {find: "dpi=300",             replace: "dpi=600"}
+      plotly:
+        - {find: "width=1600", replace: "width=800"}
+        - {find: "height=900", replace: "height=450"}
+        - {regex: 'scale=3\b', replace: "scale=6"}
+      altair:
+        - {find: "width=1600",         replace: "width=800"}
+        - {find: "height=900",         replace: "height=450"}
+        - {find: "scale_factor=3.0",   replace: "scale_factor=6.0"}
+      letsplot:
+        - {find: "ggsize(1600, 900)",  replace: "ggsize(800, 450)"}
+        - {regex: 'scale=3\b',         replace: "scale=6"}
+      bokeh:
+        - {find: "width=4800",  replace: "width=2400"}
+        - {find: "height=2700", replace: "height=1350"}
+        - {find: "width=3600",  replace: "width=1800"}
+        - {find: "height=3600", replace: "height=1800"}
+        - {find: "W, H = 4800, 2700", replace: "W, H = 2400, 1350"}
+        - {find: "W, H = 3600, 3600", replace: "W, H = 1800, 1800"}
+        - {find: '"28pt"', replace: '"56pt"'}
+        - {find: '"22pt"', replace: '"44pt"'}
+        - {find: '"18pt"', replace: '"36pt"'}
+        - {find: '"16pt"', replace: '"32pt"'}
+        - {regex: 'line_width\s*=\s*4\b', replace: "line_width=8"}
+        - {regex: 'line_width\s*=\s*3\b', replace: "line_width=6"}
+        - {regex: 'line_width\s*=\s*2\b', replace: "line_width=4"}
+      highcharts:
+        - {find: "--window-size=4800,2700", replace: "--window-size=2400,1350"}
+        - {find: "--window-size=3600,3600", replace: "--window-size=1800,1800"}
+        - {find: '"width": 4800,',  replace: '"width": 2400,'}
+        - {find: '"height": 2700,', replace: '"height": 1350,'}
+        - {find: '"width": 3600,',  replace: '"width": 1800,'}
+        - {find: '"height": 3600,', replace: '"height": 1800,'}
+        - {find: 'style="width: 4800px; height: 2700px;"', replace: 'style="width: 2400px; height: 1350px;"'}
+        - {find: 'style="width: 3600px; height: 3600px;"', replace: 'style="width: 1800px; height: 1800px;"'}
+        - {find: '"fontSize": "28px"', replace: '"fontSize": "56px"'}
+        - {find: '"fontSize": "22px"', replace: '"fontSize": "44px"'}
+        - {find: '"fontSize": "18px"', replace: '"fontSize": "36px"'}
+        - {find: '"fontSize": "16px"', replace: '"fontSize": "32px"'}
+        - {regex: '"lineWidth":\s*4\b', replace: '"lineWidth": 8'}
+        - {regex: '"radius":\s*6\b',    replace: '"radius": 12'}
+        - {regex: '"radius":\s*5\b',    replace: '"radius": 10'}
+      pygal:
+        - {find: "width=4800",  replace: "width=2400"}
+        - {find: "height=2700", replace: "height=1350"}
+        - {find: "width=3600",  replace: "width=1800"}
+        - {find: "height=3600", replace: "height=1800"}
+        - {regex: 'title_font_size\s*=\s*28\b',       replace: "title_font_size=56"}
+        - {regex: 'label_font_size\s*=\s*22\b',       replace: "label_font_size=44"}
+        - {regex: 'major_label_font_size\s*=\s*18\b', replace: "major_label_font_size=36"}
+        - {regex: 'legend_font_size\s*=\s*16\b',      replace: "legend_font_size=32"}
+        - {regex: 'value_font_size\s*=\s*14\b',       replace: "value_font_size=28"}
+        - {regex: 'stroke_width\s*=\s*3\b',           replace: "stroke_width=6"}
+
+  B_canvas_2400_keep_dpi:
+    description: "Source PNG shrinks to 2400x1350 (no DPI compensation). Fonts/lines/markers unchanged in pt/px - become relatively 2x larger. Trade-off: less 4K-detail, smaller bytes."
+    patches:
+      matplotlib:
+        - {find: "dpi=300", replace: "dpi=150"}
+      seaborn:
+        - {find: "dpi=300", replace: "dpi=150"}
+      plotnine:
+        - {find: "dpi=300", replace: "dpi=150"}
+      plotly:
+        - {find: "width=1600", replace: "width=800"}
+        - {find: "height=900", replace: "height=450"}
+      altair:
+        - {find: "width=1600", replace: "width=800"}
+        - {find: "height=900", replace: "height=450"}
+      letsplot:
+        - {find: "ggsize(1600, 900)", replace: "ggsize(800, 450)"}
+      bokeh:
+        - {find: "width=4800",  replace: "width=2400"}
+        - {find: "height=2700", replace: "height=1350"}
+        - {find: "width=3600",  replace: "width=1800"}
+        - {find: "height=3600", replace: "height=1800"}
+        - {find: "W, H = 4800, 2700", replace: "W, H = 2400, 1350"}
+        - {find: "W, H = 3600, 3600", replace: "W, H = 1800, 1800"}
+      highcharts:
+        - {find: "--window-size=4800,2700", replace: "--window-size=2400,1350"}
+        - {find: "--window-size=3600,3600", replace: "--window-size=1800,1800"}
+        - {find: '"width": 4800,',  replace: '"width": 2400,'}
+        - {find: '"height": 2700,', replace: '"height": 1350,'}
+        - {find: '"width": 3600,',  replace: '"width": 1800,'}
+        - {find: '"height": 3600,', replace: '"height": 1800,'}
+        - {find: 'style="width: 4800px; height: 2700px;"', replace: 'style="width: 2400px; height: 1350px;"'}
+        - {find: 'style="width: 3600px; height: 3600px;"', replace: 'style="width: 1800px; height: 1800px;"'}
+      pygal:
+        - {find: "width=4800",  replace: "width=2400"}
+        - {find: "height=2700", replace: "height=1350"}
+        - {find: "width=3600",  replace: "width=1800"}
+        - {find: "height=3600", replace: "height=1800"}
+
+  C_outliers_only:
+    description: "Only patch bokeh/highcharts/pygal (the 3 native-px outliers). Font x ~2.5, line x ~2.5, marker x ~2.5. Other 6 libraries unchanged."
+    patches:
+      bokeh:
+        - {find: '"28pt"', replace: '"70pt"'}
+        - {find: '"22pt"', replace: '"55pt"'}
+        - {find: '"18pt"', replace: '"45pt"'}
+        - {find: '"16pt"', replace: '"40pt"'}
+        - {regex: 'line_width\s*=\s*4\b', replace: "line_width=10"}
+        - {regex: 'line_width\s*=\s*3\b', replace: "line_width=8"}
+        - {regex: 'line_width\s*=\s*2\b', replace: "line_width=5"}
+      highcharts:
+        - {find: '"fontSize": "28px"', replace: '"fontSize": "70px"'}
+        - {find: '"fontSize": "22px"', replace: '"fontSize": "55px"'}
+        - {find: '"fontSize": "18px"', replace: '"fontSize": "45px"'}
+        - {find: '"fontSize": "16px"', replace: '"fontSize": "40px"'}
+        - {regex: '"lineWidth":\s*4\b', replace: '"lineWidth": 10'}
+        - {regex: '"radius":\s*6\b',    replace: '"radius": 15'}
+        - {regex: '"radius":\s*5\b',    replace: '"radius": 12'}
+      pygal:
+        - {regex: 'title_font_size\s*=\s*28\b',       replace: "title_font_size=70"}
+        - {regex: 'label_font_size\s*=\s*22\b',       replace: "label_font_size=55"}
+        - {regex: 'major_label_font_size\s*=\s*18\b', replace: "major_label_font_size=45"}
+        - {regex: 'legend_font_size\s*=\s*16\b',      replace: "legend_font_size=40"}
+        - {regex: 'value_font_size\s*=\s*14\b',       replace: "value_font_size=35"}
+        - {regex: 'stroke_width\s*=\s*3\b',           replace: "stroke_width=8"}
+
+  D_canvas_half_dpi_double_plus_aggressive_outliers:
+    description: "A + C combined with aggressive (~3x) outlier boost. Upper-bound sanity check - tests if A's gain plus extra outlier-headroom over-saturates."
+    patches:
+      matplotlib:
+        - {find: "figsize=(16, 9)", replace: "figsize=(8, 4.5)"}
+        - {find: "dpi=300",         replace: "dpi=600"}
+      seaborn:
+        - {find: "figsize=(16, 9)", replace: "figsize=(8, 4.5)"}
+        - {find: "dpi=300",         replace: "dpi=600"}
+      plotnine:
+        - {find: "figure_size=(16, 9)", replace: "figure_size=(8, 4.5)"}
+        - {find: "dpi=300",             replace: "dpi=600"}
+      plotly:
+        - {find: "width=1600", replace: "width=800"}
+        - {find: "height=900", replace: "height=450"}
+        - {regex: 'scale=3\b', replace: "scale=6"}
+      altair:
+        - {find: "width=1600",         replace: "width=800"}
+        - {find: "height=900",         replace: "height=450"}
+        - {find: "scale_factor=3.0",   replace: "scale_factor=6.0"}
+      letsplot:
+        - {find: "ggsize(1600, 900)",  replace: "ggsize(800, 450)"}
+        - {regex: 'scale=3\b',         replace: "scale=6"}
+      bokeh:
+        - {find: "width=4800",  replace: "width=2400"}
+        - {find: "height=2700", replace: "height=1350"}
+        - {find: "width=3600",  replace: "width=1800"}
+        - {find: "height=3600", replace: "height=1800"}
+        - {find: "W, H = 4800, 2700", replace: "W, H = 2400, 1350"}
+        - {find: "W, H = 3600, 3600", replace: "W, H = 1800, 1800"}
+        - {find: '"28pt"', replace: '"84pt"'}
+        - {find: '"22pt"', replace: '"66pt"'}
+        - {find: '"18pt"', replace: '"54pt"'}
+        - {find: '"16pt"', replace: '"48pt"'}
+        - {regex: 'line_width\s*=\s*4\b', replace: "line_width=12"}
+        - {regex: 'line_width\s*=\s*3\b', replace: "line_width=9"}
+        - {regex: 'line_width\s*=\s*2\b', replace: "line_width=6"}
+      highcharts:
+        - {find: "--window-size=4800,2700", replace: "--window-size=2400,1350"}
+        - {find: "--window-size=3600,3600", replace: "--window-size=1800,1800"}
+        - {find: '"width": 4800,',  replace: '"width": 2400,'}
+        - {find: '"height": 2700,', replace: '"height": 1350,'}
+        - {find: '"width": 3600,',  replace: '"width": 1800,'}
+        - {find: '"height": 3600,', replace: '"height": 1800,'}
+        - {find: 'style="width: 4800px; height: 2700px;"', replace: 'style="width: 2400px; height: 1350px;"'}
+        - {find: 'style="width: 3600px; height: 3600px;"', replace: 'style="width: 1800px; height: 1800px;"'}
+        - {find: '"fontSize": "28px"', replace: '"fontSize": "84px"'}
+        - {find: '"fontSize": "22px"', replace: '"fontSize": "66px"'}
+        - {find: '"fontSize": "18px"', replace: '"fontSize": "54px"'}
+        - {find: '"fontSize": "16px"', replace: '"fontSize": "48px"'}
+        - {regex: '"lineWidth":\s*4\b', replace: '"lineWidth": 12'}
+        - {regex: '"radius":\s*6\b',    replace: '"radius": 18'}
+        - {regex: '"radius":\s*5\b',    replace: '"radius": 15'}
+      pygal:
+        - {find: "width=4800",  replace: "width=2400"}
+        - {find: "height=2700", replace: "height=1350"}
+        - {find: "width=3600",  replace: "width=1800"}
+        - {find: "height=3600", replace: "height=1800"}
+        - {regex: 'title_font_size\s*=\s*28\b',       replace: "title_font_size=84"}
+        - {regex: 'label_font_size\s*=\s*22\b',       replace: "label_font_size=66"}
+        - {regex: 'major_label_font_size\s*=\s*18\b', replace: "major_label_font_size=54"}
+        - {regex: 'legend_font_size\s*=\s*16\b',      replace: "legend_font_size=48"}
+        - {regex: 'value_font_size\s*=\s*14\b',       replace: "value_font_size=42"}
+        - {regex: 'stroke_width\s*=\s*3\b',           replace: "stroke_width=9"}
+
   palette_tableau:
     description: "Tableau-10 categorical palette in place of Okabe-Ito (visual sanity check, not a real proposal)."
     patches:

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "anyplot"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Default canvas: 4800×2700 → **3200×1800** (16:9) and 3600×3600 → **2400×2400** (1:1) — ~44% pixel area, mobile-readable while keeping 3200px Hi-Res headroom for desktop monitors
- Per-library starting values updated for all 10 libraries (matplotlib `figsize=(8,4.5) dpi=400`, plotly `width=800 scale=4`, bokeh `width=3200` native, etc.) — non-strict starting points, AI may adjust per plot
- New "Proportional Sizing" section in `default-style-guide.md` + new "Proportional Sizing Check" (section 5d) in `ai-quality-review.md` — soft proportional rules (title ~50–70% width, balanced axis labels, no overlap, no overflow, density-aware markers) that cost points across VQ-01 / VQ-02 / VQ-05 holistically rather than as a separate strict pass/fail item
- Long descriptive axis labels ("Fläche von Häusern in Quadratmetern") are explicitly fine — only disproportionately oversized short labels ("Date" at 24pt) get flagged
- Repair-loop guide in `impl-repair-claude.md` extended with typical visual-sizing fixes per library family

## Context

Empirically validated via `scripts/style-experiment.py` (540 renders × 6 specs × 9 libs × 5 variants). The "B + bump" variant (2/3 of previous size) is the sweet spot: simpler than DPI-doubling for native-pixel libs (bokeh/highcharts/pygal), retains enough resolution for desktop zoom, makes mobile actually readable.

The second commit (`chore(scripts)`) is the experiment infrastructure that produced the data — parallelization, A/B/C/D variants in `style-variants.yaml`, iPhone-width thumbnails in `compare.html`. Useful for future visual A/B tests.

## Rollout
- Daily-regen is disabled (manually) so it won't pick up the changes asynchronously
- After merge, iterate by triggering \`gh workflow run impl-generate.yml -f specification_id=timeseries-forecast-uncertainty -f library=<lib>\` against main
- View PNG, judge proportions, tune prompts via small follow-up PRs, repeat
- Once all 9 libs look good for a couple of test specs, re-enable daily-regen for full ~200-spec rollout over ~14 days

## Test plan
- [ ] CI green
- [ ] After merge: trigger impl-generate for \`timeseries-forecast-uncertainty\` × matplotlib (single lib for fast feedback) → verify PNG is 3200×1800 and proportions look right
- [ ] Repeat for all 9 libs once happy with matplotlib
- [ ] Check Frontend Detail-Page on mobile (≤400 px) — tick labels should be readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)