### PR TITLE
fix(prompts): bokeh toolbar_location=None so PNG fills 3200x1800

### DIFF
--- a/prompts/library/bokeh.md
+++ b/prompts/library/bokeh.md
@@ -22,6 +22,12 @@ p = figure(
     title=title,
     x_axis_label=x_label,
     y_axis_label=y_label,
+    toolbar_location=None,   # IMPORTANT: bokeh's default toolbar (above the plot)
+                             # adds ~30-50px above the canvas, so the saved screenshot
+                             # ends up SHORTER than `height=` (e.g. 3200×1800 became
+                             # 3200×1661 in the May 2026 fan-out). Disable it for the
+                             # static catalog renders — the HTML preview retains the
+                             # default toolbar via `output_file(...)` if needed.
     min_border_bottom=160,   # room for 34pt x-tick labels + 42pt x-axis label
     min_border_left=180,     # room for 34pt y-tick labels + 42pt y-axis label
     min_border_top=110,      # room for 50pt title


### PR DESCRIPTION
## Summary
After #7414 added bokeh \`min_border\` reservations, the PNG was still 3200×1661 (139px short). Root cause: bokeh's default toolbar (\`location='above'\`) injects ~30-50px above the chart, and \`height=\` is the plot frame, not the total HTML element height — so Chrome screenshots came out short.

## Fix
\`toolbar_location=None\` in the bokeh.md figure() example. Static catalog PNG now fills the full 1800. The HTML preview (via \`output_file\` / \`save\`) keeps the default toolbar for interactive pan/zoom/save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)