### PR TITLE
fix(prompts): bokeh reserve min_border for the new larger axis labels

### DIFF
--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -11,13 +11,21 @@ from bokeh.io import output_file, save
 ## Create Figure
 
 ```python
-# Target: 3200 × 1800 px (see default-style-guide.md)
+# Target: 3200 × 1800 px (see default-style-guide.md).
+# `width` / `height` are the TOTAL canvas; axis labels at the new 36–42pt
+# native-pixel sizes need explicit `min_border_*` reservations or they get
+# clipped at the edges of the rendered PNG. Reserve ~150px per side for
+# the tick + axis-label stack.
 p = figure(
     width=3200,
     height=1800,
     title=title,
     x_axis_label=x_label,
-    y_axis_label=y_label
+    y_axis_label=y_label,
+    min_border_bottom=180,   # room for 36pt x-tick labels + 42pt x-axis label
+    min_border_left=200,     # room for 36pt y-tick labels + 42pt y-axis label
+    min_border_top=120,      # room for 56pt title
+    min_border_right=60,
 )
 ```
 


### PR DESCRIPTION
## Summary
After #7410's native-pixel font bump, bokeh's PNG came out at 3200×1661 with the x-axis labels clipped off the bottom — the new 36pt tick + 42pt axis labels need ~180px of stacked space that bokeh doesn't allocate by default.

## Fix
Added \`min_border_bottom=180\`, \`min_border_left=200\`, \`min_border_top=120\`, \`min_border_right=60\` to the bokeh figure constructor example in bokeh.md, scaled to the new font sizes.

## Test plan
- [ ] CI green
- [ ] After merge: retrigger bokeh for timeseries-forecast-uncertainty → full 3200×1800 PNG with x-axis labels visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)