### PR TITLE
fix(ui): route tag clicks to /plots and track tag_click on /stats

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -38,6 +38,7 @@ export default [
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
         performance: 'readonly',
+        crypto: 'readonly',
         // DOM types
         HTMLElement: 'readonly',
         HTMLDivElement: 'readonly',

--- a/app/src/components/SpecTabs.tsx
+++ b/app/src/components/SpecTabs.tsx
@@ -221,7 +221,7 @@ export function SpecTabs({
   const handleTagClick = useCallback(
     (paramName: string, value: string) => {
       onTrackEvent?.('tag_click', { param: paramName, value, source: 'spec_detail' });
-      navigate(`/?${paramName}=${encodeURIComponent(value)}`);
+      navigate(`/plots?${paramName}=${encodeURIComponent(value)}`);
     },
     [navigate, onTrackEvent]
   );

--- a/app/src/pages/StatsPage.test.tsx
+++ b/app/src/pages/StatsPage.test.tsx
@@ -57,7 +57,9 @@ const mockDashboard = {
   ],
   tag_distribution: {
     plot_type: { scatter: 42, line: 30 },
-    data_type: { numeric: 80 },
+    // "time series" has a space so the tag-link test below can assert
+    // encodeURIComponent is actually exercised (href -> data=time%20series).
+    data_type: { numeric: 80, 'time series': 12 },
   },
   score_distribution: { '50-60': 5, '60-70': 10, '70-80': 20, '80-90': 30, '90-100': 15 },
   timeline: [
@@ -267,10 +269,22 @@ describe('StatsPage', () => {
     const scatterLink = screen.getByText('scatter').closest('a');
     expect(scatterLink).toHaveAttribute('href', '/plots?plot=scatter');
 
+    // Tag with a space exercises encodeURIComponent — proves the encoding
+    // step isn't a no-op.
+    const timeSeriesLink = screen.getByText('time series').closest('a');
+    expect(timeSeriesLink).toHaveAttribute('href', '/plots?data=time%20series');
+
     await user.click(scatterLink!);
     expect(mockTrackEvent).toHaveBeenCalledWith('tag_click', {
       param: 'plot',
       value: 'scatter',
+      source: 'stats',
+    });
+
+    await user.click(timeSeriesLink!);
+    expect(mockTrackEvent).toHaveBeenCalledWith('tag_click', {
+      param: 'data',
+      value: 'time series',
       source: 'stats',
     });
   });

--- a/app/src/pages/StatsPage.test.tsx
+++ b/app/src/pages/StatsPage.test.tsx
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '../test-utils';
+import { render, screen, userEvent, waitFor } from '../test-utils';
 import { StatsPage } from './StatsPage';
 
 vi.mock('react-helmet-async', () => ({
   Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const mockTrackEvent = vi.fn();
+
 vi.mock('../hooks', () => ({
   useAnalytics: () => ({
     trackPageview: vi.fn(),
-    trackEvent: vi.fn(),
+    trackEvent: mockTrackEvent,
   }),
 }));
 
@@ -118,6 +120,7 @@ function mockFetchError() {
 describe('StatsPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockTrackEvent.mockClear();
   });
 
   // vi.restoreAllMocks() doesn't undo vi.stubGlobal — without this hook the
@@ -245,6 +248,30 @@ describe('StatsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/visitor data unavailable/)).toBeInTheDocument();
+    });
+  });
+
+  it('routes tag links to /plots and fires tag_click on click', async () => {
+    // Regression: pre-fix the href pointed at /?plot=scatter, which landed
+    // on LandingPage and silently dropped the filter intent. Filter routing
+    // lives on /plots after the page split, so the link must target that.
+    mockFetchSuccess();
+    const user = userEvent.setup();
+
+    render(<StatsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('scatter')).toBeInTheDocument();
+    });
+
+    const scatterLink = screen.getByText('scatter').closest('a');
+    expect(scatterLink).toHaveAttribute('href', '/plots?plot=scatter');
+
+    await user.click(scatterLink!);
+    expect(mockTrackEvent).toHaveBeenCalledWith('tag_click', {
+      param: 'plot',
+      value: 'scatter',
+      source: 'stats',
     });
   });
 });

