### PR TITLE
feat(debug): copy Claude-Code-ready prompt from feedback messages

### DIFF
--- a/app/src/pages/DebugPage.test.tsx
+++ b/app/src/pages/DebugPage.test.tsx
@@ -227,4 +227,57 @@ describe('DebugPage', () => {
     expect(replaceSpy).not.toHaveBeenCalled();
   });
 
+  // The debug feedback list ships a "copy Claude Code prompt" button next to
+  // every message so admins can drop straight from triage into a Claude Code
+  // session that already knows the URL, the reaction, and the user's text.
+  it('copies a Claude-Code-ready prompt for a feedback message', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, origin: 'https://anyplot.ai', href: 'https://anyplot.ai/debug' },
+    });
+
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (url.includes('/debug/ping')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ database_connected: true, response_time_ms: 10, timestamp: '2026-05-21T00:00:00Z' }) });
+      }
+      if (url.includes('/debug/feedback/messages')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([
+            {
+              id: 'fb-1',
+              message: 'Axis labels overlap on mobile',
+              reaction: 'bug',
+              contact: null,
+              path: '/plots/scatter-basic',
+              spec_id: 'scatter-basic',
+              viewport: '375x812',
+              status: 'new',
+              created_at: '2026-05-21T09:00:00Z',
+            },
+          ]),
+        });
+      }
+      if (url.includes('/debug/feedback/top')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockDebugData) });
+    }));
+
+    render(<DebugPage />);
+
+    const copyBtn = await screen.findByRole('button', { name: /copy claude code prompt/i });
+    fireEvent.click(copyBtn);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('https://anyplot.ai/plots/scatter-basic');
+    expect(copied).toContain('bug report');
+    expect(copied).toContain('> Axis labels overlap on mobile');
+    expect(copied).toContain('Open a pull request');
+  });
+
 });

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -4,10 +4,14 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import Tooltip from '@mui/material/Tooltip';
+import IconButton from '@mui/material/IconButton';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
 
 import { DEBUG_API_URL, LIBRARIES, LIB_ABBREV, LIB_TO_LANG } from '../constants';
 import { specPath } from '../utils/paths';
 import { SectionHeader } from '../components/SectionHeader';
+import { useCopyCode } from '../hooks';
 import { typography, colors, semanticColors, fontSize } from '../theme';
 
 // ============================================================================
@@ -159,6 +163,34 @@ function formatDateShort(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+// Builds a Claude-Code-ready prompt from a feedback message. Pasted into the
+// CLI it gives Claude the page URL, the user's words, and a clear three-step
+// plan (analyse/reproduce → implement → open PR) so triage flows from the
+// debug page straight into a working session.
+function buildClaudePrompt(
+  message: string,
+  path: string | null,
+  reaction: string | null,
+): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const url = path ? `${origin}${path}` : origin || '(unknown URL)';
+  const kind =
+    reaction === 'bug' ? 'bug report'
+    : reaction === 'idea' ? 'feature request'
+    : reaction === 'thumbs_down' ? 'negative feedback'
+    : reaction === 'thumbs_up' ? 'positive feedback'
+    : 'feedback';
+  const quoted = message.split('\n').map(line => `> ${line}`).join('\n');
+  return `A user left the following ${kind} on ${url}:
+
+${quoted}
+
+Please:
+1. Analyze the report and reproduce the issue locally (or scope the feature request).
+2. Implement a fix or the requested change.
+3. Open a pull request with the proposed solution.`;
 }
 
 // Styled native input / select / button using CSS vars
@@ -937,17 +969,22 @@ export function DebugPage() {
                   </Typography>
                 )}
               </Box>
-              <Box
-                component="select"
-                value={m.status}
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                  updateFeedbackStatus(m.id, e.target.value as FeedbackStatus)
-                }
-                sx={{ ...nativeControlSx, cursor: 'pointer', alignSelf: 'start' }}
-              >
-                {FEEDBACK_STATUS_OPTIONS.map(s => (
-                  <option key={s} value={s}>{s.replace('_', ' ')}</option>
-                ))}
+              <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'start' }}>
+                {m.message && (
+                  <CopyClaudePromptButton message={m.message} path={m.path} reaction={m.reaction} />
+                )}
+                <Box
+                  component="select"
+                  value={m.status}
+                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                    updateFeedbackStatus(m.id, e.target.value as FeedbackStatus)
+                  }
+                  sx={{ ...nativeControlSx, cursor: 'pointer', alignSelf: 'start' }}
+                >
+                  {FEEDBACK_STATUS_OPTIONS.map(s => (
+                    <option key={s} value={s}>{s.replace('_', ' ')}</option>
+                  ))}
+                </Box>
               </Box>
             </Box>
           ))}
