### PR TITLE
fix(prompts): -2pt across libs + recalibrate native-pixel math for cross-lib consistency

### DIFF
--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -183,19 +183,26 @@ Three library families with different sizing controls:
 |---------|--------------------------------------------|------------------------------------------|------------------------------------------|
 | Canvas (16:9) | `figsize=(8, 4.5)` `dpi=400` | `width=800 height=450 scale=4` | `width=3200 height=1800` |
 | Canvas (1:1) | `figsize=(6, 6)` `dpi=400` | `width=600 height=600 scale=4` | `width=2400 height=2400` |
-| Title | 14pt | 18px | bokeh `'56pt'`; highcharts `'56px'`; pygal `56` |
-| Axis labels | 12pt | 14px | bokeh `'42pt'`; highcharts `'42px'`; pygal `42` |
-| Tick labels | 10pt | 12px | bokeh `'36pt'`; highcharts `'36px'`; pygal `36` |
-| Legend | 10pt | 12px | bokeh `'36pt'`; highcharts `'36px'`; pygal `36` |
+| Title | 12pt | 16px | bokeh `'50pt'`; highcharts `'66px'`; pygal `66` |
+| Axis labels | 10pt | 12px | bokeh `'42pt'`; highcharts `'56px'`; pygal `56` |
+| Tick labels | 8pt | 10px | bokeh `'34pt'`; highcharts `'44px'`; pygal `44` |
+| Legend | 8pt | 10px | bokeh `'34pt'`; highcharts `'44px'`; pygal `44` |
 
 All three families produce the same 3200×1800 (or 2400×2400) output, so the source-pixel sizes of text are now comparable across libraries.
 
-**Why the Native-pixel numbers look so much bigger** — they aren't. The three families use completely different units for the same visual size:
-- **DPI-based** (matplotlib): `14pt × 400dpi/72 = 78 source-px`. The `pt` value is multiplied by dpi at render time.
-- **Scale-based** (plotly): `18px × scale=4 = 72 source-px`. The `px` value is multiplied by scale at render time.
-- **Native-pixel** (bokeh): `'56pt' × 96/72 ≈ 75 source-px`. The `'pt'` string is rendered as CSS pt (1pt = 1.333 px in the browser), no extra multiplier. So to match the other families' source-px values, the nominal pt/px number must be roughly **3× larger** than the DPI-based pt value.
+**Why the Native-pixel numbers look so much bigger** — and why bokeh's number differs from highcharts/pygal:
 
-The Native-pixel column uses each library's own unit convention — bokeh uses `pt` strings (rendered as CSS pt via headless Chrome), highcharts uses `px` strings (CSS), pygal uses unitless integers (treated as px). See each library's prompt for the exact API.
+The three families use completely different unit conventions for the same visual size. Target source-pixel height for the title is ~67 (matches matplotlib 12pt @ dpi=400).
+
+- **DPI-based** (matplotlib): `12pt × 400dpi/72 = 67 source-px`. The `pt` value is multiplied by dpi at render time.
+- **Scale-based** (plotly): `16px × scale=4 = 64 source-px`. The `px` value is multiplied by scale at render time.
+- **bokeh** (`'pt'` strings rendered through headless Chrome as CSS pt): `'50pt' × 1.333 = 67 source-px`. CSS pt is 1.333 source-px in the browser, no extra multiplier.
+- **highcharts** (`'px'` CSS strings rendered through headless Chrome): `'66px' = 66 source-px`. CSS px maps 1:1 to source pixels at devicePixelRatio=1.
+- **pygal** (unitless integer rendered into SVG): `66 = 66 source-px`. SVG unitless ≈ user-units ≈ pixels in the source-pixel grid.
+
+So **the same target visual size requires a different nominal number per library** because each library's unit constant differs. bokeh '50pt' ≈ highcharts '66px' ≈ pygal 66 ≈ matplotlib 12pt @ dpi=400 ≈ plotly 16px @ scale=4. Don't try to make them all look the same number.
+
+Bokeh also needs `min_border_bottom=180`, `min_border_left=200`, `min_border_top=120`, `min_border_right=60` on the `figure(...)` constructor so the new larger fonts have room and aren't clipped from the PNG.
 
 **Marker and line sizes** vary by library API and aren't directly comparable as a single number — matplotlib's `s=` is in points², plotly's `marker.size` is a pixel diameter, altair's `mark_point(size=...)` is an area, plotnine / lets-plot / ggplot2's `geom_point(size=...)` uses a smaller ggplot scale. See each library's own prompt (`prompts/library/<lib>.md` → "Sizing" section) for the canonical starting values, and adapt to data density per the heuristic below.
 

