### PR TITLE
fix(prompts): native-pixel fonts were 3× too small vs DPI/scale families

### DIFF
--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -183,12 +183,19 @@ Three library families with different sizing controls:
 |---------|--------------------------------------------|------------------------------------------|------------------------------------------|
 | Canvas (16:9) | `figsize=(8, 4.5)` `dpi=400` | `width=800 height=450 scale=4` | `width=3200 height=1800` |
 | Canvas (1:1) | `figsize=(6, 6)` `dpi=400` | `width=600 height=600 scale=4` | `width=2400 height=2400` |
-| Title | 14pt | 18px | bokeh `'18pt'`; highcharts `'18px'`; pygal `18` |
-| Axis labels | 12pt | 14px | bokeh `'14pt'`; highcharts `'14px'`; pygal `14` |
-| Tick labels | 10pt | 12px | bokeh `'12pt'`; highcharts `'12px'`; pygal `12` |
-| Legend | 10pt | 12px | bokeh `'12pt'`; highcharts `'12px'`; pygal `12` |
+| Title | 14pt | 18px | bokeh `'56pt'`; highcharts `'56px'`; pygal `56` |
+| Axis labels | 12pt | 14px | bokeh `'42pt'`; highcharts `'42px'`; pygal `42` |
+| Tick labels | 10pt | 12px | bokeh `'36pt'`; highcharts `'36px'`; pygal `36` |
+| Legend | 10pt | 12px | bokeh `'36pt'`; highcharts `'36px'`; pygal `36` |
 
-All three families produce the same 3200×1800 (or 2400×2400) output, so text pixel sizes are comparable across libraries. The Native-pixel column uses each library's own unit convention — bokeh uses `pt` strings, highcharts uses `px` strings (because it goes through CSS in the rendered HTML), pygal uses unitless integers — see each library's prompt for the exact API.
+All three families produce the same 3200×1800 (or 2400×2400) output, so the source-pixel sizes of text are now comparable across libraries.
+
+**Why the Native-pixel numbers look so much bigger** — they aren't. The three families use completely different units for the same visual size:
+- **DPI-based** (matplotlib): `14pt × 400dpi/72 = 78 source-px`. The `pt` value is multiplied by dpi at render time.
+- **Scale-based** (plotly): `18px × scale=4 = 72 source-px`. The `px` value is multiplied by scale at render time.
+- **Native-pixel** (bokeh): `'56pt' × 96/72 ≈ 75 source-px`. The `'pt'` string is rendered as CSS pt (1pt = 1.333 px in the browser), no extra multiplier. So to match the other families' source-px values, the nominal pt/px number must be roughly **3× larger** than the DPI-based pt value.
+
+The Native-pixel column uses each library's own unit convention — bokeh uses `pt` strings (rendered as CSS pt via headless Chrome), highcharts uses `px` strings (CSS), pygal uses unitless integers (treated as px). See each library's prompt for the exact API.
 
 **Marker and line sizes** vary by library API and aren't directly comparable as a single number — matplotlib's `s=` is in points², plotly's `marker.size` is a pixel diameter, altair's `mark_point(size=...)` is an area, plotnine / lets-plot / ggplot2's `geom_point(size=...)` uses a smaller ggplot scale. See each library's own prompt (`prompts/library/<lib>.md` → "Sizing" section) for the canonical starting values, and adapt to data density per the heuristic below.
 