@@ -1253,6 +1290,28 @@ function FeedbackTopList({ title, items, accent }: { title: string; items: Feedb
         </Box>
       )}
     </Box>
+  );
+}
+
+function CopyClaudePromptButton({ message, path, reaction }: { message: string; path: string | null; reaction: string | null }) {
+  const { copied, copyToClipboard } = useCopyCode();
+  return (
+    <Tooltip title={copied ? 'copied — paste into Claude Code' : 'copy prompt for Claude Code'}>
+      <IconButton
+        onClick={() => copyToClipboard(buildClaudePrompt(message, path, reaction))}
+        aria-label="Copy Claude Code prompt"
+        size="small"
+        sx={{
+          alignSelf: 'start',
+          color: copied ? colors.success : 'var(--ink-muted)',
+          border: '1px solid var(--rule)',
+          borderRadius: 1,
+          '&:hover': { bgcolor: 'var(--bg-surface)', color: colors.primary },
+        }}
+      >
+        {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+      </IconButton>
+    </Tooltip>
   );
 }
 

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -12,6 +12,7 @@ import { DEBUG_API_URL, LIBRARIES, LIB_ABBREV, LIB_TO_LANG } from '../constants'
 import { specPath } from '../utils/paths';
 import { SectionHeader } from '../components/SectionHeader';
 import { useCopyCode } from '../hooks';
+import { buildClaudePrompt } from '../utils/claudePrompt';
 import { typography, colors, semanticColors, fontSize } from '../theme';
 
 // ============================================================================
@@ -163,34 +164,6 @@ function formatDateShort(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-// Builds a Claude-Code-ready prompt from a feedback message. Pasted into the
-// CLI it gives Claude the page URL, the user's words, and a clear three-step
-// plan (analyse/reproduce → implement → open PR) so triage flows from the
-// debug page straight into a working session.
-function buildClaudePrompt(
-  message: string,
-  path: string | null,
-  reaction: string | null,
-): string {
-  const origin = typeof window !== 'undefined' ? window.location.origin : '';
-  const url = path ? `${origin}${path}` : origin || '(unknown URL)';
-  const kind =
-    reaction === 'bug' ? 'bug report'
-    : reaction === 'idea' ? 'feature request'
-    : reaction === 'thumbs_down' ? 'negative feedback'
-    : reaction === 'thumbs_up' ? 'positive feedback'
-    : 'feedback';
-  const quoted = message.split('\n').map(line => `> ${line}`).join('\n');
-  return `A user left the following ${kind} on ${url}:
-
-${quoted}
-
-Please:
-1. Analyze the report and reproduce the issue locally (or scope the feature request).
-2. Implement a fix or the requested change.
-3. Open a pull request with the proposed solution.`;
 }
 
 // Styled native input / select / button using CSS vars

--- a/app/src/utils/claudePrompt.test.ts
+++ b/app/src/utils/claudePrompt.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { buildClaudePrompt } from './claudePrompt';
+
+describe('buildClaudePrompt', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, origin: 'https://anyplot.ai', href: 'https://anyplot.ai/debug' },
+    });
+  });
+
+  it.each([
+    ['bug', 'bug report'],
+    ['idea', 'feature request'],
+    ['thumbs_down', 'negative feedback'],
+    ['thumbs_up', 'positive feedback'],
+    [null, 'feedback'],
+    ['unknown_reaction', 'feedback'],
+  ])('labels reaction %s as %s', (reaction, label) => {
+    const out = buildClaudePrompt('hi', '/plots/x', reaction);
+    expect(out).toContain(`following ${label} on`);
+  });
+
+  it('prefixes the path with the current origin', () => {
+    const out = buildClaudePrompt('msg', '/plots/scatter-basic', 'bug');
+    expect(out).toContain('on https://anyplot.ai/plots/scatter-basic:');
+  });
+
+  it('falls back to the origin when path is null', () => {
+    const out = buildClaudePrompt('msg', null, 'bug');
+    expect(out).toContain('on https://anyplot.ai:');
+    expect(out).not.toContain('null');
+  });
+
+  it('uses "(unknown URL)" when origin and path are both empty', () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, origin: '' },
+    });
+    const out = buildClaudePrompt('msg', null, null);
+    expect(out).toContain('on (unknown URL):');
+  });
+
+  it('quotes every line of multi-line messages', () => {
+    const out = buildClaudePrompt('line one\nline two\nline three', '/p', 'idea');
+    expect(out).toContain('> line one\n> line two\n> line three');
+  });
+
+  it('includes the three-step instruction block', () => {
+    const out = buildClaudePrompt('hi', '/p', 'bug');
+    expect(out).toMatch(/Analyze the report/);
+    expect(out).toMatch(/Implement a fix/);
+    expect(out).toMatch(/Open a pull request/);
+  });
+});