--- a/prompts/default-style-guide.md
+++ b/prompts/default-style-guide.md
@@ -202,7 +202,7 @@ The three families use completely different unit conventions for the same visual
 
 So **the same target visual size requires a different nominal number per library** because each library's unit constant differs. bokeh '50pt' ≈ highcharts '66px' ≈ pygal 66 ≈ matplotlib 12pt @ dpi=400 ≈ plotly 16px @ scale=4. Don't try to make them all look the same number.
 
-Bokeh also needs `min_border_bottom=180`, `min_border_left=200`, `min_border_top=120`, `min_border_right=60` on the `figure(...)` constructor so the new larger fonts have room and aren't clipped from the PNG.
+Bokeh also needs `min_border_*` reservations on the `figure(...)` constructor so the larger axis labels have room and aren't clipped from the PNG. See `prompts/library/bokeh.md` for the canonical numbers — keep that file as the single source of truth so the bottom/left/top/right values don't drift between here and the library prompt.
 
 **Marker and line sizes** vary by library API and aren't directly comparable as a single number — matplotlib's `s=` is in points², plotly's `marker.size` is a pixel diameter, altair's `mark_point(size=...)` is an area, plotnine / lets-plot / ggplot2's `geom_point(size=...)` uses a smaller ggplot scale. See each library's own prompt (`prompts/library/<lib>.md` → "Sizing" section) for the canonical starting values, and adapt to data density per the heuristic below.
 

--- a/prompts/library/altair.md
+++ b/prompts/library/altair.md
@@ -15,13 +15,13 @@ chart = alt.Chart(df).mark_point(size=60).encode(  # size ~2-3x default, density
 ).properties(
     width=800,
     height=450,
-    title=alt.Title(title, fontSize=18)  # kept compact for the long mandated title
+    title=alt.Title(title, fontSize=16)  # kept compact for the long mandated title
 ).configure_axis(
-    labelFontSize=12,
-    titleFontSize=14
-).configure_legend(
-    labelFontSize=12,
+    labelFontSize=10,
     titleFontSize=12
+).configure_legend(
+    labelFontSize=10,
+    titleFontSize=10
 )
 ```
 

--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -22,10 +22,10 @@ p = figure(
     title=title,
     x_axis_label=x_label,
     y_axis_label=y_label,
-    min_border_bottom=180,   # room for 36pt x-tick labels + 42pt x-axis label
-    min_border_left=200,     # room for 36pt y-tick labels + 42pt y-axis label
-    min_border_top=120,      # room for 56pt title
-    min_border_right=60,
+    min_border_bottom=160,   # room for 34pt x-tick labels + 42pt x-axis label
+    min_border_left=180,     # room for 34pt y-tick labels + 42pt y-axis label
+    min_border_top=110,      # room for 50pt title
+    min_border_right=50,
 )
 ```
 
