### PR TITLE
fix(prompts): address Copilot follow-up review on canvas-halve PRs

### DIFF
--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -183,12 +183,12 @@ Three library families with different sizing controls:
 |---------|--------------------------------------------|------------------------------------------|------------------------------------------|
 | Canvas (16:9) | `figsize=(8, 4.5)` `dpi=400` | `width=800 height=450 scale=4` | `width=3200 height=1800` |
 | Canvas (1:1) | `figsize=(6, 6)` `dpi=400` | `width=600 height=600 scale=4` | `width=2400 height=2400` |
-| Title | 14pt | 18px | '18pt' |
-| Axis labels | 12pt | 14px | '14pt' |
-| Tick labels | 10pt | 12px | '12pt' |
-| Legend | 10pt | 12px | '12pt' |
+| Title | 14pt | 18px | bokeh `'18pt'`; highcharts `'18px'`; pygal `18` |
+| Axis labels | 12pt | 14px | bokeh `'14pt'`; highcharts `'14px'`; pygal `14` |
+| Tick labels | 10pt | 12px | bokeh `'12pt'`; highcharts `'12px'`; pygal `12` |
+| Legend | 10pt | 12px | bokeh `'12pt'`; highcharts `'12px'`; pygal `12` |
 
-All three families produce the same 3200×1800 (or 2400×2400) output, so text pixel sizes are comparable across libraries.
+All three families produce the same 3200×1800 (or 2400×2400) output, so text pixel sizes are comparable across libraries. The Native-pixel column uses each library's own unit convention — bokeh uses `pt` strings, highcharts uses `px` strings (because it goes through CSS in the rendered HTML), pygal uses unitless integers — see each library's prompt for the exact API.
 
 **Marker and line sizes** vary by library API and aren't directly comparable as a single number — matplotlib's `s=` is in points², plotly's `marker.size` is a pixel diameter, altair's `mark_point(size=...)` is an area, plotnine / lets-plot / ggplot2's `geom_point(size=...)` uses a smaller ggplot scale. See each library's own prompt (`prompts/library/<lib>.md` → "Sizing" section) for the canonical starting values, and adapt to data density per the heuristic below.
 

--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -96,6 +96,10 @@ p.yaxis.axis_label_text_font_size = '14pt'
 p.xaxis.major_label_text_font_size = '12pt'
 p.yaxis.major_label_text_font_size = '12pt'
 
+# Legend text — apply only when a legend is present
+# (set legend_label= on glyphs or configure p.legend after add_layout)
+# p.legend.label_text_font_size = '12pt'
+
 # Element sizes (density-aware — see default-style-guide.md)
 p.scatter(..., size=10)        # ~2-3x default
 p.line(..., line_width=2.5)

--- a/prompts/library/highcharts.md
+++ b/prompts/library/highcharts.md
@@ -152,7 +152,7 @@ See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 6. **X-axis labels cut off in PNG**: Category labels may be clipped at the bottom. Fix by:
    - Increase bottom margin: `chart.options.chart = {'marginBottom': 100, ...}`
    - Or add spacingBottom: `chart.options.chart = {'spacingBottom': 60, ...}`
-   - Ensure labels have `style: {'fontSize': '14px'}` for visibility at 3200x1800
+   - Default `style: {'fontSize': '12px'}` per the new 3200×1800 sizing. If still clipped after the margin fixes, bump to `'14px'` for that specific case — but keep all other label fontsizes at 12px for cross-axis balance.
 
 ## Colors
 

--- a/prompts/library/matplotlib.md
+++ b/prompts/library/matplotlib.md
@@ -54,7 +54,10 @@ ax.set_title(title, fontsize=14, fontweight='medium')
 ax.set_xlabel(x_label, fontsize=12)
 ax.set_ylabel(y_label, fontsize=12)
 ax.tick_params(axis='both', labelsize=10)
-ax.legend(fontsize=10)
+# Legend at 10pt — skip ax.legend() for single-series plots (avoids the
+# "No artists with labels found to put in legend" warning)
+if len(ax.get_legend_handles_labels()[0]) > 1:
+    ax.legend(fontsize=10)
 
 # Element sizes
 ax.scatter(x, y, s=100, edgecolors='white', linewidth=0.5)  # s=60-150 (density-aware)

