### PR TITLE
fix(prompts): remove stale 4800x2700 refs + reconcile VQ-01 wording

### DIFF
--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -213,7 +213,7 @@ Marker and line sizes should adapt to how dense the data is — no fixed values:
 
 The review step checks these proportions visually from the source PNG. There are no hard pixel thresholds — violations cost points in the existing VQ-01 (Text Legibility), VQ-02 (No Overlap), VQ-05 (Layout & Canvas) categories rather than triggering a separate pass/fail. This keeps the contract holistic: a single visual problem (oversized short axis label, overlapping ticks) can reduce points in multiple categories.
 
-- **Title proportion:** Title takes ~50–70% of the plot width. Too narrow → fontsize probably too small. Too wide / overflowing → fontsize probably too big or title too verbose.
+- **Title proportion:** Title comfortably takes ~50–70% of the plot width. The mandated `{spec-id} · {lang} · {lib} · anyplot.ai` title is ~67 chars long and naturally fills 70–85% at the style-guide default fontsize — this is **expected**, not a violation. Only flag if title overflows past ~90% of width OR fontsize is too generous for the content.
 - **Axis label proportionality:** Short labels ("Date", "Year") should not dominate the axis with oversized fontsizes. Long descriptive labels ("Fläche von Häusern in Quadratmetern") are fine as long as they don't overflow — the "no overflow" rule covers that case.
 - **Axis label balance:** X-axis label and Y-axis label are visually similar in size — one much larger than the other without semantic reason is a violation.
 - **Tick label balance:** X-axis and Y-axis tick labels are visually similar in size (exception: rotated long categorical labels).
@@ -253,4 +253,4 @@ The AI makes the following design decisions for each visualization:
 - Data label placement
 - Annotations and callouts (only when specification explicitly requests them)
 
-**Priority:** Clarity, beauty, and readability at full resolution (~13 million pixels).
+**Priority:** Clarity, beauty, and readability at full resolution (~5.76 million pixels) AND when scaled down to mobile width (~400 px).

--- a/prompts/plot-generator.md
+++ b/prompts/plot-generator.md
@@ -109,18 +109,18 @@ np.random.seed(42)
 study_hours = np.random.normal(6, 2, 80)
 exam_scores = study_hours * 8 + np.random.normal(0, 5, 80) + 30
 
-# Plot
-fig, ax = plt.subplots(figsize=(16, 9), facecolor=PAGE_BG)
+# Plot — see default-style-guide.md "Visual Sizing Defaults" for the canvas + sizing values
+fig, ax = plt.subplots(figsize=(8, 4.5), dpi=400, facecolor=PAGE_BG)
 ax.set_facecolor(PAGE_BG)
-ax.scatter(study_hours, exam_scores, alpha=0.7, s=200,
+ax.scatter(study_hours, exam_scores, alpha=0.7, s=100,
            color=BRAND, edgecolors=PAGE_BG, linewidth=0.5)
 
-# Style
-ax.set_xlabel('Study Hours per Day', fontsize=20, color=INK)
-ax.set_ylabel('Exam Score (%)', fontsize=20, color=INK)
+# Style — title kept compact because the mandated anyplot title is ~67 chars long
+ax.set_xlabel('Study Hours per Day', fontsize=12, color=INK)
+ax.set_ylabel('Exam Score (%)', fontsize=12, color=INK)
 ax.set_title('scatter-basic · python · matplotlib · anyplot.ai',
-             fontsize=24, fontweight='medium', color=INK)
-ax.tick_params(axis='both', labelsize=16, colors=INK_SOFT)
+             fontsize=14, fontweight='medium', color=INK)
+ax.tick_params(axis='both', labelsize=10, colors=INK_SOFT)
 ax.spines['top'].set_visible(False)
 ax.spines['right'].set_visible(False)
 for s in ('left', 'bottom'):
@@ -128,7 +128,7 @@ for s in ('left', 'bottom'):
 ax.yaxis.grid(True, alpha=0.10, linewidth=0.8, color=INK)
 
 plt.tight_layout()
-plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight', facecolor=PAGE_BG)
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight', facecolor=PAGE_BG)
 ```
 
 **The generated script must be run twice by the pipeline** — once with `ANYPLOT_THEME=light`, once with `ANYPLOT_THEME=dark` — producing `plot-light.png` and `plot-dark.png`. Interactive libraries additionally produce `plot-light.html` and `plot-dark.html`.
@@ -366,7 +366,7 @@ np.random.seed(42)
 ...
 
 # Plot
-fig, ax = plt.subplots(figsize=(16, 9))
+fig, ax = plt.subplots(figsize=(8, 4.5), dpi=400)
 ...
 
 # Style
@@ -374,7 +374,7 @@ ax.set_xlabel(...)
 ...
 
 # Save
-plt.savefig('plot.png', dpi=300, bbox_inches='tight')
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ```
 
 ### Import Organization
@@ -404,7 +404,7 @@ Blank line between groups. Only import what you use.
 
 ```python
 ax.scatter(study_hours, exam_scores,
-           alpha=0.7, s=200,
+           alpha=0.7, s=100,
            color=BRAND, edgecolors=PAGE_BG)
 ```
 
@@ -414,13 +414,13 @@ ax.scatter(study_hours, exam_scores,
 
 Must pass all visual quality criteria (VQ-01 through VQ-06) and design excellence criteria (DE-01 through DE-03) from `prompts/quality-criteria.md`.
 
-**IMPORTANT: Large Canvas Size!**
+**IMPORTANT: Standard Canvas Size**
 
-anyplot renders at **4800 × 2700 px** (16:9) or **3600 × 3600 px** (1:1) — standard element sizes are too small!
+anyplot renders at **3200 × 1800 px** (16:9) or **2400 × 2400 px** (1:1) — library default sizes are still too small at this canvas!
 
-- Elements should be **~3-4x larger** than library defaults
-- See `prompts/default-style-guide.md` for aesthetic principles and sizing
-- See `prompts/library/{library}.md` for library-specific sizes
+- Elements should be **~2-3x larger** than library defaults
+- See `prompts/default-style-guide.md` for "Visual Sizing Defaults" + "Proportional Sizing" criteria
+- See `prompts/library/{library}.md` for library-specific starting values
 
 **Aesthetic requirements from style guide:**
 - Follow minimalism: every element must earn its place

--- a/prompts/quality-criteria.md
+++ b/prompts/quality-criteria.md
@@ -90,10 +90,10 @@ A static library (matplotlib, seaborn, plotnine) simulates interactive features 
 
 | Format | Size | Aspect Ratio |
 |--------|------|--------------|
-| **Landscape** | 4800 × 2700 px | 16:9 |
-| **Square** | 3600 × 3600 px | 1:1 |
+| **Landscape** | 3200 × 1800 px | 16:9 |
+| **Square** | 2400 × 2400 px | 1:1 |
 
-**Both have ~13M pixels** → same font sizes work for both.
+**Both have ~5.76M pixels** → same font sizes work for both.
 
 **AI decides freely** which format is best for the specific plot.
 
@@ -153,14 +153,16 @@ A static library (matplotlib, seaborn, plotnine) simulates interactive features 
 
 ### VQ-01: Text Legibility (8 Points)
 
-All text must be clearly readable at 4800×2700 / 3600×3600 px.
+All text must be clearly readable at 3200×1800 / 2400×2400 px and remain legible when the PNG is scaled down to ~400 px (mobile viewport). See `prompts/default-style-guide.md` → "Visual Sizing Defaults" for per-library-family starting values and "Proportional Sizing" for the proportional checks.
+
+**Source-of-values is irrelevant** for VQ-01: defaults, AI-tuned, or repair-loop-tuned all score equally — what matters is the visual result. If the AI deviates from the style-guide defaults because the plot looks better that way (e.g. shrinking the title to fit a long mandated string, or growing tick labels for a sparse plot), that is **not** a deduction.
 
 | Points | Criterion |
 |--------|-----------|
-| 8 | All font sizes explicitly set: Title ≥24pt, Labels ≥20pt, Ticks ≥16pt, all perfectly readable |
-| 5 | All readable, but relying on library defaults rather than explicit sizing |
-| 3 | Partially too small |
-| 0 | Text hard to read |
+| 8 | All font sizes explicitly set and the result looks well-proportioned: no overflow, balanced X/Y axis labels + ticks, readable at both desktop and mobile widths. Title fits without clipping — for the long mandated `{spec-id} · {lang} · {lib} · anyplot.ai` format ~70–85% of width is expected and fine; shorter custom titles aim for ~50–70%. Deviations from style-guide defaults are fine if they improve the result. |
+| 5 | All readable but relying on library defaults rather than explicit sizing |
+| 3 | Partially too small OR proportions clearly off (e.g. short axis label "Date" disproportionately oversized, title overflowing >90% of width or clipping the canvas edges) |
+| 0 | Text hard to read at the canvas size, or text element unreadable in one of the two themes |
 
 **Key distinction:** Score of 8 requires **explicitly setting** font sizes, not just lucky defaults.
 

--- a/prompts/quality-evaluator.md
+++ b/prompts/quality-evaluator.md
@@ -277,10 +277,10 @@ Only award full points (5/5) for real, neutral contexts:
 ## Image Formats
 
 Both are valid:
-- **Landscape**: 4800 × 2700 px (16:9)
-- **Square**: 3600 × 3600 px (1:1)
+- **Landscape**: 3200 × 1800 px (16:9)
+- **Square**: 2400 × 2400 px (1:1)
 
-Both have ~13M pixels, so font size recommendations apply equally.
+Both have ~5.76M pixels, so font size recommendations apply equally.
 
 ## Interactive Libraries
 

--- a/prompts/workflow-prompts/ai-quality-review.md
+++ b/prompts/workflow-prompts/ai-quality-review.md
@@ -69,7 +69,7 @@ A plot that's perfect in one theme but unreadable in the other still **fails** �
 
 Visually estimate from each PNG — no pixel measurement needed. These are soft proportional checks **without hard thresholds**. Violations cost points in the existing VQ-01 (Text Legibility), VQ-02 (No Overlap), and VQ-05 (Layout & Canvas) categories rather than triggering a separate pass/fail item. A single visual problem can reduce points in multiple categories simultaneously (holistic, not strict).
 
-- **Title proportion:** Title occupies ~50–70% of the plot width. Too narrow → fontsize probably too small (deduct VQ-01). Too wide / overflowing → fontsize probably too big OR title too verbose (deduct VQ-01 + VQ-05).
+- **Title proportion:** Title comfortably occupies ~50–70% of the plot width. **Note:** the mandated `{spec-id} · {lang} · {lib} · anyplot.ai` title is ~67 chars; at the style-guide default fontsize it naturally fills ~70–85% on landscape. That is **expected and not a deduction** — the AI made the right tradeoff. Only deduct if either: (a) the title overflows beyond ~90% of plot width / clips edges, or (b) the fontsize is too generous for the title length (squeezed look, no breathing room) → VQ-01 + VQ-05.
 - **Axis label proportionality:** Short labels with few words ("Date", "Year") must not dominate the axis with oversized fontsizes. Long descriptive labels ("Fläche von Häusern in Quadratmetern", "Average temperature in °C") are completely fine as long as they don't overflow — the "No overflow" check below covers that. Disproportionately oversized short labels → deduct VQ-05.
 - **Axis label balance:** X-axis and Y-axis labels are visually similar in size. One much larger than the other without semantic reason → deduct VQ-05.
 - **Tick label balance:** X-axis and Y-axis tick labels are visually similar in size. Exception: rotated long categorical labels may legitimately look wider.
@@ -78,9 +78,13 @@ Visually estimate from each PNG — no pixel measurement needed. These are soft 
 - **Marker / line density appropriateness:** Sparse data (< 50 points) should have prominent markers; dense data (> 500 points) should have smaller markers + `alpha < 1` to combat overplotting → deduct VQ-03 when poorly chosen.
 
 **Required:** Note specific violations in `weaknesses` with enough context for the repair loop to fix them. Examples:
-- "X-axis label 'Date' is oversized at fontsize=24pt, dominates the axis disproportional to its info content — reduce to ~12pt."
-- "Title overflows ~95% of plot width — reduce title fontsize from 22 to 14, or accept that the long mandated anyplot title needs ~14pt at this canvas."
-- "Sparse scatter (32 points) but marker size=6 px makes them barely visible — increase to size=12-16."
+- "X-axis label 'Date' is oversized at fontsize=18pt, dominates the axis disproportional to its info content — reduce to ~10pt."
+- "Title overflows beyond plot edge (~95% width) — reduce title fontsize from 18pt to 12pt."
+- "Sparse scatter (32 points) but marker size=4 px makes them barely visible — increase to size=10-14."
+
+**Counter-examples (NOT deductions):**
+- "Title spans ~80% of width at fontsize=14pt." → Expected for the long mandated anyplot title; no deduction.
+- "Y-axis label 'Fläche von Häusern in Quadratmetern' takes ~40% of axis length at fontsize=12pt." → Genuinely long label at sensible fontsize; no deduction as long as it doesn't overflow the axis.
 
 ### 6. Check for Auto-Reject (AR-08)
 


### PR DESCRIPTION
## Summary
5 prompt files still contradicted the canvas-halve work from #7387 / #7389. This PR makes the prompt set self-consistent.

## Changes
**Canvas size cleanup** (4 places that still said 4800×2700 / 3600×3600 / ~13M pixels):
- \`quality-criteria.md\` image-formats table
- \`quality-evaluator.md\` image-formats section
- \`plot-generator.md\` large-canvas warning + example code (\`figsize=(16,9)\` + \`dpi=300\` + \`s=200\` + \`fontsize=24/20/16\` → \`figsize=(8,4.5)\` + \`dpi=400\` + \`s=100\` + \`fontsize=14/12/10\`)
- \`default-style-guide.md\` lingering \"~13 million pixels\"

**Reviewer-rubric reconciliation** (the important one):
- \`quality-criteria.md\` VQ-01 8/8: rewrote to grade on visual result, not whether AI used the style-guide defaults. Deviations from defaults are explicitly OK if they improve the result.
- \`quality-criteria.md\` VQ-01 + \`ai-quality-review.md\` Section 5d + \`default-style-guide.md\` Proportional Sizing all aligned on the title-proportion rule: 50–70% is comfortable, the mandated 67-char \`{spec-id} · {lang} · {lib} · anyplot.ai\` title naturally fills 70–85% at the style-guide default fontsize and that's **expected and not a deduction**. Only deduct if title overflows beyond ~90% / clips edges, or the fontsize is generous for the title length (squeezed look).
- Section 5d weakness examples updated from old (\`fontsize=24pt\`, \`size=22\`) to new (\`18pt\`, \`14pt\`) so the examples are self-consistent.
- Added counter-examples in Section 5d: \"Title at 80% width with 14pt fontsize → expected for long mandated title, no deduction\".

## Why now
Reviewing PR #7388's metadata exposed two issues:
1. Reviewer was deducting on the \"title spans 80% width\" without considering that this is unavoidable for the mandated long title — should be a non-issue.
2. The old VQ-01 ≥24pt threshold contradicted the new 14pt defaults, so without this fix the reviewer would systematically downscore every new implementation.

## Test plan
- [ ] CI green  
- [ ] After merge, retrigger matplotlib for timeseries-forecast-uncertainty → reviewer no longer flags the long title at the new 14pt default

🤖 Generated with [Claude Code](https://claude.com/claude-code)