@@ -98,19 +98,19 @@ driver.quit()
 
 ```python
 # Text sizes — bokeh fonts render via headless Chrome at CSS pt sizing
-# (1pt ≈ 1.333 source-px), so nominal values must be ~3× larger than the
-# DPI-based equivalents to match the same visual size. The pt values here
-# end up at roughly the same source-pixel height as matplotlib's
-# 14/12/10pt × dpi=400.
-p.title.text_font_size = '56pt'
+# (1pt ≈ 1.333 source-px). The pt values here end up at roughly the same
+# source-pixel height as matplotlib 12/10/8pt @ dpi=400 (target ~67 px
+# for title). See default-style-guide.md "Why the Native-pixel numbers
+# look so much bigger".
+p.title.text_font_size = '50pt'
 p.xaxis.axis_label_text_font_size = '42pt'
 p.yaxis.axis_label_text_font_size = '42pt'
-p.xaxis.major_label_text_font_size = '36pt'
-p.yaxis.major_label_text_font_size = '36pt'
+p.xaxis.major_label_text_font_size = '34pt'
+p.yaxis.major_label_text_font_size = '34pt'
 
 # Legend text — apply only when a legend is present
 # (set legend_label= on glyphs or configure p.legend after add_layout)
-# p.legend.label_text_font_size = '36pt'
+# p.legend.label_text_font_size = '34pt'
 
 # Element sizes (density-aware — see default-style-guide.md)
 p.scatter(..., size=10)        # ~2-3x default

--- a/prompts/library/ggplot2.md
+++ b/prompts/library/ggplot2.md
@@ -73,12 +73,12 @@ elements for the anyplot canvas:
 ```r
 p <- p +
   theme(
-    text             = element_text(size = 8),   # base text
-    axis.title       = element_text(size = 12),  # axis labels
-    axis.text        = element_text(size = 10),  # tick labels
-    plot.title       = element_text(size = 14),  # kept compact for the long mandated title
-    legend.text      = element_text(size = 10),
-    legend.title     = element_text(size = 12)
+    text             = element_text(size = 7),   # base text
+    axis.title       = element_text(size = 10),  # axis labels
+    axis.text        = element_text(size = 8),   # tick labels
+    plot.title       = element_text(size = 12),  # kept compact for the long mandated title
+    legend.text      = element_text(size = 8),
+    legend.title     = element_text(size = 10)
   )
 
 # Element sizes inside geoms (~2-3× ggplot2 defaults, density-aware):
@@ -230,9 +230,9 @@ p <- ggplot(df, aes(x, y)) +
     panel.background = element_rect(fill = PAGE_BG, color = NA),
     panel.grid.major = element_line(color = INK, linewidth = 0.3),
     panel.grid.minor = element_line(color = INK, linewidth = 0.2),
-    axis.title       = element_text(color = INK,      size = 12),
-    axis.text        = element_text(color = INK_SOFT, size = 10),
-    plot.title       = element_text(color = INK,      size = 14)
+    axis.title       = element_text(color = INK,      size = 10),
+    axis.text        = element_text(color = INK_SOFT, size = 8),
+    plot.title       = element_text(color = INK,      size = 12)
   )
 
 # --- Save -------------------------------------------------------------------

--- a/prompts/library/highcharts.md
+++ b/prompts/library/highcharts.md
@@ -152,7 +152,7 @@ See `prompts/default-style-guide.md` "Proportional Sizing" for review criteria.
 6. **X-axis labels cut off in PNG**: Category labels may be clipped at the bottom. Fix by:
    - Increase bottom margin: `chart.options.chart = {'marginBottom': 100, ...}`
    - Or add spacingBottom: `chart.options.chart = {'spacingBottom': 60, ...}`
-   - Default `style: {'fontSize': '36px'}` per the new 3200×1800 sizing (native-pixel libraries need ~3× the matplotlib pt value — see default-style-guide.md "Why the Native-pixel numbers look so much bigger"). If still clipped after the margin fixes, bump to `'42px'` for that specific case — but keep all other label fontsizes at 36px for cross-axis balance.
+   - Default `style: {'fontSize': '44px'}` per the new 3200×1800 sizing (highcharts uses CSS px directly — see default-style-guide.md "Why the Native-pixel numbers look so much bigger"). If still clipped after the margin fixes, bump to `'52px'` for that specific case — but keep all other label fontsizes at 44px for cross-axis balance.
 
 ## Colors
 
@@ -195,22 +195,24 @@ chart.options.chart = {
     'backgroundColor': PAGE_BG,
     'style': {'color': INK},
 }