--- a/app/src/utils/claudePrompt.ts
+++ b/app/src/utils/claudePrompt.ts
@@ -1,0 +1,29 @@
+/**
+ * Builds a Claude-Code-ready prompt from a feedback message. Pasted into the
+ * CLI it gives Claude the page URL, the user's words, and a clear three-step
+ * plan (analyse/reproduce → implement → open PR) so triage on /debug flows
+ * straight into a working session.
+ */
+export function buildClaudePrompt(
+  message: string,
+  path: string | null,
+  reaction: string | null,
+): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const url = path ? `${origin}${path}` : origin || '(unknown URL)';
+  const kind =
+    reaction === 'bug' ? 'bug report'
+    : reaction === 'idea' ? 'feature request'
+    : reaction === 'thumbs_down' ? 'negative feedback'
+    : reaction === 'thumbs_up' ? 'positive feedback'
+    : 'feedback';
+  const quoted = message.split('\n').map(line => `> ${line}`).join('\n');
+  return `A user left the following ${kind} on ${url}:
+
+${quoted}
+
+Please:
+1. Analyze the report and reproduce the issue locally (or scope the feature request).
+2. Implement a fix or the requested change.
+3. Open a pull request with the proposed solution.`;
+}


### PR DESCRIPTION
## Summary

Adds a one-click "copy prompt" button next to every feedback message in the `/debug` triage list (`app/src/pages/DebugPage.tsx`). The copied text is a self-contained, Claude-Code-ready prompt:

```
A user left the following bug report on https://anyplot.ai/plots/scatter-basic:

> Axis labels overlap on mobile

Please:
1. Analyze the report and reproduce the issue locally (or scope the feature request).
2. Implement a fix or the requested change.
3. Open a pull request with the proposed solution.
```

So an admin can sit on `/debug`, spot a bug/idea report, hit the copy icon, paste straight into Claude Code, and a session starts with the page URL, the reaction tag (bug / idea / thumbs), the user's verbatim message, and a three-step plan (analyse & reproduce → implement → open PR) — no manual context stitching.

### Implementation notes

- Reuses the existing `useCopyCode` hook + the established `ContentCopyIcon` / `CheckIcon` swap pattern (`SpecTabs.tsx`, `SpecOverview.tsx`).
- New `buildClaudePrompt(message, path, reaction)` helper composes the full URL from `window.location.origin + path` and maps the reaction to a human label (`bug report`, `feature request`, `negative feedback`, …). Multi-line messages are quoted line-by-line.
- New `CopyClaudePromptButton` sub-component keeps the "copied" state local per row, so each card animates independently.
- The button only renders when `m.message` is non-empty (thumbs reactions without text are skipped — there's nothing to paste).
- Slots into the existing 3-column message-card grid next to the status `<select>`; no layout changes elsewhere.

## Test plan

- [x] `yarn type-check` — clean
- [x] `yarn test src/pages/DebugPage.test.tsx` — 11/11 pass, incl. new test that mocks `navigator.clipboard.writeText` and asserts the copied payload contains the full URL, the reaction label, the quoted message, and the "Open a pull request" instruction
- [x] `eslint src/pages/DebugPage.tsx src/pages/DebugPage.test.tsx --max-warnings 0` — clean (the 2 warnings from `yarn lint` are pre-existing in unrelated files: `MapPage.tsx`, `test-utils.tsx`)
- [ ] Manual: open `/debug` as admin, click the copy icon on a feedback message, paste into Claude Code, confirm session bootstraps with the URL/message/reaction

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdUmMmGr3VGT4Haj742Z9k)_