--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -89,16 +89,20 @@ driver.quit()
 ## Sizing for 3200×1800 px (starting values — review-loop tunes)
 
 ```python
-# Text sizes — title kept compact for the long mandated anyplot title
-p.title.text_font_size = '18pt'
-p.xaxis.axis_label_text_font_size = '14pt'
-p.yaxis.axis_label_text_font_size = '14pt'
-p.xaxis.major_label_text_font_size = '12pt'
-p.yaxis.major_label_text_font_size = '12pt'
+# Text sizes — bokeh fonts render via headless Chrome at CSS pt sizing
+# (1pt ≈ 1.333 source-px), so nominal values must be ~3× larger than the
+# DPI-based equivalents to match the same visual size. The pt values here
+# end up at roughly the same source-pixel height as matplotlib's
+# 14/12/10pt × dpi=400.
+p.title.text_font_size = '56pt'
+p.xaxis.axis_label_text_font_size = '42pt'
+p.yaxis.axis_label_text_font_size = '42pt'
+p.xaxis.major_label_text_font_size = '36pt'
+p.yaxis.major_label_text_font_size = '36pt'
 
 # Legend text — apply only when a legend is present
 # (set legend_label= on glyphs or configure p.legend after add_layout)
-# p.legend.label_text_font_size = '12pt'
+# p.legend.label_text_font_size = '36pt'
 
 # Element sizes (density-aware — see default-style-guide.md)
 p.scatter(..., size=10)        # ~2-3x default

--- a/prompts/library/highcharts.md
+++ b/prompts/library/highcharts.md
@@ -152,7 +152,7 @@ See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 6. **X-axis labels cut off in PNG**: Category labels may be clipped at the bottom. Fix by:
    - Increase bottom margin: `chart.options.chart = {'marginBottom': 100, ...}`
    - Or add spacingBottom: `chart.options.chart = {'spacingBottom': 60, ...}`
-   - Default `style: {'fontSize': '12px'}` per the new 3200×1800 sizing. If still clipped after the margin fixes, bump to `'14px'` for that specific case — but keep all other label fontsizes at 12px for cross-axis balance.
+   - Default `style: {'fontSize': '36px'}` per the new 3200×1800 sizing (native-pixel libraries need ~3× the matplotlib pt value — see default-style-guide.md "Why the Native-pixel numbers look so much bigger"). If still clipped after the margin fixes, bump to `'42px'` for that specific case — but keep all other label fontsizes at 36px for cross-axis balance.
 
 ## Colors
 
@@ -195,19 +195,22 @@ chart.options.chart = {
     'backgroundColor': PAGE_BG,
     'style': {'color': INK},
 }
-chart.options.title = {'text': title, 'style': {'fontSize': '18px', 'color': INK}}
+# Native-pixel sizing: highcharts fonts go through CSS in the rendered
+# HTML at the source-pixel grid (no scale multiplier), so the px values
+# here must be ~3× the matplotlib pt values to match the same visual size.
+chart.options.title = {'text': title, 'style': {'fontSize': '56px', 'color': INK}}
 chart.options.x_axis = {
-    'title': {'text': x_label, 'style': {'fontSize': '14px', 'color': INK}},
-    'labels': {'style': {'fontSize': '12px', 'color': INK_SOFT}},
+    'title': {'text': x_label, 'style': {'fontSize': '42px', 'color': INK}},
+    'labels': {'style': {'fontSize': '36px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.y_axis = {
-    'title': {'text': y_label, 'style': {'fontSize': '14px', 'color': INK}},
-    'labels': {'style': {'fontSize': '12px', 'color': INK_SOFT}},
+    'title': {'text': y_label, 'style': {'fontSize': '42px', 'color': INK}},
+    'labels': {'style': {'fontSize': '36px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.legend = {
-    'itemStyle': {'color': INK_SOFT, 'fontSize': '12px'},
+    'itemStyle': {'color': INK_SOFT, 'fontSize': '36px'},
     'backgroundColor': ELEVATED_BG, 'borderColor': INK_SOFT, 'borderWidth': 1,
 }
 ```

--- a/prompts/library/pygal.md
+++ b/prompts/library/pygal.md
@@ -79,11 +79,15 @@ custom_style = Style(
     foreground_strong=INK,          # title
     foreground_subtle=INK_MUTED,    # tick labels, grid tone
     colors=OKABE_ITO,               # first series = brand green
-    title_font_size=18,             # kept compact for the long mandated title
-    label_font_size=12,
-    major_label_font_size=12,
-    legend_font_size=12,
-    value_font_size=10,
+    # pygal font sizes are unitless integers, rendered into the SVG at the
+    # source-pixel grid (no DPI/scale multiplier). Need ~3× the matplotlib
+    # pt values to match — see default-style-guide.md "Why the Native-pixel
+    # numbers look so much bigger".
+    title_font_size=56,             # kept compact for the long mandated title
+    label_font_size=42,
+    major_label_font_size=36,
+    legend_font_size=36,
+    value_font_size=30,
     stroke_width=2.5,
 )
 


### PR DESCRIPTION
## Summary
Today's bulk-generate fan-out for \`timeseries-forecast-uncertainty\` exposed a fundamental cross-library bug: bokeh / highcharts / pygal rendered text ~3× smaller than matplotlib / seaborn / plotnine, even though the style guide table claimed the values were equivalent.

## Root cause
Different unit conversions across families:

| Family | nominal | source-pixel height |
|---|---|---|
| matplotlib (dpi=400) | 14pt | 78 |
| plotly (scale=4) | 18px | 72 |
| bokeh / highcharts (CSS) | '18pt' | **24** |

The DPI- and scale-based families multiply by dpi/72 or scale respectively. Native-pixel libs render through CSS at 1pt ≈ 1.333 px with **no extra multiplier**. So nominal pt/px values must be ~3× larger to land at the same source-pixel size.

## Fix
- Style guide table: Title 14/18 → bokeh/highcharts/pygal **56**; Axis 12/14 → **42**; Tick + Legend 10/12 → **36**.
- New explainer block \"Why the Native-pixel numbers look so much bigger\" in default-style-guide.md.
- Per-library prompts (bokeh.md, highcharts.md, pygal.md) updated.
- Highcharts \"X-axis labels cut off\" pitfall also bumped (12px → 36px / 14px → 42px).

## Test plan
- [ ] CI green
- [ ] After merge: retrigger bokeh / highcharts / pygal for timeseries-forecast-uncertainty → all three should now show readable titles and axis labels comparable in source-pixel size to matplotlib

🤖 Generated with [Claude Code](https://claude.com/claude-code)