### PR TITLE
fix(style): smaller title/tick/legend defaults for 3200x1800 canvas

### DIFF
--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -183,10 +183,10 @@ Three library families with different sizing controls:
 |---------|--------------------------------------------|------------------------------------------|------------------------------------------|
 | Canvas (16:9) | `figsize=(8, 4.5)` `dpi=400` | `width=800 height=450 scale=4` | `width=3200 height=1800` |
 | Canvas (1:1) | `figsize=(6, 6)` `dpi=400` | `width=600 height=600 scale=4` | `width=2400 height=2400` |
-| Title | 18pt | 22px | '22pt' |
-| Axis labels | 14pt | 16px | '16pt' |
-| Tick labels | 12pt | 14px | '14pt' |
-| Legend | 12pt | 14px | '14pt' |
+| Title | 14pt | 18px | '18pt' |
+| Axis labels | 12pt | 14px | '14pt' |
+| Tick labels | 10pt | 12px | '12pt' |
+| Legend | 10pt | 12px | '12pt' |
 
 All three families produce the same 3200×1800 (or 2400×2400) output, so text pixel sizes are comparable across libraries.
 

--- a/prompts/library/altair.md
+++ b/prompts/library/altair.md
@@ -15,10 +15,13 @@ chart = alt.Chart(df).mark_point(size=60).encode(  # size ~2-3x default, density
 ).properties(
     width=800,
     height=450,
-    title=alt.Title(title, fontSize=22)
+    title=alt.Title(title, fontSize=18)  # kept compact for the long mandated title
 ).configure_axis(
-    labelFontSize=14,
-    titleFontSize=16
+    labelFontSize=12,
+    titleFontSize=14
+).configure_legend(
+    labelFontSize=12,
+    titleFontSize=12
 )
 ```
 

--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -89,12 +89,12 @@ driver.quit()
 ## Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ```python
-# Text sizes
-p.title.text_font_size = '22pt'
-p.xaxis.axis_label_text_font_size = '16pt'
-p.yaxis.axis_label_text_font_size = '16pt'
-p.xaxis.major_label_text_font_size = '14pt'
-p.yaxis.major_label_text_font_size = '14pt'
+# Text sizes — title kept compact for the long mandated anyplot title
+p.title.text_font_size = '18pt'
+p.xaxis.axis_label_text_font_size = '14pt'
+p.yaxis.axis_label_text_font_size = '14pt'
+p.xaxis.major_label_text_font_size = '12pt'
+p.yaxis.major_label_text_font_size = '12pt'
 
 # Element sizes (density-aware — see default-style-guide.md)
 p.scatter(..., size=10)        # ~2-3x default

--- a/prompts/library/ggplot2.md
+++ b/prompts/library/ggplot2.md
@@ -62,7 +62,7 @@ set.seed(42)
 p <- ggplot(df, aes(x = col_x, y = col_y)) +
   geom_point() +
   labs(x = x_label, y = y_label, title = plot_title) +
-  theme_minimal(base_size = 10)
+  theme_minimal(base_size = 8)
 ```
 
 ## Figure Size & Sizing for 3200×1800 px (starting values — review-loop tunes)
@@ -73,12 +73,12 @@ elements for the anyplot canvas:
 ```r
 p <- p +
   theme(
-    text             = element_text(size = 10),  # base text
-    axis.title       = element_text(size = 14),  # axis labels
-    axis.text        = element_text(size = 12),  # tick labels
-    plot.title       = element_text(size = 18),
-    legend.text      = element_text(size = 12),
-    legend.title     = element_text(size = 14)
+    text             = element_text(size = 8),   # base text
+    axis.title       = element_text(size = 12),  # axis labels
+    axis.text        = element_text(size = 10),  # tick labels
+    plot.title       = element_text(size = 14),  # kept compact for the long mandated title
+    legend.text      = element_text(size = 10),
+    legend.title     = element_text(size = 12)
   )
 
 # Element sizes inside geoms (~2-3× ggplot2 defaults, density-aware):