--- a/app/src/pages/StatsPage.tsx
+++ b/app/src/pages/StatsPage.tsx
@@ -466,7 +466,8 @@ export function StatsPage() {
                     <Link
                       key={tag}
                       component={RouterLink}
-                      to={param ? `/?${param}=${tag}` : '/'}
+                      to={param ? `/plots?${param}=${encodeURIComponent(tag)}` : '/plots'}
+                      onClick={() => { if (param) trackEvent('tag_click', { param, value: tag, source: 'stats' }); }}
                       sx={{
                         fontFamily: typography.fontFamily, fontSize: size, fontWeight: weight, textDecoration: 'none',
                         px: 0.75, py: 0.25, borderRadius: 0.5,

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -129,7 +129,7 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `open_interactive` | `spec`, `library` | SpecOverview.tsx, SpecDetailView.tsx | User opens interactive HTML view |
 | `suggest_spec` | - | SpecsListPage.tsx | User clicks the `spec.suggest()` link on the specs list page. The mirror link on the landing page emits `nav_click` with `source: suggest_spec_link` instead. |
 | `report_issue` | `spec`, `library`? | SpecPage.tsx | User clicks "report issue" link |
-| `tag_click` | `param`, `value`, `source` | SpecTabs.tsx | User clicks a tag chip to filter |
+| `tag_click` | `param`, `value`, `source` | SpecTabs.tsx, StatsPage.tsx | User clicks a tag chip to filter (`source` ∈ `spec_detail`, `stats`) |
 | `theme_toggle` | `to` | MastheadRule.tsx | User cycles tri-state theme mode (`to` ∈ `system`, `light`, `dark`). The cycle order is `system → light → dark → system`. |
 | `potd_dismiss` | `spec`, `library` | PlotOfTheDay.tsx | User dismisses the plot-of-the-day banner |
 | `view_mode_change` | `mode`, `library` | SpecDetailView.tsx | User toggles preview ↔ interactive view inside a spec detail. `mode` ∈ `preview`, `interactive`. Fires on every toggle in either direction (cf. `open_interactive`, which only fires when the interactive HTML is opened in a new tab). |
@@ -445,7 +445,7 @@ User lands on anyplot.ai
 | `filter_remove` | `category`, `value` | useFilterState.ts |
 | `grid_resize` | `size` | ToolbarActions.tsx |
 | `tab_toggle` | `action`, `tab`, `library` | SpecTabs.tsx |
-| `tag_click` | `param`, `value`, `source` | SpecTabs.tsx |
+| `tag_click` | `param`, `value`, `source` | SpecTabs.tsx, StatsPage.tsx |
 | `plot_rotate` | `spec` | SpecsListPage.tsx |
 | `open_interactive` | `spec`, `library` | SpecOverview.tsx, SpecDetailView.tsx |
 | `suggest_spec` | - | SpecsListPage.tsx (LandingPage mirror attributed via `nav_click` with `source: suggest_spec_link`) |


### PR DESCRIPTION
## Summary
- Tag chips on spec/impl detail (under the image) and on `/stats` (tag distribution block) built URLs as `/?<param>=<value>`. Since the page split, `/` is `LandingPage` and only `/plots` handles filter query params, so the links broke. Route them to `/plots` instead.
- StatsPage was silent on `tag_click` while SpecTabs already fired it — added the event with `source: 'stats'` so Plausible coverage matches the spec.
- Drive-by: `crypto` was missing from the eslint browser-globals list, making `FeedbackWidget.tsx`'s `crypto.randomUUID()`/`getRandomValues()` fail `no-undef`. Added it.

## Files
- `app/src/components/SpecTabs.tsx` — `handleTagClick` now navigates to `/plots?…`. Covers both spec-overview and impl-detail (both routes go through `SpecPage` → `<SpecTabs>`).
- `app/src/pages/StatsPage.tsx` — link target → `/plots`, `encodeURIComponent` on the value, fire `tag_click` with `source: 'stats'`.
- `docs/reference/plausible.md` — `tag_click` source list now includes `StatsPage.tsx` and documents `source ∈ spec_detail, stats`.
- `app/eslint.config.js` — `crypto: 'readonly'` added to browser globals.

## Test plan
- [ ] On a spec page (e.g. `/scatter-basic`), click a tag chip under the image → URL is `/plots?<param>=<value>`, grid is filtered, Plausible fires `tag_click` with `source: spec_detail`.
- [ ] On an impl page (e.g. `/scatter-basic/python/matplotlib`), repeat → same behaviour (same component, but verify explicitly).
- [ ] On `/stats`, click a tag in the tag-distribution block → URL is `/plots?<param>=<value>`, grid is filtered, Plausible fires `tag_click` with `source: stats`.
- [ ] Tag with a special character (e.g. with `+` or a space) URL-encodes correctly.
- [ ] `yarn tsc --noEmit`, `yarn lint`, `yarn test` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)