### PR TITLE
fix(prompts): regen base-style override explicitly includes canvas + sizing

### DIFF
--- a/prompts/workflow-prompts/impl-generate-claude.md
+++ b/prompts/workflow-prompts/impl-generate-claude.md
@@ -41,7 +41,7 @@ When regenerating an existing implementation, you MUST read these BEFORE writing
 
 - Preserve the bits listed under "Strengths" unchanged.
 - Address every bullet under "Weaknesses" and each ❌ item in the criteria checklist.
-- If a base style rule (palette, theme colors, chrome, etc. from `prompts/default-style-guide.md` or `prompts/library/{LIBRARY}.md`) conflicts with the previous implementation, update the previous code to match — base style wins.
+- **Base style ALWAYS wins.** If anything in `prompts/default-style-guide.md` or `prompts/library/{LIBRARY}.md` differs from the previous implementation, update the previous code to match. This explicitly includes — but is not limited to — **canvas size** (`figsize`/`dpi` for matplotlib/seaborn/plotnine/ggplot2, `width`/`height`/`scale_factor` for plotly/altair/letsplot, `width`/`height` for bokeh/highcharts/pygal), **font sizes** (title, axis labels, tick labels, legend), **marker and line sizes**, **palette** (Okabe-Ito positions), **theme tokens** (background, INK, INK_SOFT, ELEVATED_BG, GRID), and **chrome** (spines, gridlines, legend frame). The previous review may not have flagged the old values because they were valid at the time — that does NOT make them current. Always re-read the library prompt's "Sizing" section and the style guide's "Visual Sizing Defaults" table on every regen and align.
 - Do NOT discard working structure / data generation / layout choices that the previous review did not flag.
 - Your deliverable is a refined version of the previous file, not a fresh rewrite from the spec.
 


### PR DESCRIPTION
## Summary
Today's bulk-generate fan-out (#7395-#7405) revealed a regen-mindset bug: 3 of 10 libraries (seaborn #7396, altair #7398, ggplot2 #7403) kept their OLD 4800×2700 / 3600×3600 canvas + old fontsizes even though the library prompts had been updated to 3200×1800.

## Root cause
\`impl-generate-claude.md\` already said \"base style wins over previous implementation\" — but listed only \"palette, theme colors, chrome, etc.\" as the affected dimensions. Claude treated that list as exhaustive and assumed canvas / fontsize / marker / line-size changes were NOT in scope, since the previous review hadn't flagged the (then-valid) old values.

## Fix
Made the override rule explicit on every axis where the base style has an opinion:
- canvas size (figsize/dpi, width/height/scale_factor, native width/height)
- font sizes (title, axis, tick, legend)
- marker + line sizes
- palette + theme tokens + chrome (already covered, kept)

Plus: instruct the AI to **re-read the library prompt's \"Sizing\" section + the style guide's \"Visual Sizing Defaults\" table on every regen**, not just rely on what the previous review flagged.

## Test plan
- [ ] CI green
- [ ] After merge: re-trigger seaborn / altair / ggplot2 for timeseries-forecast-uncertainty → all three should produce 3200×1800 canvas in line with the other 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)