-# Native-pixel sizing: highcharts fonts go through CSS in the rendered
-# HTML at the source-pixel grid (no scale multiplier), so the px values
-# here must be ~3× the matplotlib pt values to match the same visual size.
-chart.options.title = {'text': title, 'style': {'fontSize': '56px', 'color': INK}}
+# Native-pixel sizing: highcharts fonts go through CSS px in the rendered
+# HTML; CSS px maps 1:1 to source pixels. To match matplotlib 14pt @ dpi=400
+# (= 78 source-px), the px values here are the same as the target source-px
+# (NOT multiplied by anything). See default-style-guide.md "Why the
+# Native-pixel numbers look so much bigger".
+chart.options.title = {'text': title, 'style': {'fontSize': '66px', 'color': INK}}
 chart.options.x_axis = {
-    'title': {'text': x_label, 'style': {'fontSize': '42px', 'color': INK}},
-    'labels': {'style': {'fontSize': '36px', 'color': INK_SOFT}},
+    'title': {'text': x_label, 'style': {'fontSize': '56px', 'color': INK}},
+    'labels': {'style': {'fontSize': '44px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.y_axis = {
-    'title': {'text': y_label, 'style': {'fontSize': '42px', 'color': INK}},
-    'labels': {'style': {'fontSize': '36px', 'color': INK_SOFT}},
+    'title': {'text': y_label, 'style': {'fontSize': '56px', 'color': INK}},
+    'labels': {'style': {'fontSize': '44px', 'color': INK_SOFT}},
     'lineColor': INK_SOFT, 'tickColor': INK_SOFT, 'gridLineColor': GRID,
 }
 chart.options.legend = {
-    'itemStyle': {'color': INK_SOFT, 'fontSize': '36px'},
+    'itemStyle': {'color': INK_SOFT, 'fontSize': '44px'},
     'backgroundColor': ELEVATED_BG, 'borderColor': INK_SOFT, 'borderWidth': 1,
 }
 ```

--- a/prompts/library/highcharts.md
+++ b/prompts/library/highcharts.md
@@ -196,8 +196,8 @@ chart.options.chart = {
     'style': {'color': INK},
 }
 # Native-pixel sizing: highcharts fonts go through CSS px in the rendered
-# HTML; CSS px maps 1:1 to source pixels. To match matplotlib 14pt @ dpi=400
-# (= 78 source-px), the px values here are the same as the target source-px
+# HTML; CSS px maps 1:1 to source pixels. To match matplotlib 12pt @ dpi=400
+# (= 67 source-px), the px values here are the same as the target source-px
 # (NOT multiplied by anything). See default-style-guide.md "Why the
 # Native-pixel numbers look so much bigger".
 chart.options.title = {'text': title, 'style': {'fontSize': '66px', 'color': INK}}

--- a/prompts/library/letsplot.md
+++ b/prompts/library/letsplot.md
@@ -27,10 +27,10 @@ plot = plot + ggsize(800, 450)
 
 # Text and element sizes
 plot = plot + theme(
-    axis_title=element_text(size=14),
-    axis_text=element_text(size=12),
-    plot_title=element_text(size=18),  # kept compact for the long mandated title
-    legend_text=element_text(size=12)
+    axis_title=element_text(size=12),
+    axis_text=element_text(size=10),
+    plot_title=element_text(size=16),  # kept compact for the long mandated title
+    legend_text=element_text(size=10)
 )
 
 # Element sizes in geoms (density-aware — see default-style-guide.md)

--- a/prompts/library/matplotlib.md
+++ b/prompts/library/matplotlib.md
@@ -50,14 +50,14 @@ plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ```python
 # Text sizes — title kept compact because the mandated "{spec-id} · python · matplotlib · anyplot.ai"
 # title is ~67 chars and would overflow at 16+pt on the 3200px-wide canvas.
-ax.set_title(title, fontsize=14, fontweight='medium')
-ax.set_xlabel(x_label, fontsize=12)
-ax.set_ylabel(y_label, fontsize=12)
-ax.tick_params(axis='both', labelsize=10)
-# Legend at 10pt — skip ax.legend() for single-series plots (avoids the
+ax.set_title(title, fontsize=12, fontweight='medium')
+ax.set_xlabel(x_label, fontsize=10)
+ax.set_ylabel(y_label, fontsize=10)
+ax.tick_params(axis='both', labelsize=8)
+# Legend at 8pt — skip ax.legend() for single-series plots (avoids the
 # "No artists with labels found to put in legend" warning)
 if len(ax.get_legend_handles_labels()[0]) > 1:
-    ax.legend(fontsize=10)
+    ax.legend(fontsize=8)
 
 # Element sizes
 ax.scatter(x, y, s=100, edgecolors='white', linewidth=0.5)  # s=60-150 (density-aware)
@@ -76,10 +76,10 @@ See `prompts/default-style-guide.md` "Proportional Sizing" for the review-step c
 ## Styling
 
 ```python
-ax.set_xlabel(x_label, fontsize=12)
-ax.set_ylabel(y_label, fontsize=12)
-ax.set_title(title, fontsize=14, fontweight='medium')
-ax.legend(fontsize=10)  # if needed (omit for single-series)
+ax.set_xlabel(x_label, fontsize=10)
+ax.set_ylabel(y_label, fontsize=10)
+ax.set_title(title, fontsize=12, fontweight='medium')
+ax.legend(fontsize=8)  # if needed (omit for single-series)
 plt.tight_layout()
 ```
 

--- a/prompts/library/plotly.md
+++ b/prompts/library/plotly.md
@@ -25,9 +25,9 @@ fig = px.scatter(df, x='col_x', y='col_y')
 fig.update_layout(
     # Title kept compact — the long mandated "{spec-id} · python · plotly · anyplot.ai"
     # title would overflow at 22+px on this canvas.
-    title=dict(text=title, font=dict(size=18)),
-    xaxis=dict(title=dict(text=x_label, font=dict(size=14)), tickfont=dict(size=12)),
-    yaxis=dict(title=dict(text=y_label, font=dict(size=14)), tickfont=dict(size=12)),
+    title=dict(text=title, font=dict(size=16)),
+    xaxis=dict(title=dict(text=x_label, font=dict(size=12)), tickfont=dict(size=10)),
+    yaxis=dict(title=dict(text=y_label, font=dict(size=12)), tickfont=dict(size=10)),
     template='plotly_white',
 )
 

--- a/prompts/library/plotnine.md
+++ b/prompts/library/plotnine.md
@@ -50,11 +50,11 @@ plot = (
 ```python
 plot = plot + theme(
     figure_size=(8, 4.5),
-    text=element_text(size=8),            # Base text
-    axis_title=element_text(size=12),     # Axis labels
-    axis_text=element_text(size=10),      # Tick labels
-    plot_title=element_text(size=14),     # Title — kept compact to fit the long mandated title
-    legend_text=element_text(size=10)
+    text=element_text(size=7),            # Base text
+    axis_title=element_text(size=10),     # Axis labels
+    axis_text=element_text(size=8),       # Tick labels
+    plot_title=element_text(size=12),     # Title — kept compact to fit the long mandated title
+    legend_text=element_text(size=8)
 )
 
 # Element sizes in geoms (density-aware — see default-style-guide.md)

--- a/prompts/library/pygal.md
+++ b/prompts/library/pygal.md
@@ -80,14 +80,15 @@ custom_style = Style(
     foreground_subtle=INK_MUTED,    # tick labels, grid tone
     colors=OKABE_ITO,               # first series = brand green
     # pygal font sizes are unitless integers, rendered into the SVG at the
-    # source-pixel grid (no DPI/scale multiplier). Need ~3× the matplotlib
-    # pt values to match — see default-style-guide.md "Why the Native-pixel
+    # source-pixel grid (no DPI/scale multiplier). To match matplotlib 14pt
+    # @ dpi=400 (= 78 source-px), set unitless values directly to the target
+    # source-pixel size — see default-style-guide.md "Why the Native-pixel
     # numbers look so much bigger".
-    title_font_size=56,             # kept compact for the long mandated title
-    label_font_size=42,
-    major_label_font_size=36,
-    legend_font_size=36,
-    value_font_size=30,
+    title_font_size=66,             # kept compact for the long mandated title
+    label_font_size=56,
+    major_label_font_size=44,
+    legend_font_size=44,
+    value_font_size=36,
     stroke_width=2.5,
 )
 

--- a/prompts/library/pygal.md
+++ b/prompts/library/pygal.md
@@ -80,8 +80,8 @@ custom_style = Style(
     foreground_subtle=INK_MUTED,    # tick labels, grid tone
     colors=OKABE_ITO,               # first series = brand green
     # pygal font sizes are unitless integers, rendered into the SVG at the
-    # source-pixel grid (no DPI/scale multiplier). To match matplotlib 14pt
-    # @ dpi=400 (= 78 source-px), set unitless values directly to the target
+    # source-pixel grid (no DPI/scale multiplier). To match matplotlib 12pt
+    # @ dpi=400 (= 67 source-px), set unitless values directly to the target
     # source-pixel size — see default-style-guide.md "Why the Native-pixel
     # numbers look so much bigger".
     title_font_size=66,             # kept compact for the long mandated title

--- a/prompts/library/seaborn.md
+++ b/prompts/library/seaborn.md
@@ -48,13 +48,13 @@ plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight')
 ```python
 # Text sizes (seaborn uses matplotlib underneath) — title kept compact to avoid
 # overflow of the long mandated "{spec-id} · python · seaborn · anyplot.ai" title.
-ax.set_title(title, fontsize=14, fontweight='medium')
-ax.set_xlabel(x_label, fontsize=12)
-ax.set_ylabel(y_label, fontsize=12)
-ax.tick_params(axis='both', labelsize=10)
-# Legend at 10pt — skip for single-series plots (no labeled artists → warning)
+ax.set_title(title, fontsize=12, fontweight='medium')
+ax.set_xlabel(x_label, fontsize=10)
+ax.set_ylabel(y_label, fontsize=10)
+ax.tick_params(axis='both', labelsize=8)
+# Legend at 8pt — skip for single-series plots (no labeled artists → warning)
 if len(ax.get_legend_handles_labels()[0]) > 1:
-    ax.legend(fontsize=10)
+    ax.legend(fontsize=8)
 
 # Or use sns.set_context for global scaling
 sns.set_context("notebook", font_scale=1.0)


### PR DESCRIPTION
## Summary
User feedback after the timeseries-forecast-uncertainty fan-out (10 libs merged):
- matplotlib reference fonts still felt a tick too big
- bokeh / highcharts / pygal differed in visual size after #7410's same-number assumption

Two changes bundled (same files):

### 1. -2pt across all libraries
Matplotlib reference now reads as well-proportioned at fontsize=12pt title (preview rendered locally — looks balanced at ~70% width, lots of breathing room).

| family    | Title | Axis | Tick | Legend |
|-----------|-------|------|------|--------|
| DPI       | 14→12 | 12→10| 10→8 | 10→8   |
| Scale     | 18→16 | 14→12| 12→10| 12→10  |

plotnine + ggplot2 \`base_size\` 8→7.

### 2. Native-pixel math recalibrate
#7410 grouped bokeh / highcharts / pygal under one set of numbers (56/42/36) assuming \"no multiplier\". Actually each lib uses a different unit:

- bokeh \`'pt'\` strings: CSS pt × 1.333 → source-px
- highcharts \`'px'\` strings: CSS px × 1.0 → source-px
- pygal unitless integers: SVG user-unit × 1.0 → source-px

So same nominal number ≠ same visual size. New values land all three at the matplotlib 12pt @ dpi=400 target (~67 source-px for title):

| | bokeh | highcharts | pygal |
|---|---|---|---|
| Title | \`'50pt'\` | \`'66px'\` | 66 |
| Axis  | \`'42pt'\` | \`'56px'\` | 56 |
| Tick  | \`'34pt'\` | \`'44px'\` | 44 |
| Legend| \`'34pt'\` | \`'44px'\` | 44 |

bokeh `min_border_*` kept from #7414 (with values adjusted for the new fontsizes) so axis labels don't get clipped.

### Cross-lib title source-px consistency after this PR

| matplotlib | seaborn | plotnine | ggplot2 | plotly | altair | letsplot | bokeh | highcharts | pygal |
|------------|---------|----------|---------|--------|--------|----------|-------|------------|-------|
| 67         | 67      | 67       | 67      | 64     | 64     | 64       | 67    | 66         | 66    |

Max/min spread = 1.05. The AI may still tune per plot via the proportional review loop.

## Test plan
- [ ] CI green
- [ ] After merge: retrigger all 10 libs for timeseries-forecast-uncertainty → all should land at visually consistent text sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)