### PR TITLE
fix(stats): include today in visitors chart on stats page

### DIFF
--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -633,9 +633,15 @@ async def get_related_specs(
 async def _fetch_plausible_visitors() -> VisitorsResponse:
     """Query the Plausible Stats API v2 for unique visitors per day (last 28d).
 
-    The 28-day window matches Plausible's own default "Last 28 days" report so
-    the totals here align with what the dashboard at plausible.io/anyplot.ai
-    shows by default.
+    The 28-day window ends on today (inclusive) so the rightmost bar reflects
+    current-day traffic as a partial day, matching how Plausible's dashboard
+    "Last 28 days" view renders.
+
+    Note: we deliberately do NOT use Plausible's `"28d"` preset because it
+    maps to `[today-28, today-1]` (the source uses `last = today - 1 day`,
+    see plausible/analytics PR #5282), which excludes today and left the
+    rightmost chart bar permanently at 0. An explicit `[today-27, today]`
+    custom range pulls today's partial row in.
 
     Returns an empty `points` list when the API key is not configured or the
     upstream call fails — the stats page treats `points: []` as "no data" and
@@ -647,10 +653,12 @@ async def _fetch_plausible_visitors() -> VisitorsResponse:
     if not settings.plausible_api_key:
         return VisitorsResponse(points=[])
 
+    today = datetime.now(timezone.utc).date()
+    start = today - timedelta(days=27)
     payload = {
         "site_id": settings.plausible_site_id,
         "metrics": ["visitors"],
-        "date_range": "28d",
+        "date_range": [start.isoformat(), today.isoformat()],
         "dimensions": ["time:day"],
     }
     try:
@@ -682,7 +690,6 @@ async def _fetch_plausible_visitors() -> VisitorsResponse:
             count = 0
         by_date[day_str] = count
 
-    today = datetime.now(timezone.utc).date()
     points = [
         VisitorPoint(
             date=(today - timedelta(days=offset)).isoformat(),

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -1953,6 +1953,61 @@ class TestInsightsRouter:
             today_point = next(p for p in points if p["date"] == today_iso)
             assert today_point["visitors"] == 42
 
+    def test_visitors_requests_explicit_date_range_including_today(self, client: TestClient) -> None:
+        """Plausible's `"28d"` preset excludes today (it maps to [today-28, today-1]),
+        so we must send an explicit `[today-27, today]` custom date range to
+        ensure today's partial-day visitors appear in the rightmost chart bar.
+        Locking this in via the outgoing payload so the bug can't silently
+        regress to the "always 0 today" behavior.
+        """
+        from datetime import datetime as _dt
+        from datetime import timedelta
+        from datetime import timezone as _tz
+
+        frozen_now = _dt(2026, 5, 13, 12, 0, 0, tzinfo=_tz.utc)
+        today_iso = frozen_now.date().isoformat()
+        expected_start_iso = (frozen_now.date() - timedelta(days=27)).isoformat()
+
+        captured: dict = {}
+
+        class _MockResp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"results": []}
+
+        class _MockClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            async def post(self, *_args, **kwargs):
+                captured["payload"] = kwargs.get("json")
+                return _MockResp()
+
+        class _FrozenDatetime(_dt):
+            @classmethod
+            def now(cls, tz=None):  # type: ignore[override]
+                return frozen_now if tz is _tz.utc else frozen_now.replace(tzinfo=None)
+
+        with (
+            patch("api.routers.insights.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.insights.settings") as mock_settings,
+            patch("api.routers.insights.httpx.AsyncClient", return_value=_MockClient()),
+            patch("api.routers.insights.datetime", _FrozenDatetime),
+        ):
+            mock_settings.plausible_api_key = "test-key"
+            mock_settings.plausible_site_id = "anyplot.ai"
+            mock_settings.plausible_api_url = "https://plausible.io/api/v2/query"
+            response = client.get("/insights/visitors")
+            assert response.status_code == 200
+            assert captured["payload"]["date_range"] == [expected_start_iso, today_iso]
+
 
 class TestSpecCodeEndpoint:
     """Tests for the /specs/{spec_id}/{library}/code endpoint."""


### PR DESCRIPTION
## Summary

The rightmost bar on the visitors chart on `/stats` was always 0 (regardless of how much traffic the day had so far).

Root cause: Plausible's `"28d"` date_range preset is documented as "Last 28 days relative to today", but the source maps it to `[today-28, today-1]` and explicitly **excludes today** (`last = today - 1 day`, see [plausible/analytics PR #5282](https://github.com/plausible/analytics/pull/5282)). Our `_fetch_plausible_visitors` zero-filled a `[today-27, today]` window and looked up today's row in the response, which Plausible never returned → permanent 0.

Fix: send an explicit custom `date_range: [today-27, today]` so today is included as a partial day, matching what the Plausible dashboard's "Last 28 days" view shows for the same site.

- `api/routers/insights.py`: switch payload from `"date_range": "28d"` to an explicit `[start, today]` array; move the `today` computation above the payload.
- `tests/unit/api/test_routers.py`: add `test_visitors_requests_explicit_date_range_including_today` which captures the outgoing payload and asserts the `date_range` array — locks in the fix against silent regression.

## Test plan

- [x] `pytest tests/unit/api/test_routers.py::TestInsightsRouter` — 13/13 pass (including the new test)
- [x] `ruff check api/routers/insights.py tests/unit/api/test_routers.py` — clean
- [ ] After deploy, verify the rightmost bar on `anyplot.ai/stats` shows a non-zero (or correctly-zero-but-only-because-no-traffic) value for today
- [ ] Cross-check the total against the "Last 28 days" view on `plausible.io/anyplot.ai`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWYEuB9xuqDqKKDyyNhCyv)_