@@ -149,7 +149,7 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
-anyplot_theme <- theme_minimal(base_size = 10) +
+anyplot_theme <- theme_minimal(base_size = 8) +
   theme(
     plot.background   = element_rect(fill = PAGE_BG, color = PAGE_BG),
     panel.background  = element_rect(fill = PAGE_BG, color = NA),
@@ -224,15 +224,15 @@ df <- tibble::tibble(
 p <- ggplot(df, aes(x, y)) +
   geom_point(color = OKABE_ITO[1], size = 2.5, alpha = 0.7) +
   labs(title = "scatter-basic · r · ggplot2 · anyplot.ai", x = "X", y = "Y") +
-  theme_minimal(base_size = 10) +
+  theme_minimal(base_size = 8) +
   theme(
     plot.background  = element_rect(fill = PAGE_BG, color = PAGE_BG),
     panel.background = element_rect(fill = PAGE_BG, color = NA),
     panel.grid.major = element_line(color = INK, linewidth = 0.3),
     panel.grid.minor = element_line(color = INK, linewidth = 0.2),
-    axis.title       = element_text(color = INK,      size = 14),
-    axis.text        = element_text(color = INK_SOFT, size = 12),
-    plot.title       = element_text(color = INK,      size = 18)
+    axis.title       = element_text(color = INK,      size = 12),
+    axis.text        = element_text(color = INK_SOFT, size = 10),
+    plot.title       = element_text(color = INK,      size = 14)
   )
 
 # --- Save -------------------------------------------------------------------

--- a/prompts/library/highcharts.md
+++ b/prompts/library/highcharts.md
@@ -195,19 +195,19 @@ chart.options.chart = {
     'backgroundColor': PAGE_BG,
     'style': {'color': INK},
 }
-chart.options.title = {'text': title, 'style': {'fontSize': '22px', 'color': INK}}
+chart.options.title = {'text': title, 'style': {'fontSize': '18px', 'color': INK}}
 chart.options.x_axis = {
-    'title': {'text': x_label, 'style': {'fontSize': '16px', 'color': INK}},
-    'labels': {'style': {'fontSize': '14px', 'color': INK_SOFT}},
+    'title': {'text': x_label, 'style': {'fontSize': '14px', 'color': INK}},
+    'labels': {'style': {'fontSize': '12px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.y_axis = {
-    'title': {'text': y_label, 'style': {'fontSize': '16px', 'color': INK}},
-    'labels': {'style': {'fontSize': '14px', 'color': INK_SOFT}},
+    'title': {'text': y_label, 'style': {'fontSize': '14px', 'color': INK}},
+    'labels': {'style': {'fontSize': '12px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.legend = {
-    'itemStyle': {'color': INK_SOFT, 'fontSize': '14px'},
+    'itemStyle': {'color': INK_SOFT, 'fontSize': '12px'},
     'backgroundColor': ELEVATED_BG, 'borderColor': INK_SOFT, 'borderWidth': 1,
 }
 ```

--- a/prompts/library/letsplot.md
+++ b/prompts/library/letsplot.md
@@ -27,10 +27,10 @@ plot = plot + ggsize(800, 450)
 
 # Text and element sizes
 plot = plot + theme(
-    axis_title=element_text(size=16),
-    axis_text=element_text(size=14),
-    plot_title=element_text(size=22),
-    legend_text=element_text(size=14)
+    axis_title=element_text(size=14),
+    axis_text=element_text(size=12),
+    plot_title=element_text(size=18),  # kept compact for the long mandated title
+    legend_text=element_text(size=12)
 )
 
 # Element sizes in geoms (density-aware — see default-style-guide.md)

--- a/prompts/library/matplotlib.md
+++ b/prompts/library/matplotlib.md
@@ -48,12 +48,13 @@ plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ## Sizing for 3200×1800 px (starting values — adjust per plot, review-loop tunes)
 
 ```python
-# Text sizes
-ax.set_title(title, fontsize=18, fontweight='medium')
-ax.set_xlabel(x_label, fontsize=14)
-ax.set_ylabel(y_label, fontsize=14)
-ax.tick_params(axis='both', labelsize=12)
-ax.legend(fontsize=12)
+# Text sizes — title kept compact because the mandated "{spec-id} · python · matplotlib · anyplot.ai"
+# title is ~67 chars and would overflow at 16+pt on the 3200px-wide canvas.
+ax.set_title(title, fontsize=14, fontweight='medium')
+ax.set_xlabel(x_label, fontsize=12)
+ax.set_ylabel(y_label, fontsize=12)
+ax.tick_params(axis='both', labelsize=10)
+ax.legend(fontsize=10)
 
 # Element sizes
 ax.scatter(x, y, s=100, edgecolors='white', linewidth=0.5)  # s=60-150 (density-aware)
@@ -72,10 +73,10 @@ See `prompts/default-style-guide.md` "Proportional Sizing" for the review-step c
 ## Styling
 
 ```python
-ax.set_xlabel(x_label, fontsize=14)
-ax.set_ylabel(y_label, fontsize=14)
-ax.set_title(title, fontsize=18, fontweight='medium')
-ax.legend(fontsize=12)  # if needed (omit for single-series)
+ax.set_xlabel(x_label, fontsize=12)
+ax.set_ylabel(y_label, fontsize=12)
+ax.set_title(title, fontsize=14, fontweight='medium')
+ax.legend(fontsize=10)  # if needed (omit for single-series)
 plt.tight_layout()
 ```
 

--- a/prompts/library/plotly.md
+++ b/prompts/library/plotly.md
@@ -23,9 +23,11 @@ fig = px.scatter(df, x='col_x', y='col_y')
 
 ```python
 fig.update_layout(
-    title=dict(text=title, font=dict(size=22)),
-    xaxis=dict(title=dict(text=x_label, font=dict(size=16)), tickfont=dict(size=14)),
-    yaxis=dict(title=dict(text=y_label, font=dict(size=16)), tickfont=dict(size=14)),
+    # Title kept compact — the long mandated "{spec-id} · python · plotly · anyplot.ai"
+    # title would overflow at 22+px on this canvas.
+    title=dict(text=title, font=dict(size=18)),
+    xaxis=dict(title=dict(text=x_label, font=dict(size=14)), tickfont=dict(size=12)),
+    yaxis=dict(title=dict(text=y_label, font=dict(size=14)), tickfont=dict(size=12)),
     template='plotly_white',
 )
 

--- a/prompts/library/plotnine.md
+++ b/prompts/library/plotnine.md
@@ -49,11 +49,11 @@ plot = (
 ```python
 plot = plot + theme(
     figure_size=(8, 4.5),
-    text=element_text(size=10),           # Base text
-    axis_title=element_text(size=14),     # Axis labels
-    axis_text=element_text(size=12),      # Tick labels
-    plot_title=element_text(size=18),     # Title
-    legend_text=element_text(size=12)
+    text=element_text(size=8),            # Base text
+    axis_title=element_text(size=12),     # Axis labels
+    axis_text=element_text(size=10),      # Tick labels
+    plot_title=element_text(size=14),     # Title — kept compact to fit the long mandated title
+    legend_text=element_text(size=10)
 )
 
 # Element sizes in geoms (density-aware — see default-style-guide.md)

--- a/prompts/library/pygal.md
+++ b/prompts/library/pygal.md
@@ -79,11 +79,11 @@ custom_style = Style(
     foreground_strong=INK,          # title
     foreground_subtle=INK_MUTED,    # tick labels, grid tone
     colors=OKABE_ITO,               # first series = brand green
-    title_font_size=22,
-    label_font_size=14,
-    major_label_font_size=14,
-    legend_font_size=14,
-    value_font_size=12,
+    title_font_size=18,             # kept compact for the long mandated title
+    label_font_size=12,
+    major_label_font_size=12,
+    legend_font_size=12,
+    value_font_size=10,
     stroke_width=2.5,
 )
 

--- a/prompts/library/seaborn.md
+++ b/prompts/library/seaborn.md
@@ -46,11 +46,12 @@ plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ## Sizing for 3200×1800 px (starting values — adjust per plot, review-loop tunes)
 
 ```python
-# Text sizes (seaborn uses matplotlib underneath)
-ax.set_title(title, fontsize=18, fontweight='medium')
-ax.set_xlabel(x_label, fontsize=14)
-ax.set_ylabel(y_label, fontsize=14)
-ax.tick_params(axis='both', labelsize=12)
+# Text sizes (seaborn uses matplotlib underneath) — title kept compact to avoid
+# overflow of the long mandated "{spec-id} · python · seaborn · anyplot.ai" title.
+ax.set_title(title, fontsize=14, fontweight='medium')
+ax.set_xlabel(x_label, fontsize=12)
+ax.set_ylabel(y_label, fontsize=12)
+ax.tick_params(axis='both', labelsize=10)
 
 # Or use sns.set_context for global scaling
 sns.set_context("notebook", font_scale=1.0)


### PR DESCRIPTION
## Summary
- Title default reduced (18→14 DPI / 22→18 px/native) so the long mandated \"{spec-id} · {lang} · {lib} · anyplot.ai\" title (~67 chars) fits under the proportional check's 70% width target without needing a repair-loop iteration
- Tick + legend default reduced by 2pt per family — user feedback after PR #7388: 12pt felt visually too large on 3200×1800

## Why
First iteration (matplotlib `timeseries-forecast-uncertainty`, PR #7388):
- Title at 18pt → 95-100% width → repair-loop reduced to 15pt → still 80% width → reviewer marked "acceptable" but VQ-01 + VQ-05 each lost 1 point
- User feedback on the merged result: tick labels + legend also a bit too big

This bakes the lower defaults in so the AI starts near the converged values instead of needing repair iterations each time.

## Changes
| Family           | Title    | Axis     | Tick     | Legend   |
|------------------|----------|----------|----------|----------|
| DPI (mpl/sns/p9) | 18 → 14  | 14 → 12  | 12 → 10  | 12 → 10  |
| Scale (ply/at/lp)| 22 → 18  | 16 → 14  | 14 → 12  | 14 → 12  |
| Native (bk/hc/pg)| 22 → 18  | 16 → 14  | 14 → 12  | 14 → 12  |
| ggplot2 (R)      | 18 → 14  | 14 → 12  | 12 → 10  | 12 → 10  |

`default-style-guide.md` Visual Sizing Defaults table updated to match.

## Test plan
- [ ] CI green
- [ ] After merge: trigger \`gh workflow run impl-generate.yml -f specification_id=timeseries-forecast-uncertainty -f library=matplotlib\` → verify title fits under 70% width on first attempt
- [ ] If matplotlib looks good, fan out to other 8 libs

🤖 Generated with [Claude Code](https://claude.com/claude-code)