--- a/prompts/library/plotnine.md
+++ b/prompts/library/plotnine.md
@@ -29,6 +29,7 @@ from plotnine import (
     ggplot, aes,
     geom_point, geom_line, geom_bar, geom_boxplot,
     labs, theme, theme_minimal,
+    element_text, element_rect, element_line,
     scale_fill_brewer, scale_color_brewer
 )
 ```

--- a/prompts/library/seaborn.md
+++ b/prompts/library/seaborn.md
@@ -52,6 +52,9 @@ ax.set_title(title, fontsize=14, fontweight='medium')
 ax.set_xlabel(x_label, fontsize=12)
 ax.set_ylabel(y_label, fontsize=12)
 ax.tick_params(axis='both', labelsize=10)
+# Legend at 10pt — skip for single-series plots (no labeled artists → warning)
+if len(ax.get_legend_handles_labels()[0]) > 1:
+    ax.legend(fontsize=10)
 
 # Or use sns.set_context for global scaling
 sns.set_context("notebook", font_scale=1.0)

--- a/prompts/plot-generator.md
+++ b/prompts/plot-generator.md
@@ -447,11 +447,11 @@ anyplot renders at **3200 × 1800 px** (16:9) or **2400 × 2400 px** (1:1) — l
 ```python
 THEME = os.getenv("ANYPLOT_THEME", "light")  # already defined at top
 
-# matplotlib/seaborn/plotnine (static, PNG only)
-plt.savefig(f'plot-{THEME}.png', dpi=300, bbox_inches='tight', facecolor=PAGE_BG)
+# matplotlib/seaborn/plotnine (static, PNG only) — figsize=(8, 4.5) dpi=400 → 3200×1800
+plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight', facecolor=PAGE_BG)
 
-# plotly (PNG + HTML)
-fig.write_image(f'plot-{THEME}.png', width=1600, height=900, scale=3)
+# plotly (PNG + HTML) — width=800 height=450 scale=4 → 3200×1800
+fig.write_image(f'plot-{THEME}.png', width=800, height=450, scale=4)
 fig.write_html(f'plot-{THEME}.html', include_plotlyjs='cdn')
 
 # bokeh (PNG + HTML)

--- a/prompts/quality-evaluator.md
+++ b/prompts/quality-evaluator.md
@@ -91,12 +91,12 @@ You evaluate implementations that passed all auto-reject checks. Focus purely on
 
 ```json
 {
-  "score": 76,
+  "score": 77,
   "tier": "Good",
   "pass": false,
 
   "visual_quality": {
-    "total": 23,
+    "total": 24,
     "vq01_text_legibility": {"score": 6, "max": 8, "note": "Title slightly oversized for content — fontsize=18pt squeezes against the right edge; reduce to ~14pt"},
     "vq02_no_overlap": {"score": 6, "max": 6, "note": "No overlap"},
     "vq03_element_visibility": {"score": 5, "max": 6, "note": "Visible but markers could be better adapted"},


### PR DESCRIPTION
## Summary
Late-arriving Copilot review comments on #7389 / #7391 / #7393 — all substantive, all applied here.

## Fixes
**High-impact** (would have caused generation failures or wrong sizing):
- \`plot-generator.md\`: Output Files snippet still had \`dpi=300\` (matplotlib) and \`width=1600 scale=3\` (plotly) — Claude would have used those in new plots
- \`library/plotnine.md\`: \`element_text\` used in snippet but missing from imports → \`NameError\` in generated code
- \`library/highcharts.md\`: \"X-axis labels cut off\" pitfall recommended \`14px\` contradicting the new 12px default

**Consistency**:
- \`default-style-guide.md\`: Native-pixel column mixed pt/px/unitless under one cell → split per library with explanatory note
- \`library/matplotlib.md\` + \`seaborn.md\`: \`ax.legend(...)\` was unconditional → wrapped in \`if len(...) > 1\` to avoid the \"No artists with labels\" warning on single-series plots
- \`library/bokeh.md\`: added commented legend fontsize example
- \`quality-evaluator.md\`: example JSON arithmetic was broken (sub-scores sum to 24 but total said 23 after #7393's score bump) — fixed total + top-level score

## Process note
All these comments arrived AFTER the parent PRs auto-merged via \`--auto\`. Per CLAUDE.md PR Follow-Through, I should poll Copilot review explicitly before \`--auto\`-merging prompt/cosmetic PRs in the future. Adding to the process-gaps memo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)