### PR TITLE
feat(makie): add Julia + Makie.jl as the third language (Phase 5)

### DIFF
--- a/.github/actions/setup-julia/action.yml
+++ b/.github/actions/setup-julia/action.yml
@@ -42,7 +42,11 @@ runs:
       # `Pkg.instantiate()` restores the exact versions pinned in
       # Manifest.toml. If Manifest.toml is absent (first run before the
       # lockfile is committed), `Pkg.add(...)` falls back to fresh resolution
-      # of the packages we need so impl runs don't hard-fail.
+      # of the packages we need so impl runs don't hard-fail. The fallback
+      # list intentionally excludes Julia stdlibs (`Random`, `Statistics`):
+      # they ship with Julia itself, are not in the General registry, and
+      # `Pkg.add("Random")` would error before precompile. Stdlibs stay in
+      # Project.toml `[deps]` for the post-Manifest path.
       shell: bash
       run: |
         julia --project=. -e '
@@ -53,7 +57,7 @@ runs:
               Pkg.add([
                   "CairoMakie", "Makie", "DataFrames", "CSV",
                   "Colors", "ColorSchemes", "RDatasets",
-                  "PalmerPenguins", "Random", "Statistics"
+                  "PalmerPenguins"
               ])
               Pkg.precompile()
           end

--- a/.github/actions/setup-julia/action.yml
+++ b/.github/actions/setup-julia/action.yml
@@ -1,0 +1,75 @@
+name: "Setup Julia + Makie.jl"
+description: >-
+  Installs Julia, the system libraries needed for headless plot rendering with
+  CairoMakie, and the package set used by anyplot's Julia implementations
+  (Makie + CairoMakie + DataFrames + dataset packages). Packages are restored
+  from the committed top-level Project.toml / Manifest.toml for reproducibility.
+inputs:
+  julia-version:
+    description: "Julia version to install"
+    required: false
+    default: "1.11"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Julia
+      # julia-actions/setup-julia ships every sub-action from one repo and
+      # tags them together; `@v2` is the maintained moving tag. Dependabot
+      # will pin to a SHA on first run.
+      uses: julia-actions/setup-julia@v2
+      with:
+        version: ${{ inputs.julia-version }}
+
+    # CairoMakie bundles Cairo via Cairo_jll, so apt installs are not strictly
+    # required; keep the fallback in place so the action is robust against
+    # future runner-image changes that affect font rendering.
+    - name: Install system dependencies for CairoMakie
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libfontconfig1-dev \
+          libfreetype6-dev \
+          libpng-dev
+
+    # Speed up subsequent runs — Julia precompilation is slow on cold start.
+    # `julia-actions/cache@v2` keys on Project.toml + Manifest.toml.
+    - name: Cache Julia depot
+      uses: julia-actions/cache@v2
+
+    - name: Install Julia packages
+      # `Pkg.instantiate()` restores the exact versions pinned in
+      # Manifest.toml. If Manifest.toml is absent (first run before the
+      # lockfile is committed), `Pkg.add(...)` falls back to fresh resolution
+      # of the packages we need so impl runs don't hard-fail.
+      shell: bash
+      run: |
+        julia --project=. -e '
+          using Pkg
+          if isfile("Manifest.toml")
+              Pkg.instantiate()
+          else
+              Pkg.add([
+                  "CairoMakie", "Makie", "DataFrames", "CSV",
+                  "Colors", "ColorSchemes", "RDatasets",
+                  "PalmerPenguins", "Random", "Statistics"
+              ])
+              Pkg.precompile()
+          end
+        '
+
+    - name: Smoke-test CairoMakie renders a PNG
+      shell: bash
+      run: |
+        julia --project=. -e '
+          using CairoMakie
+          tmp = tempname() * ".png"
+          fig = Figure(resolution = (400, 300))
+          ax  = Axis(fig[1, 1])
+          scatter!(ax, 1:10, rand(10))
+          save(tmp, fig)
+          @assert isfile(tmp) "smoke-test PNG was not created"
+          @assert filesize(tmp) > 0 "smoke-test PNG is empty"
+          println("ok: ", tmp, " (", filesize(tmp), " bytes)")
+        '

--- a/.github/workflows/bulk-generate.yml
+++ b/.github/workflows/bulk-generate.yml
@@ -29,6 +29,7 @@ on:
           - highcharts
           - letsplot
           - ggplot2
+          - makie
       dry_run:
         description: "List what would be generated without executing"
         type: boolean
@@ -53,7 +54,7 @@ on:
         default: '{}'
 
 env:
-  ALL_LIBRARIES: "matplotlib seaborn plotly bokeh altair plotnine pygal highcharts letsplot ggplot2"
+  ALL_LIBRARIES: "matplotlib seaborn plotly bokeh altair plotnine pygal highcharts letsplot ggplot2 makie"
 
 # Serialise bulk-generate runs. Each run paces its own dispatches with
 # `pace_seconds`; letting two runs overlap would interleave their

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -30,6 +30,7 @@ on:
           - highcharts
           - letsplot
           - ggplot2
+          - makie
       issue_number:
         description: "Issue number (optional, for tracking)"
         required: false
@@ -118,6 +119,10 @@ jobs:
             ggplot2)
               LANGUAGE="r"
               EXT=".R"
+              ;;
+            makie)
+              LANGUAGE="julia"
+              EXT=".jl"
               ;;
             *)
               LANGUAGE="python"
@@ -245,6 +250,10 @@ jobs:
       - name: Setup R + ggplot2
         if: steps.inputs.outputs.language == 'r'
         uses: ./.github/actions/setup-r
+
+      - name: Setup Julia + Makie
+        if: steps.inputs.outputs.language == 'julia'
+        uses: ./.github/actions/setup-julia
 
       # ========================================================================
       # Generate: Create implementation branch and code
@@ -511,13 +520,20 @@ jobs:
             # Rscript exits non-zero after partial stdout.
             LANGUAGE_VERSION=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e 'cat(as.character(getRversion()))' 2>/dev/null | tail -n1)
             is_version "$LANGUAGE_VERSION" || LANGUAGE_VERSION="unknown"
+          elif [ "$LANGUAGE" = "julia" ]; then
+            # `julia -e 'print(VERSION)'` prints `1.11.2` (or similar) on stdout.
+            # tail -n1 + is_version reject anything else that might leak in or land
+            # if julia exits non-zero after partial stdout.
+            LANGUAGE_VERSION=$(julia -e 'print(VERSION)' 2>/dev/null | tail -n1)
+            is_version "$LANGUAGE_VERSION" || LANGUAGE_VERSION="unknown"
           else
             LANGUAGE_VERSION="$PYTHON_VERSION"
           fi
 
           # Get library version. Python libs read via `pip show`; R libs via
-          # packageVersion() inside Rscript. Names that differ between catalogue
-          # id and registry id are mapped explicitly.
+          # packageVersion() inside Rscript; Julia libs via Pkg API.
+          # Names that differ between catalogue id and registry id are mapped
+          # explicitly.
           get_pip_version() {
             .venv/bin/pip show "$1" 2>/dev/null | grep -i "^Version:" | awk '{print $2}'
           }
@@ -526,9 +542,36 @@ jobs:
             v=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1)
             is_version "$v" && printf '%s' "$v"
           }
+          get_julia_version() {
+            # Pkg.dependencies() returns a Dict{UUID, PackageInfo}; locate the
+            # entry by name and print its `.version`. Any version-parse failure
+            # gets rejected by the is_version check downstream.
+            local v
+            v=$(julia --project=. -e "
+              using Pkg
+              for (_, info) in Pkg.dependencies()
+                if info.name == \"$1\"
+                  print(info.version)
+                  break
+                end
+              end
+            " 2>/dev/null | tail -n1)
+            is_version "$v" && printf '%s' "$v"
+          }
 
           if [ "$LANGUAGE" = "r" ]; then
             LIBRARY_VERSION=$(get_r_version "$LIBRARY")
+          elif [ "$LANGUAGE" = "julia" ]; then
+            # Catalogue id `makie` maps to the Julia package `Makie` (CairoMakie
+            # bundles the same version; we report the user-facing Makie version).
+            case "$LIBRARY" in
+              makie)
+                LIBRARY_VERSION=$(get_julia_version "Makie")
+                ;;
+              *)
+                LIBRARY_VERSION=$(get_julia_version "$LIBRARY")
+                ;;
+            esac
           else
             case "$LIBRARY" in
               letsplot)

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -109,6 +109,10 @@ jobs:
               LANGUAGE="r"
               EXT=".R"
               ;;
+            makie)
+              LANGUAGE="julia"
+              EXT=".jl"
+              ;;
             *)
               LANGUAGE="python"
               EXT=".py"
@@ -331,8 +335,9 @@ jobs:
           ISSUE: ${{ steps.issue.outputs.number }}
           SPEC_ID: ${{ steps.extract.outputs.specification_id }}
         run: |
-          # All 9 supported libraries
-          LIBRARIES="matplotlib seaborn plotly bokeh altair plotnine pygal highcharts letsplot"
+          # All supported libraries (mirrors core/constants.py SUPPORTED_LIBRARIES).
+          # ggplot2 (R) and makie (Julia) are non-Python entries; everything else is Python.
+          LIBRARIES="matplotlib seaborn plotly bokeh altair plotnine pygal highcharts letsplot ggplot2 makie"
 
           # Get current labels on the issue
           LABELS=$(gh issue view "$ISSUE" --json labels -q '.labels[].name' 2>/dev/null || echo "")
@@ -353,11 +358,12 @@ jobs:
             fi
           done
 
+          TOTAL_LIBS=$(echo "$LIBRARIES" | wc -w | tr -d ' ')
           TOTAL=$((DONE_COUNT + FAILED_COUNT))
-          echo "::notice::Libraries: $DONE_COUNT done, $FAILED_COUNT failed, $TOTAL/9 total"
+          echo "::notice::Libraries: $DONE_COUNT done, $FAILED_COUNT failed, $TOTAL/$TOTAL_LIBS total"
 
-          # Close issue if all 9 libraries are done OR done+failed=9
-          if [ "$TOTAL" -eq 9 ]; then
+          # Close issue if all supported libraries are done OR done+failed=TOTAL_LIBS
+          if [ "$TOTAL" -eq "$TOTAL_LIBS" ]; then
             # Build status table
             TABLE="| Library | Status |\n|---------|--------|"
             for lib in $LIBRARIES; do
@@ -370,10 +376,10 @@ jobs:
 
             if [ "$FAILED_COUNT" -eq 0 ]; then
               TITLE=":tada: All Implementations Complete!"
-              SUMMARY="All 9 library implementations for \`${SPEC_ID}\` have been successfully merged."
+              SUMMARY="All ${TOTAL_LIBS} library implementations for \`${SPEC_ID}\` have been successfully merged."
             else
               TITLE=":white_check_mark: Implementations Complete"
-              SUMMARY="${DONE_COUNT}/9 implementations merged, ${FAILED_COUNT} libraries could not implement this plot type."
+              SUMMARY="${DONE_COUNT}/${TOTAL_LIBS} implementations merged, ${FAILED_COUNT} libraries could not implement this plot type."
             fi
 
             gh issue comment "$ISSUE" --body "## ${TITLE}

--- a/.github/workflows/impl-repair.yml
+++ b/.github/workflows/impl-repair.yml
@@ -75,6 +75,10 @@ jobs:
               LANGUAGE="r"
               EXT=".R"
               ;;
+            makie)
+              LANGUAGE="julia"
+              EXT=".jl"
+              ;;
             *)
               LANGUAGE="python"
               EXT=".py"
@@ -118,6 +122,10 @@ jobs:
       - name: Setup R + ggplot2
         if: steps.lang.outputs.language == 'r'
         uses: ./.github/actions/setup-r
+
+      - name: Setup Julia + Makie
+        if: steps.lang.outputs.language == 'julia'
+        uses: ./.github/actions/setup-julia
 
       - name: Extract AI feedback from PR
         id: feedback

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -678,10 +678,17 @@ jobs:
                   f"# Library: {library} {lib_version} | {RUNTIME_LABEL} {lang_version}\n"
                   f"# Quality: {score}/100 | {date_info}"
               )
-              # Match a leading run of `#`-prefixed lines (the existing header).
-              # Anchored to start of file. If no header exists we fall back to
-              # prepending one. We must NOT match `#=` block-comment openers as
-              # part of the header — restrict to lines starting with `# ` or `#$`.
+              # Match a leading run of `#`-prefixed Julia line-comments (the
+              # existing header). Anchored to start of file. If no header
+              # exists we fall back to prepending one. The character class
+              # after `#` is intentionally narrow: either `[ \t]` (a space or
+              # tab — the canonical header style `# anyplot.ai`) or empty
+              # (i.e. a bare `#` immediately followed by `\n`). This excludes:
+              # `#=` (block-comment openers, which would otherwise swallow the
+              # block-comment body) and `#!` (shebangs — Julia ignores them
+              # but they're not part of the header we own). If either ever
+              # appears as the first non-blank line of a file, the regex
+              # falls through and the canonical header is prepended above it.
               pattern = r"\A(?:#(?:[ \t][^\n]*|)\n)+"
               if re.match(pattern, content):
                   new_content = re.sub(pattern, new_header + "\n", content, count=1)

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -105,6 +105,10 @@ jobs:
               LANGUAGE="r"
               EXT=".R"
               ;;
+            makie)
+              LANGUAGE="julia"
+              EXT=".jl"
+              ;;
             *)
               LANGUAGE="python"
               EXT=".py"
@@ -263,6 +267,7 @@ jobs:
               "plotnine":   "Check `ggsave(width=…, height=…, units='in', dpi=400)` and `theme(figure_size=…)`; do not pass `bbox_inches='tight'`.",
               "letsplot":   "Check `ggsize(W, H)` and `ggsave(..., scale=4)` pair — only the two canonical pairs land on target.",
               "ggplot2":    "Check `ggsave(width=…, height=…, units='in', dpi=400)` with `ragg::agg_png`.",
+              "makie":      "Check `Figure(resolution=(1600, 900))` + `save(..., px_per_unit=2)` (landscape) or `resolution=(1200, 1200)` + `px_per_unit=2` (square) — those are the only two canonical pairs.",
           }
           cause = causes.get(LIBRARY, f"Review `prompts/library/{LIBRARY}.md` 'Canvas — hard rule' section.")
 
@@ -640,7 +645,7 @@ jobs:
 
           # Human-readable runtime label for the header. Extend this map when a new
           # language joins the catalog.
-          RUNTIME_LABEL = {"python": "Python", "r": "R"}.get(language, language.capitalize())
+          RUNTIME_LABEL = {"python": "Python", "r": "R", "julia": "Julia"}.get(language, language.capitalize())
 
           with open(impl_file, "r") as f:
               content = f.read()
@@ -658,6 +663,26 @@ jobs:
               # Match a leading run of #' lines (the existing roxygen header). Anchored to
               # start of file. If no header exists we fall back to prepending one.
               pattern = r"\A(?:#'[^\n]*\n)+"
+              if re.match(pattern, content):
+                  new_content = re.sub(pattern, new_header + "\n", content, count=1)
+              else:
+                  new_content = new_header + "\n" + content
+          elif language == "julia":
+              # Julia has no docstring syntax; anyplot uses a leading `#` comment
+              # block, mirroring the Python/R conventions. Newlines in the title
+              # would break the comment block, so sanitize them.
+              title_safe = title.replace("\n", " ")
+              new_header = (
+                  "# anyplot.ai\n"
+                  f"# {spec_id}: {title_safe}\n"
+                  f"# Library: {library} {lib_version} | {RUNTIME_LABEL} {lang_version}\n"
+                  f"# Quality: {score}/100 | {date_info}"
+              )
+              # Match a leading run of `#`-prefixed lines (the existing header).
+              # Anchored to start of file. If no header exists we fall back to
+              # prepending one. We must NOT match `#=` block-comment openers as
+              # part of the header — restrict to lines starting with `# ` or `#$`.
+              pattern = r"\A(?:#(?:[ \t][^\n]*|)\n)+"
               if re.match(pattern, content):
                   new_content = re.sub(pattern, new_header + "\n", content, count=1)
               else:

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,38 @@
+name = "anyplot"
+uuid = "5f9c7e1d-8b3d-4c1a-9f6e-1a2b3c4d5e6f"
+authors = ["anyplot contributors"]
+version = "0.1.0"
+
+# Julia runtime stack for the CairoMakie implementations.
+#
+# Reproducibility model — sibling of `renv.lock` for R:
+# - Project.toml lists the packages we depend on (this file).
+# - Manifest.toml pins the exact resolved versions across the entire
+#   dependency tree (committed alongside this file once Julia has run
+#   `Pkg.instantiate()` for the first time).
+# - The setup-julia action restores from Manifest.toml when present;
+#   otherwise it falls back to `Pkg.add(...)` so first-time CI doesn't
+#   hard-fail before the lockfile lands.
+
+[deps]
+CairoMakie     = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+CSV            = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Colors         = "5ae59095-9a9b-59fe-a467-6f913c188581"
+ColorSchemes   = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+DataFrames     = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Makie          = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+PalmerPenguins = "8b842266-38fa-440a-9b57-31493939ab85"
+Random         = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RDatasets      = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
+Statistics     = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+julia          = "1.11"
+CairoMakie     = "0.12, 0.13"
+Makie          = "0.21, 0.22"
+DataFrames     = "1"
+CSV            = "0.10"
+Colors         = "0.12, 0.13"
+ColorSchemes   = "3"
+RDatasets      = "0.7"
+PalmerPenguins = "0.1"

--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -22,6 +22,9 @@ This document contains comprehensive project documentation for AI agents working
 *R (1):*
 - **ggplot2** - The de facto standard for R; grammar of graphics, layered chart composition
 
+*Julia (1):*
+- **Makie.jl** - High-performance Julia visualization. CairoMakie ships publication-quality static PNG via a pure-Cairo backend.
+
 **Core Principle**: Community proposes plot ideas via GitHub Issues -> AI generates code -> AI quality review -> Deployed.
 
 ## Essential Commands
@@ -327,13 +330,13 @@ gs://anyplot-images/
 3. `impl-merge.yml` promotes staging -> production when PR merges to main
 
 **Interactive libraries** (generate `.html`): plotly, bokeh, altair, highcharts, pygal, letsplot
-**PNG only**: matplotlib, seaborn, plotnine
+**PNG only**: matplotlib, seaborn, plotnine, ggplot2, makie
 
 ## Tech Stack
 
 - **Backend**: FastAPI, SQLAlchemy (async), PostgreSQL, Python 3.13+
 - **Frontend**: React 19, Vite 8, TypeScript 6, MUI 9
-- **Plotting**: matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot
+- **Plotting**: matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot, ggplot2, Makie.jl
 - **Package Manager**: uv (fast Python installer)
 - **Infrastructure**: Google Cloud Run, Cloud SQL, Cloud Storage
 - **Automation**: GitHub Actions
@@ -690,7 +693,7 @@ uv run python -m automation.scripts.label_manager list
 ### Implementation Labels (on specification issue)
 
 - **`generate:{library}`** - Trigger single library generation (e.g., `generate:matplotlib`)
-- **`generate:all`** - Trigger all 10 libraries via bulk-generate
+- **`generate:all`** - Trigger all 11 libraries via bulk-generate
 - **`impl:{library}:pending`** - Generation in progress
 - **`impl:{library}:done`** - Implementation merged to main
 - **`impl:{library}:failed`** - Max retries exhausted (3 attempts)

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -117,6 +117,7 @@ class SpecStatusItem(BaseModel):
     ggplot2: float | None = None
     highcharts: float | None = None
     letsplot: float | None = None
+    makie: float | None = None
     matplotlib: float | None = None
     plotly: float | None = None
     plotnine: float | None = None
@@ -315,6 +316,7 @@ async def get_debug_status(request: Request, db: AsyncSession = Depends(require_
                 ggplot2=spec_scores.get("ggplot2"),
                 highcharts=spec_scores.get("highcharts"),
                 letsplot=spec_scores.get("letsplot"),
+                makie=spec_scores.get("makie"),
                 matplotlib=spec_scores.get("matplotlib"),
                 plotly=spec_scores.get("plotly"),
                 plotnine=spec_scores.get("plotnine"),
@@ -336,6 +338,7 @@ async def get_debug_status(request: Request, db: AsyncSession = Depends(require_
         "ggplot2": "ggplot2",
         "highcharts": "Highcharts",
         "letsplot": "lets-plot",
+        "makie": "Makie.jl",
         "matplotlib": "Matplotlib",
         "plotly": "Plotly",
         "plotnine": "plotnine",

--- a/api/routers/specs.py
+++ b/api/routers/specs.py
@@ -201,9 +201,9 @@ async def get_impl_code(spec_id: str, library: str, language: str = "python", db
 
     Code field is deferred in the main `/specs/{id}` query so it must be
     fetched here on-demand. `language` disambiguates when the same library_id
-    could exist for multiple languages (today only ggplot2 is R; everything
-    else is Python). Defaults to python for backwards compat with older
-    clients that don't send the param.
+    could exist for multiple languages (today ggplot2 is R and makie is Julia;
+    everything else is Python). Defaults to python for backwards compat with
+    older clients that don't send the param.
     """
 
     async def _fetch() -> dict:

--- a/app/src/components/CodeHighlighter.test.tsx
+++ b/app/src/components/CodeHighlighter.test.tsx
@@ -32,6 +32,10 @@ vi.mock('react-syntax-highlighter/dist/esm/languages/prism/r', () => ({
   default: {},
 }));
 
+vi.mock('react-syntax-highlighter/dist/esm/languages/prism/julia', () => ({
+  default: {},
+}));
+
 import CodeHighlighter from './CodeHighlighter';
 
 describe('CodeHighlighter', () => {
@@ -61,6 +65,14 @@ describe('CodeHighlighter', () => {
     expect(screen.getByTestId('syntax-highlighter')).toHaveAttribute(
       'data-language',
       'r'
+    );
+  });
+
+  it('uses julia grammar when language is "julia"', () => {
+    render(<CodeHighlighter code='using CairoMakie' language="julia" />);
+    expect(screen.getByTestId('syntax-highlighter')).toHaveAttribute(
+      'data-language',
+      'julia'
     );
   });
 

--- a/app/src/components/CodeHighlighter.tsx
+++ b/app/src/components/CodeHighlighter.tsx
@@ -1,16 +1,19 @@
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
 import python from 'react-syntax-highlighter/dist/esm/languages/prism/python';
 import r from 'react-syntax-highlighter/dist/esm/languages/prism/r';
+import julia from 'react-syntax-highlighter/dist/esm/languages/prism/julia';
 import { typography } from '../theme';
 
 SyntaxHighlighter.registerLanguage('python', python);
 SyntaxHighlighter.registerLanguage('r', r);
+SyntaxHighlighter.registerLanguage('julia', julia);
 
 // Map anyplot language IDs → Prism grammar names. Anything we don't know about
 // falls back to plain text so the block still renders, just unhighlighted.
 const PRISM_LANGUAGE: Record<string, string> = {
   python: 'python',
   r: 'r',
+  julia: 'julia',
 };
 
 // Theme-aware Okabe-Ito syntax theme. All colors come from CSS variables in

--- a/app/src/components/LibraryCard.tsx
+++ b/app/src/components/LibraryCard.tsx
@@ -13,6 +13,7 @@ const DESCRIPTIONS: Record<string, string> = {
   highcharts: 'Interactive web charts, stock charts, and maps.',
   letsplot: 'Grammar of graphics by JetBrains. Interactive.',
   ggplot2: 'The reference grammar of graphics. R’s expressive plotting standard.',
+  makie: 'High-performance Julia visualization. CairoMakie ships publication-quality static charts.',
 };
 
 interface LibraryCardProps {

--- a/app/src/components/PlotOfTheDay.tsx
+++ b/app/src/components/PlotOfTheDay.tsx
@@ -103,10 +103,11 @@ export function PlotOfTheDay() {
           <Typography sx={{ fontFamily: mono, fontSize: fontSize.xs, color: colors.primary, fontWeight: 600 }}>$</Typography>
           {(() => {
             // Per-language file extension + runner command. Anyplot ships Python
-            // for nine libraries and R for ggplot2; the chip mimics what a user
-            // would actually type into a shell, so the runner label flips too.
-            const ext = data.language === 'r' ? '.R' : '.py';
-            const runner = data.language === 'r' ? 'Rscript' : 'python';
+            // for nine libraries, R for ggplot2, and Julia for makie; the chip
+            // mimics what a user would actually type into a shell, so the
+            // runner label flips too.
+            const ext = data.language === 'r' ? '.R' : data.language === 'julia' ? '.jl' : '.py';
+            const runner = data.language === 'r' ? 'Rscript' : data.language === 'julia' ? 'julia --project=.' : 'python';
             return (
               <Typography
                 component="a"
@@ -264,7 +265,7 @@ export function PlotOfTheDay() {
             │
           </Typography>
           <Typography sx={{ fontFamily: mono, fontSize: fontSize.xxs, color: semanticColors.mutedText, whiteSpace: 'nowrap' }}>
-            {data.library_name}{data.library_version && data.library_version !== 'unknown' ? ` ${data.library_version}` : ''} · {data.language === 'r' ? 'R' : 'Python'} {data.language_version || data.python_version || (data.language === 'r' ? '4.4' : '3.13')}
+            {data.library_name}{data.library_version && data.library_version !== 'unknown' ? ` ${data.library_version}` : ''} · {data.language === 'r' ? 'R' : data.language === 'julia' ? 'Julia' : 'Python'} {data.language_version || data.python_version || (data.language === 'r' ? '4.4' : data.language === 'julia' ? '1.11' : '3.13')}
           </Typography>
         </Box>
       </Box>

--- a/app/src/components/PlotOfTheDayTerminal.tsx
+++ b/app/src/components/PlotOfTheDayTerminal.tsx
@@ -42,10 +42,12 @@ export function PlotOfTheDayTerminal({
   const previewUrl = selectPreviewUrl(potd, isDark);
   if (!potd || !previewUrl) return null;
 
-  // File extension + runner command follow the implementation language;
-  // ggplot2 (R) ships as .R + Rscript, every Python library as .py + python.
-  const ext = potd.language === 'r' ? '.R' : '.py';
-  const runner = potd.language === 'r' ? 'Rscript' : 'python';
+  // File extension + runner command follow the implementation language:
+  // - ggplot2 (R) ships as .R + Rscript
+  // - makie (Julia) ships as .jl + `julia --project=.`
+  // - every Python library as .py + python
+  const ext = potd.language === 'r' ? '.R' : potd.language === 'julia' ? '.jl' : '.py';
+  const runner = potd.language === 'r' ? 'Rscript' : potd.language === 'julia' ? 'julia --project=.' : 'python';
   const displayFilename = `plots/${potd.spec_id}/${potd.library_id}${ext}`;
   const implPath = specPath(potd.spec_id, potd.language, potd.library_id);
   const githubFileUrl = `${GITHUB_URL}/blob/main/plots/${potd.spec_id}/implementations/${potd.language}/${potd.library_id}${ext}`;

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -6,7 +6,7 @@ export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 // sent with fetch. Falls back to API_URL locally where there's no Worker.
 export const DEBUG_API_URL = import.meta.env.VITE_DEBUG_API_URL || API_URL;
 export const GITHUB_URL = 'https://github.com/MarkusNeusinger/anyplot';
-export const LIBRARIES = ['altair', 'bokeh', 'ggplot2', 'highcharts', 'letsplot', 'matplotlib', 'plotly', 'plotnine', 'pygal', 'seaborn'];
+export const LIBRARIES = ['altair', 'bokeh', 'ggplot2', 'highcharts', 'letsplot', 'makie', 'matplotlib', 'plotly', 'plotnine', 'pygal', 'seaborn'];
 export const BATCH_SIZE = 36;
 
 // Image size: 'normal' or 'compact' (half size)
@@ -24,6 +24,7 @@ export const LIB_ABBREV: Record<string, string> = {
   highcharts: 'hc',
   letsplot: 'lp',
   ggplot2: 'gg',
+  makie: 'mk',
 };
 
 // Static library → language map, mirroring core/constants.py LIBRARIES_METADATA.
@@ -38,6 +39,7 @@ export const LIB_TO_LANG: Record<string, string> = {
   ggplot2: 'r',
   highcharts: 'python',
   letsplot: 'python',
+  makie: 'julia',
   matplotlib: 'python',
   plotly: 'python',
   plotnine: 'python',
@@ -49,13 +51,15 @@ export const LIB_TO_LANG: Record<string, string> = {
 export const LANG_DISPLAY: Record<string, string> = {
   python: 'Python',
   r: 'R',
+  julia: 'Julia',
 };
 
 // File-extension token for a language id (e.g. used as the suffix in compact
-// plot cards: "mpl.py", "ggplot2.r"). The .R extension is uppercase on disk
-// for R scripts, but the suffix here mirrors the language id for symmetry
-// with "py" — display only, not a filesystem reference.
+// plot cards: "mpl.py", "ggplot2.r", "makie.jl"). The .R extension is uppercase
+// on disk for R scripts, but the suffix here mirrors the language id for
+// symmetry with "py" — display only, not a filesystem reference.
 export const LANG_EXT: Record<string, string> = {
   python: 'py',
   r: 'r',
+  julia: 'jl',
 };

--- a/app/src/hooks/useCodeFetch.test.ts
+++ b/app/src/hooks/useCodeFetch.test.ts
@@ -179,24 +179,48 @@ describe('useCodeFetch', () => {
       );
     });
 
-    it('caches python and r impls under separate keys for the same library_id', async () => {
+    it('appends ?language=julia for makie impls', async () => {
+      const jlCode = 'using CairoMakie';
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ code: jlCode }),
+      });
+
+      const { result } = renderHook(() => useCodeFetch());
+      let code: string | null = null;
+      await act(async () => {
+        code = await result.current.fetchCode('scatter-basic', 'makie', 'julia');
+      });
+
+      expect(code).toBe(jlCode);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/specs/scatter-basic/makie/code?language=julia')
+      );
+    });
+
+    it('caches python, r, and julia impls under separate keys for the same library_id', async () => {
       const pyCode = 'import matplotlib';
       const rCode = 'library(matplotlib)';
+      const jlCode = 'using Matplotlib';
       globalThis.fetch = vi.fn()
         .mockResolvedValueOnce({ ok: true, json: async () => ({ code: pyCode }) })
-        .mockResolvedValueOnce({ ok: true, json: async () => ({ code: rCode }) });
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ code: rCode }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ code: jlCode }) });
 
       const { result } = renderHook(() => useCodeFetch());
       let py: string | null = null;
       let r: string | null = null;
+      let jl: string | null = null;
       await act(async () => {
         py = await result.current.fetchCode('hypothetical', 'matplotlib');
         r = await result.current.fetchCode('hypothetical', 'matplotlib', 'r');
+        jl = await result.current.fetchCode('hypothetical', 'matplotlib', 'julia');
       });
 
       expect(py).toBe(pyCode);
       expect(r).toBe(rCode);
-      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+      expect(jl).toBe(jlCode);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/app/src/pages/AboutPage.tsx
+++ b/app/src/pages/AboutPage.tsx
@@ -51,7 +51,7 @@ export function AboutPage() {
         <title>about | anyplot.ai</title>
         <meta
           name="description"
-          content="a catalogue of python plotting examples across nine libraries. plot ideas come from humans; ai drafts the spec, generates code for every library, and reviews each implementation."
+          content="a catalogue of plotting examples across eleven libraries in python, r, and julia. plot ideas come from humans; ai drafts the spec, generates code for every library, and reviews each implementation."
         />
         <meta property="og:title" content="about | anyplot.ai" />
         <meta

--- a/app/src/pages/DebugPage.test.tsx
+++ b/app/src/pages/DebugPage.test.tsx
@@ -35,7 +35,7 @@ const mockDebugData = {
       updated: '2025-01-01',
       avg_score: 92,
       altair: 90, bokeh: 91, ggplot2: null, highcharts: null, letsplot: null,
-      matplotlib: 95, plotly: 88, plotnine: null, pygal: null, seaborn: 94,
+      makie: null, matplotlib: 95, plotly: 88, plotnine: null, pygal: null, seaborn: 94,
     },
   ],
 };

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -29,6 +29,7 @@ interface SpecStatus {
   ggplot2: number | null;
   highcharts: number | null;
   letsplot: number | null;
+  makie: number | null;
   matplotlib: number | null;
   plotly: number | null;
   plotnine: number | null;

--- a/app/src/pages/LibrariesPage.tsx
+++ b/app/src/pages/LibrariesPage.tsx
@@ -32,12 +32,12 @@ export function LibrariesPage() {
         <title>libraries | anyplot.ai</title>
         <meta
           name="description"
-          content="Ten plotting libraries across Python and R — matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot, ggplot2. Same specs, every library."
+          content="Eleven plotting libraries across Python, R, and Julia — matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot, ggplot2, Makie.jl. Same specs, every library."
         />
         <meta property="og:title" content="libraries | anyplot.ai" />
         <meta
           property="og:description"
-          content="Ten plotting libraries across Python and R — same specs, every library."
+          content="Eleven plotting libraries across Python, R, and Julia — same specs, every library."
         />
         <link rel="canonical" href="https://anyplot.ai/libraries" />
       </Helmet>

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -173,7 +173,7 @@ export function PlotsPage() {
     <Box onClick={handleContainerClick}>
       <Helmet>
         <title>plots | anyplot.ai</title>
-        <meta name="description" content="Browse and filter 2,600+ Python visualization examples across 9 libraries. Search by plot type, domain, features, and more." />
+        <meta name="description" content="Browse and filter 2,600+ visualization examples across 11 libraries in Python, R, and Julia. Search by plot type, domain, features, and more." />
         <link rel="canonical" href="https://anyplot.ai/plots" />
       </Helmet>
 

--- a/app/src/types/react-syntax-highlighter.d.ts
+++ b/app/src/types/react-syntax-highlighter.d.ts
@@ -7,3 +7,8 @@ declare module 'react-syntax-highlighter/dist/esm/languages/prism/r' {
   const language: unknown;
   export default language;
 }
+
+declare module 'react-syntax-highlighter/dist/esm/languages/prism/julia' {
+  const language: unknown;
+  export default language;
+}

--- a/core/constants.py
+++ b/core/constants.py
@@ -14,11 +14,23 @@ from __future__ import annotations
 
 # Canonical set of all supported plotting libraries (IDs)
 SUPPORTED_LIBRARIES = frozenset(
-    ["altair", "bokeh", "ggplot2", "highcharts", "letsplot", "matplotlib", "plotly", "plotnine", "pygal", "seaborn"]
+    [
+        "altair",
+        "bokeh",
+        "ggplot2",
+        "highcharts",
+        "letsplot",
+        "makie",
+        "matplotlib",
+        "plotly",
+        "plotnine",
+        "pygal",
+        "seaborn",
+    ]
 )
 
 # Supported programming languages
-SUPPORTED_LANGUAGES = frozenset(["python", "r"])
+SUPPORTED_LANGUAGES = frozenset(["python", "r", "julia"])
 
 # Language metadata for database seeding (analog to LIBRARIES_METADATA)
 LANGUAGES_METADATA = [
@@ -37,6 +49,14 @@ LANGUAGES_METADATA = [
         "runtime_version": "4.4",
         "documentation_url": "https://www.r-project.org",
         "description": "Language and environment for statistical computing and graphics. Widely used in academia, biotech, and finance research, with a rich package ecosystem on CRAN.",
+    },
+    {
+        "id": "julia",
+        "name": "Julia",
+        "file_extension": ".jl",
+        "runtime_version": "1.11",
+        "documentation_url": "https://julialang.org",
+        "description": "High-level, high-performance dynamic language for technical computing. Combines the productivity of Python/R with the speed of compiled languages; popular in scientific computing, numerical analysis, and machine learning research.",
     },
 ]
 
@@ -84,6 +104,14 @@ LIBRARIES_METADATA = [
         "version": "4.5.0",
         "documentation_url": "https://lets-plot.org",
         "description": "Multiplatform plotting library built on the principles of the Grammar of Graphics. A faithful adaptation of R's ggplot2 that extends Grammar of Graphics principles to both Python and Kotlin.",
+    },
+    {
+        "id": "makie",
+        "name": "Makie.jl",
+        "language_id": "julia",
+        "version": "0.22",
+        "documentation_url": "https://docs.makie.org",
+        "description": "High-performance, extensible visualization ecosystem for Julia. CairoMakie renders publication-quality static PNG/SVG/PDF; GLMakie/WGLMakie handle interactive use. anyplot uses CairoMakie for the static gallery.",
     },
     {
         "id": "matplotlib",

--- a/docs/concepts/library-expansion.md
+++ b/docs/concepts/library-expansion.md
@@ -14,20 +14,24 @@ priority order.
 
 ## 1. Current state
 
-anyplot currently ships **9 Python libraries** and **1 R library** (ggplot2 —
-the first non-Python entry; landed as Phase 3 of the rollout below).
+anyplot currently ships **9 Python libraries**, **1 R library** (ggplot2 —
+the first non-Python entry; landed as Phase 3 of the rollout below), and
+**1 Julia library** (Makie.jl via CairoMakie; landed as Phase 5 ahead of the
+original roadmap order — see §8).
 
-| # | Library    | Native     | In anyplot as | Most-used variant | Notes                                       |
-|---|------------|------------|---------------|-------------------|---------------------------------------------|
-| 1 | Matplotlib | Python     | Python        | Python            | Native = most-used.                         |
-| 2 | Seaborn    | Python     | Python        | Python            | Built on matplotlib.                        |
-| 3 | Plotly     | JavaScript | Python        | **Python**        | PyPI ~18 M / wk vs `plotly.js` ~0.8 M / wk. |
-| 4 | Bokeh      | Python     | Python        | Python            | Native = most-used.                         |
-| 5 | Altair     | Python     | Python        | Python            | Python interface to Vega-Lite (JSON spec).  |
-| 6 | plotnine   | Python     | Python        | Python            | Sister library to ggplot2, not a wrapper.   |
-| 7 | Pygal      | Python     | Python        | Python            | Native = most-used.                         |
-| 8 | Highcharts | JavaScript | Python        | **JavaScript**    | npm ~1 M / wk vs `highcharts-core` ~5 k / wk.|
-| 9 | lets-plot  | Kotlin     | Python        | Python            | Python frontend has the most users today.   |
+| #  | Library    | Native     | In anyplot as | Most-used variant | Notes                                       |
+|----|------------|------------|---------------|-------------------|---------------------------------------------|
+| 1  | Matplotlib | Python     | Python        | Python            | Native = most-used.                         |
+| 2  | Seaborn    | Python     | Python        | Python            | Built on matplotlib.                        |
+| 3  | Plotly     | JavaScript | Python        | **Python**        | PyPI ~18 M / wk vs `plotly.js` ~0.8 M / wk. |
+| 4  | Bokeh      | Python     | Python        | Python            | Native = most-used.                         |
+| 5  | Altair     | Python     | Python        | Python            | Python interface to Vega-Lite (JSON spec).  |
+| 6  | plotnine   | Python     | Python        | Python            | Sister library to ggplot2, not a wrapper.   |
+| 7  | Pygal      | Python     | Python        | Python            | Native = most-used.                         |
+| 8  | Highcharts | JavaScript | Python        | **JavaScript**    | npm ~1 M / wk vs `highcharts-core` ~5 k / wk.|
+| 9  | lets-plot  | Kotlin     | Python        | Python            | Python frontend has the most users today.   |
+| 10 | ggplot2    | R          | R             | R                 | First non-Python entry; landed in Phase 3.  |
+| 11 | Makie.jl   | Julia      | Julia         | Julia             | CairoMakie backend (static PNG). Phase 5.   |
 
 **Implication:** under the most-used rule (see §6), only **Highcharts** is
 filed under the wrong language and should move to JavaScript. Plotly and
@@ -302,9 +306,9 @@ Ranked by `reach × ease-of-integration ÷ duplication-risk`.
 | 0     | —                                   | Python        |  9                       | shipped  |
 | 1     | Chart.js, D3.js, ECharts            | + JavaScript  | 12                       | planned  |
 | 2     | Highcharts (replaces Python entry)  | —             | 12                       | planned  |
-| 3     | **ggplot2**                         | **+ R**       | **10**                   | **shipped** (Phase 3 was implemented before Phases 1+2; net total is 10 not 13 until JS lands) |
+| 3     | **ggplot2**                         | **+ R**       | **10**                   | **shipped** (Phase 3 was implemented before Phases 1+2; net total was 10 until Phase 5 landed Julia) |
 | 4     | Recharts, Observable Plot           | —             | TBD                      | planned  |
-| 5     | Makie.jl, ApexCharts                | + Julia       | TBD                      | planned  |
+| 5     | **Makie.jl** (ApexCharts deferred)  | **+ Julia**   | **11**                   | **shipped** (Phase 5 was implemented before Phases 1+2+4 to validate the multi-language pipeline on a second non-Python runtime; ApexCharts split to a later phase) |
 
 > **Why Phase 2 ≠ Tier 2 #4 from §7.** §7 ranks ggplot2 (Tier 2 #4) above
 > Highcharts (Tier 2 #5) by reach; §8 still ships Highcharts first because
@@ -348,6 +352,22 @@ entries.
   commercial-with-free-tier model) at ~18× lower download volume, and a
   second commercial entry would weaken the FOSS-first stance. Revisit only
   if Plausible data shows unmet demand for amCharts-specific examples.
+- **Phase 5 (Julia / Makie.jl) shipped before Phases 1+2 (JavaScript).**
+  The original roadmap order was Phase 1 (Chart.js / D3 / ECharts) →
+  Phase 2 (Highcharts JS) → Phase 3 (ggplot2) → Phase 4 (Recharts /
+  Observable Plot) → Phase 5 (Makie.jl). After Phase 3 landed and the
+  multi-language pipeline proved stable on R, shipping Julia next provided
+  a cheap second non-Python validation that surfaces multi-language gaps
+  the JS work would otherwise hit cold. The JavaScript phases remain
+  planned; their relative ordering is unchanged.
+- **Makie.jl over Plots.jl.** Makie is a distinct scientific stack, not a
+  wrapper, and it earns its own entry under the "most-used variant" rule
+  in §6. Plots.jl is the alternative; we ship Makie unless Plausible data
+  later shows the audience flips. `PlotlyJS.jl` is a wrapper around
+  plotly.js and is already covered via the Python Plotly entry.
+- **CairoMakie backend only.** GLMakie / WGLMakie are interactive backends
+  out of scope for the static gallery; `INTERACTIVE_LIBRARIES` intentionally
+  excludes Makie.
 
 ## 10. Open questions for the team
 

--- a/docs/concepts/vision.md
+++ b/docs/concepts/vision.md
@@ -42,7 +42,7 @@ anyplot is different: **AI curates and maintains, humans discover and choose.**
 
 ### What Makes It Different
 
-- **Library Agnostic**: Compare libraries side-by-side. Ten ecosystems across two languages today — Python (matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot) and R (ggplot2); the architecture is designed to welcome more
+- **Library Agnostic**: Compare libraries side-by-side. Eleven ecosystems across three languages today — Python (matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot), R (ggplot2), and Julia (Makie.jl); the architecture is designed to welcome more
 - **Always Current**: AI agents keep examples updated and optimized
 - **Multi-Dimensional Discovery**: Find plots by domain (finance, research), type (scatter, bar), or specific use case (
   ROC curve, Sankey diagram)

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -302,7 +302,7 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | Property | Description | Used By Events |
 |----------|-------------|----------------|
 | `spec` | Plot specification ID | `copy_code`, `download_image`, `plot_rotate`, `external_link`, `internal_link`, `open_interactive`, `report_issue`, `tag_click`, `og_image_view` |
-| `language` | Language slug (`python`, future: `julia`, `r`, `matlab`) | `og_image_view` |
+| `language` | Language slug (`python`, `r`, `julia`; future: `matlab`) | `og_image_view` |
 | `library` | Library name (matplotlib, seaborn, etc.) | `copy_code`, `download_image`, `external_link`, `internal_link`, `open_interactive`, `tab_toggle`, `og_image_view` |
 | `method` | Action method (card, image, tab, click, space, doubletap) | `copy_code`, `random_filter` |
 | `page` | Page context (home, plots, spec_overview, spec_detail) | `copy_code`, `download_image`, `og_image_view` |

--- a/docs/reference/repository.md
+++ b/docs/reference/repository.md
@@ -67,7 +67,7 @@ anyplot/
 │   ├── quality-evaluator.md           # AI quality evaluation prompt
 │   ├── spec-id-generator.md           # Assigns spec IDs
 │   ├── default-style-guide.md         # Default visual style rules
-│   ├── library/                       # Library-specific rules (10 files: 9 Python + ggplot2)
+│   ├── library/                       # Library-specific rules (11 files: 9 Python + ggplot2 + makie)
 │   │   ├── matplotlib.md
 │   │   ├── seaborn.md
 │   │   └── ...
@@ -340,9 +340,19 @@ gs://anyplot-images/
 
 ### `plots/{spec-id}/implementations/`
 
-**Purpose**: Library-specific Python implementations
+**Purpose**: Library-specific implementations, organized by language
 
-**File Naming**: `{library}.py`
+**Layout**:
+```
+plots/{spec-id}/implementations/
+├── python/   # 9 Python libraries (.py)
+├── r/        # ggplot2 (.R)
+└── julia/    # Makie.jl (.jl)
+```
+
+**File Naming** (by language):
+
+Python (`python/`, `.py`):
 - `matplotlib.py`
 - `seaborn.py`
 - `plotly.py`
@@ -352,6 +362,12 @@ gs://anyplot-images/
 - `pygal.py`
 - `highcharts.py`
 - `letsplot.py`
+
+R (`r/`, `.R`):
+- `ggplot2.R`
+
+Julia (`julia/`, `.jl`):
+- `makie.jl`
 
 **Code Style** (KISS):
 ```python
@@ -396,7 +412,7 @@ plt.savefig('plot.png', dpi=300)
 **Purpose**: AI agent prompts for code generation and quality evaluation
 
 **Subdirectories**:
-- `library/` - Library-specific rules (9 files: matplotlib, seaborn, plotly, etc.)
+- `library/` - Library-specific rules (11 files: 9 Python + ggplot2 + makie)
 - `templates/` - Templates for new specs (`specification.md`, `specification.yaml`)
 - `workflow-prompts/` - Workflow-specific prompt templates
 

--- a/docs/reference/style-guide.md
+++ b/docs/reference/style-guide.md
@@ -20,7 +20,7 @@ anyplot.ai is a considered reference work styled like a code editor over a paper
 |-------|------|--------|
 | **Brand** | Identity, voice, logo, tone of communication | Lowercase default; `any.plot()` wordmark with green dot |
 | **Frontend** | Website visual language: typography, layout, components | Editorial-scientific paper × terminal/code-editor overlay |
-| **Plots** | Color palette for every visualization across all 10 libraries (9 Python + R/ggplot2) | Okabe-Ito 8-color categorical, brand `#009E73` first |
+| **Plots** | Color palette for every visualization across all 11 libraries (9 Python + R/ggplot2 + Julia/Makie) | Okabe-Ito 8-color categorical, brand `#009E73` first |
 
 **Aesthetic direction:** `arXiv paper` × `tmux/lazygit` rather than `SaaS dashboard` or `AI startup`. The reader should feel they're browsing a curated journal that happens to live inside a terminal — section headers carry shell prompts (`❯`, `$`, `~/plots/`), hero text types itself with a blinking cursor, action buttons read as method calls (`.copy()`, `.open()`, `.download()`).
 
@@ -266,7 +266,7 @@ The lowercase default matches the code-forward aesthetic and keeps the site feel
 
 > Instead of: `🚀 Supercharge your data viz workflow with AI-powered plot generation! Unlock 1000+ beautifully crafted charts across multiple libraries. Ship faster, iterate smarter, and empower your team to create stunning visualizations!`
 >
-> Write: `A catalogue of 1,000+ plotting examples across ten libraries in two languages (Python + R). Plot ideas come from humans; AI drafts the spec, generates code for every library, and reviews each implementation. Humans approve specs and tune the rules when something repeatedly fails. Every example uses the same colorblind-safe palette, so switching libraries never breaks your color grammar.`
+> Write: `A catalogue of 1,000+ plotting examples across eleven libraries in three languages (Python + R + Julia). Plot ideas come from humans; AI drafts the spec, generates code for every library, and reviews each implementation. Humans approve specs and tune the rules when something repeatedly fails. Every example uses the same colorblind-safe palette, so switching libraries never breaks your color grammar.`
 
 The second version is shorter, says what's actually happening (humans submit ideas + approve + tune; AI does the drafting/generating/reviewing), and reads as if written by someone who cares about what they're building.
 
@@ -299,7 +299,7 @@ Narrative hooks for talking about anyplot — adapt to context, don't recite ver
 
 **The library-agnostic story:** A "Gentoo penguin" is always blue, whether you draw it in matplotlib, plotly, or bokeh. The palette travels with you across libraries. Switching tools doesn't mean re-learning your color grammar.
 
-**The catalogue story:** A thousand examples across ten libraries in two languages, each reproducible and copy-pasteable. No ads. No affiliate links. No "suggested tutorials you might like." Just the plots and the code that made them.
+**The catalogue story:** A thousand examples across eleven libraries in three languages, each reproducible and copy-pasteable. No ads. No affiliate links. No "suggested tutorials you might like." Just the plots and the code that made them.
 
 **The origin story:** It started as pyplots.ai, a small Python-only catalogue I built in a weekend. It grew when I realized people wanted the same examples across different libraries, and the same safe palette everywhere. anyplot is the grown-up version.
 

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -13,7 +13,7 @@ Git history shows all changes (`git log -p prompts/plot-generator.md`).
 |------|-------|------|
 | `plot-generator.md` | Plot Generator | Base rules for all plot implementations |
 | `default-style-guide.md` | Plot Generator | Default visual style (colors, typography, layout) |
-| `library/*.md` | Plot Generator | Library-specific rules (10 files: 9 Python + ggplot2) |
+| `library/*.md` | Plot Generator | Library-specific rules (11 files: 9 Python + ggplot2 + makie) |
 | `quality-criteria.md` | All | Definition of what "good code" means |
 | `quality-evaluator.md` | Quality Checker | AI quality evaluation |
 | `spec-id-generator.md` | Spec ID Generator | Assigns unique spec IDs |

--- a/prompts/library/makie.md
+++ b/prompts/library/makie.md
@@ -21,8 +21,10 @@ Out of native CairoMakie scope:
 - True interactivity (hover, zoom, brush, animation) — needs `GLMakie` /
   `WGLMakie`
 - WebGL-only effects
-- Embedded D3-style network layouts (NetworkLayout.jl is allowed; use it
-  judiciously)
+- Embedded D3-style network layouts — `NetworkLayout.jl` is **not**
+  installed in the CI runtime, so do not `using NetworkLayout`. Network /
+  graph specs whose primary value is the layout itself should return
+  `NOT_FEASIBLE` rather than improvise.
 
 ## Interactive Spec Handling
 

--- a/prompts/library/makie.md
+++ b/prompts/library/makie.md
@@ -1,0 +1,313 @@
+# Makie.jl
+
+Makie.jl is the high-performance visualization ecosystem for Julia. This is
+anyplot's first Julia-language entry; the file extension is **`.jl`** and the
+runtime is **`julia --project=.`**, not Python and not Rscript.
+
+anyplot uses the **CairoMakie** backend exclusively — pure-Cairo, headless,
+PNG/SVG/PDF out of the box, no GPU or display server required. `GLMakie` and
+`WGLMakie` are interactive backends that are explicitly out of scope.
+
+## IMPORTANT: No Workarounds
+
+**If Makie cannot implement a plot type natively, DO NOT shell out to
+matplotlib, Python, R, or another backend.**
+
+Makie is a complete visualization grammar. If a spec genuinely cannot be
+expressed with Makie + the recipe ecosystem, the implementation should FAIL
+rather than fall back to another library.
+
+Out of native CairoMakie scope:
+- True interactivity (hover, zoom, brush, animation) — needs `GLMakie` /
+  `WGLMakie`
+- WebGL-only effects
+- Embedded D3-style network layouts (NetworkLayout.jl is allowed; use it
+  judiciously)
+
+## Interactive Spec Handling
+
+CairoMakie produces **static PNG only**. Same model as matplotlib / seaborn /
+plotnine / ggplot2. When implementing specs that mention interactive
+features:
+
+- Specs whose PRIMARY value is interactivity (hover, zoom, click, brush) →
+  **NOT_FEASIBLE**
+- Specs with animation → use small multiples (facetted `Axis` grid) as a
+  static alternative
+- Mixed specs (static + interactive) → implement static features only, omit
+  interactive silently
+- **NEVER** simulate tooltips, hover states, or controls. See AR-08 in
+  `prompts/quality-criteria.md`.
+
+---
+
+## Imports
+
+```julia
+using CairoMakie
+using Makie
+using DataFrames
+using Colors
+using ColorSchemes
+using Random
+using Statistics
+```
+
+Optional dataset packages available in the CI runtime: `RDatasets` (gives
+`iris`, `mtcars`, `diamonds` cross-language-compatibly), `PalmerPenguins`.
+`CSV` is available for ad-hoc data loading but anyplot implementations
+should generate data in-memory.
+
+## Reproducibility
+
+```julia
+Random.seed!(42)
+```
+
+## Canvas — hard rule, no deviation
+
+The saved PNG must be **exactly** one of these two sizes (post-render gate
+in `impl-review.yml` rejects anything off by more than 16 px and re-triggers
+repair):
+
+| Orientation | `Figure(resolution=...)` × `save(..., px_per_unit=...)` | Final PNG     |
+|-------------|----------------------------------------------------------|---------------|
+| Landscape   | `resolution = (1600, 900)`, `px_per_unit = 2`            | 3200 × 1800   |
+| Square      | `resolution = (1200, 1200)`, `px_per_unit = 2`           | 2400 × 2400   |
+
+Pick the orientation that suits the spec. CairoMakie honours `resolution`
+and `px_per_unit` exactly — no padding or cropping, so the saved PNG lands
+on target without extra tricks. Do **not** deviate from these pairs.
+
+## Figure Size & Sizing for 3200×1800 px (starting values — review loop tunes)
+
+Makie's text sizes are scaled by `px_per_unit`. With `px_per_unit = 2` and
+the landscape canvas, the values below produce a comfortable proportional
+result; tune up or down if review feedback says so.
+
+```julia
+fig = Figure(
+    resolution = (1600, 900),
+    fontsize   = 14,        # base font; px_per_unit doubles this on save
+    backgroundcolor = PAGE_BG,
+)
+
+ax = Axis(
+    fig[1, 1];
+    title       = "scatter-basic · julia · makie · anyplot.ai",
+    titlesize   = 20,
+    xlabel      = "X",
+    ylabel      = "Y",
+    xlabelsize  = 14,
+    ylabelsize  = 14,
+    xticklabelsize = 12,
+    yticklabelsize = 12,
+    backgroundcolor = PAGE_BG,
+)
+```
+
+Geom-equivalent sizing (Makie plot primitives):
+- `scatter!(ax, x, y; markersize = 12)` — sparse data; bump down for dense.
+- `lines!(ax, x, y; linewidth = 2.5)` — sparse; ~1.5 for dense overlays.
+
+## Save (PNG, both themes)
+
+```julia
+save("plot-$(THEME).png", fig; px_per_unit = 2)
+```
+
+`px_per_unit = 2` doubles the resolution at write time — combined with the
+canonical `resolution` values above, this is what produces 3200×1800 or
+2400×2400 pixels.
+
+## Colors
+
+Use the Okabe-Ito palette (see `prompts/default-style-guide.md`
+"Categorical Palette"). First series is **always** `#009E73`.
+
+```julia
+const OKABE_ITO = [
+    colorant"#009E73",  # 1 — first categorical series (anyplot brand green)
+    colorant"#D55E00",  # 2
+    colorant"#0072B2",  # 3
+    colorant"#CC79A7",  # 4
+    colorant"#E69F00",  # 5
+    colorant"#56B4E9",  # 6
+    colorant"#F0E442",  # 7
+]
+
+# Single-series
+scatter!(ax, x, y; color = OKABE_ITO[1])
+
+# Multi-series — categorical
+scatter!(ax, x, y; color = group, colormap = OKABE_ITO)
+
+# Continuous — NOT Okabe-Ito:
+# Sequential
+heatmap!(ax, z; colormap = :viridis)
+heatmap!(ax, z; colormap = :cividis)
+# Diverging
+heatmap!(ax, z; colormap = :BrBG)
+```
+
+Never use `:rainbow`, `:jet`, `:hsv`, `:gist_rainbow`, or any other
+rainbow-family colormap — they all fail CVD and luminance ordering.
+
+## Theme-adaptive Chrome (Makie mapping)
+
+Read `ANYPLOT_THEME` from the environment and flip chrome tokens. Data
+colors stay identical between themes — only the surrounding chrome changes.
+
+```julia
+const THEME       = get(ENV, "ANYPLOT_THEME", "light")
+const PAGE_BG     = THEME == "light" ? colorant"#FAF8F1" : colorant"#1A1A17"
+const ELEVATED_BG = THEME == "light" ? colorant"#FFFDF6" : colorant"#242420"
+const INK         = THEME == "light" ? colorant"#1A1A17" : colorant"#F0EFE8"
+const INK_SOFT    = THEME == "light" ? colorant"#4A4A44" : colorant"#B8B7B0"
+
+fig = Figure(
+    resolution      = (1600, 900),
+    fontsize        = 14,
+    backgroundcolor = PAGE_BG,
+)
+
+ax = Axis(
+    fig[1, 1];
+    backgroundcolor   = PAGE_BG,
+    titlecolor        = INK,
+    xlabelcolor       = INK,
+    ylabelcolor       = INK,
+    xticklabelcolor   = INK_SOFT,
+    yticklabelcolor   = INK_SOFT,
+    xtickcolor        = INK_SOFT,
+    ytickcolor        = INK_SOFT,
+    leftspinecolor    = INK_SOFT,
+    bottomspinecolor  = INK_SOFT,
+    topspinevisible   = false,
+    rightspinevisible = false,
+    xgridcolor        = RGBAf(INK.r, INK.g, INK.b, 0.10),
+    ygridcolor        = RGBAf(INK.r, INK.g, INK.b, 0.10),
+    xminorgridvisible = false,
+    yminorgridvisible = false,
+)
+```
+
+## Plot Primitives (most common)
+
+```julia
+scatter!(ax, x, y)              # scatter
+lines!(ax, x, y)                # line
+barplot!(ax, x, y)              # bar from precomputed values
+hist!(ax, x; bins = 30)         # histogram
+density!(ax, x)                 # density
+heatmap!(ax, z)                 # heatmap
+contour!(ax, x, y, z)           # contour
+boxplot!(ax, group, value)      # boxplot
+violin!(ax, group, value)       # violin
+
+# Small multiples: layout into a grid
+ax1 = Axis(fig[1, 1]); ax2 = Axis(fig[1, 2])
+```
+
+## Script Skeleton
+
+A complete Makie implementation reads `ANYPLOT_THEME`, generates data,
+builds the figure, and saves both themed PNGs by being invoked twice with
+different env values. The same single `.jl` file handles both themes — no
+two-file split.
+
+```julia
+using CairoMakie
+using Colors
+using Random
+
+Random.seed!(42)
+
+# --- Theme tokens -----------------------------------------------------------
+const THEME    = get(ENV, "ANYPLOT_THEME", "light")
+const PAGE_BG  = THEME == "light" ? colorant"#FAF8F1" : colorant"#1A1A17"
+const INK      = THEME == "light" ? colorant"#1A1A17" : colorant"#F0EFE8"
+const INK_SOFT = THEME == "light" ? colorant"#4A4A44" : colorant"#B8B7B0"
+const OKABE_ITO = [
+    colorant"#009E73", colorant"#D55E00", colorant"#0072B2", colorant"#CC79A7",
+    colorant"#E69F00", colorant"#56B4E9", colorant"#F0E442",
+]
+
+# --- Data -------------------------------------------------------------------
+x = randn(100)
+y = randn(100)
+
+# --- Plot -------------------------------------------------------------------
+fig = Figure(
+    resolution      = (1600, 900),
+    fontsize        = 14,
+    backgroundcolor = PAGE_BG,
+)
+
+ax = Axis(
+    fig[1, 1];
+    title              = "scatter-basic · julia · makie · anyplot.ai",
+    titlesize          = 20,
+    titlecolor         = INK,
+    xlabel             = "X",
+    ylabel             = "Y",
+    xlabelcolor        = INK,
+    ylabelcolor        = INK,
+    xticklabelcolor    = INK_SOFT,
+    yticklabelcolor    = INK_SOFT,
+    backgroundcolor    = PAGE_BG,
+    topspinevisible    = false,
+    rightspinevisible  = false,
+    leftspinecolor     = INK_SOFT,
+    bottomspinecolor   = INK_SOFT,
+    xgridcolor         = RGBAf(INK.r, INK.g, INK.b, 0.10),
+    ygridcolor         = RGBAf(INK.r, INK.g, INK.b, 0.10),
+)
+
+scatter!(ax, x, y; color = OKABE_ITO[1], markersize = 12, strokewidth = 0)
+
+# --- Save -------------------------------------------------------------------
+save("plot-$(THEME).png", fig; px_per_unit = 2)
+```
+
+## Output Files
+
+- Implementation: `plots/{spec-id}/implementations/julia/makie.jl` —
+  executed twice with different `ANYPLOT_THEME`.
+- Generated artifacts: `plot-light.png` + `plot-dark.png` (CairoMakie is
+  PNG-only in this catalog; no HTML variant — GLMakie / WGLMakie are out
+  of scope).
+
+## Header Style
+
+Julia has no docstring syntax in the Python sense. anyplot uses a `#`
+comment block at the top of every `.jl` file, mirroring the conventions
+for Python (triple-quoted docstring) and R (`#'` roxygen block).
+
+```julia
+# anyplot.ai
+# scatter-basic: Basic Scatter Plot
+# Library: Makie.jl 0.22 | Julia 1.11
+# Quality: pending | Created: 2026-05-22
+```
+
+The pipeline's `impl-review.yml` header-rewrite step replaces the leading
+block with the canonical four-line header once a quality score is
+assigned. If the file has no leading `#` block, the rewrite prepends one.
+
+## Julia / Makie-Specific Gotchas
+
+- `using CairoMakie` is enough — do **not** also `import Plots`. Plots.jl
+  is the alternative ecosystem and is out of scope for this entry.
+- Never call `display(fig)` instead of `save(...)` — `display` opens an
+  interactive backend, which CI does not have.
+- `@show` and bare expressions at the script level pollute stdout in
+  the runner; keep the script silent except for the `save` call.
+- `colorant"#RRGGBB"` (from `Colors`) is the canonical hex-to-color
+  helper. Prefer it over manual `RGB(r/255, g/255, b/255)` constructors.
+- For multi-series categorical color, pass an `OKABE_ITO[1:n]` slice to
+  `colormap = ...` rather than letting Makie's default cycle pick the
+  first color (which is **not** Okabe-Ito green).
+- The implementation file must end with a trailing newline — Julia
+  parses fine without it, but the impl-review header rewrite assumes
+  one.

--- a/prompts/plot-generator.md
+++ b/prompts/plot-generator.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-You are an expert for data visualization. You generate clean, readable plot scripts that anyone can copy and use. Most anyplot libraries are Python (matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot); **ggplot2 is R** — same rules, different runtime.
+You are an expert for data visualization. You generate clean, readable plot scripts that anyone can copy and use. Most anyplot libraries are Python (matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot); **ggplot2 is R** and **Makie.jl is Julia** — same rules, different runtimes.
 
 ## Task
 
@@ -11,10 +11,10 @@ Create a script for the specified plot type and library. The code should be simp
 ## Input
 
 1. **Spec**: Markdown specification from `plots/{spec-id}/specification.md`
-2. **Library**: matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot, or ggplot2
+2. **Library**: matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot, ggplot2, or makie
 3. **Library Rules**: Specific rules from `prompts/library/{library}.md`
 4. **Previous Metadata** (if regenerating): `plots/{spec-id}/metadata/{language}/{library}.yaml`
-5. **Previous Code** (if regenerating): `plots/{spec-id}/implementations/{language}/{library}{ext}` — `{ext}` is `.py` for python libraries, `.R` for ggplot2
+5. **Previous Code** (if regenerating): `plots/{spec-id}/implementations/{language}/{library}{ext}` — `{ext}` is `.py` for python libraries, `.R` for ggplot2, `.jl` for makie
 
 ## Available Standard Packages
 
@@ -28,9 +28,14 @@ Create a script for the specified plot type and library. The code should be simp
 
 **Built-in R datasets**: `mtcars`, `iris`, `diamonds`, `economics`, `mpg`, `faithful`, `palmerpenguins::penguins`, `gapminder::gapminder`.
 
+**Julia / Makie** has access to: `CairoMakie`, `Makie`, `DataFrames`, `CSV`, `Colors`, `ColorSchemes`, `RDatasets`, `PalmerPenguins`, `Random`, `Statistics`.
+
+**Built-in Julia datasets** (via `RDatasets.dataset("datasets", "iris")` etc.): `iris`, `mtcars`, `diamonds`. Plus `PalmerPenguins.load()`.
+
 **Usage guidelines:**
 - Python: `np.random.seed(42)` for reproducibility when using random data
 - R: `set.seed(42)` for reproducibility when using random data
+- Julia: `Random.seed!(42)` for reproducibility when using random data
 - Keep code simple — import only what you need
 - Use realistic data with proper domain context (salaries, test scores, measurements, etc.)
 
@@ -62,7 +67,7 @@ charts rendered by different engines defeat the point.
 
 **Allowed inputs for this implementation:**
 - `plots/{spec-id}/specification.md` and `specification.yaml`
-- `plots/{spec-id}/implementations/{language}/{this-library}{ext}` (if regenerating, same library only — `.py` for python, `.R` for ggplot2)
+- `plots/{spec-id}/implementations/{language}/{this-library}{ext}` (if regenerating, same library only — `.py` for python, `.R` for ggplot2, `.jl` for makie)
 - `plots/{spec-id}/metadata/{language}/{this-library}.yaml` (its own previous review only)
 - `prompts/library/{this-library}.md`
 - `prompts/plot-generator.md`, `prompts/quality-criteria.md`, `prompts/default-style-guide.md`
@@ -84,7 +89,7 @@ implementation's own decision.
 
 ## Output
 
-A simple script with the structure below. The example is Python; ggplot2 follows the same imports → data → plot → save shape — see `prompts/library/ggplot2.md` for the R-flavoured version.
+A simple script with the structure below. The example is Python; ggplot2 follows the same imports → data → plot → save shape — see `prompts/library/ggplot2.md` for the R-flavoured version and `prompts/library/makie.md` for the Julia-flavoured version.
 
 ```python
 """ anyplot.ai
@@ -141,13 +146,14 @@ plt.savefig(f'plot-{THEME}.png', dpi=400, bbox_inches='tight', facecolor=PAGE_BG
 {spec-id} · {language} · {library} · anyplot.ai
 ```
 
-`{language}` is the implementation's language, lowercase: `python` or `r`. The language token is **required** — viewers cannot tell from `ggplot2` alone whether a chart is Python or R (`plotnine` is the Python ggplot port), and going forward every rendered title must surface the runtime language. Keep it lowercase to match the lowercase `{spec-id}` and `{library}` tokens.
+`{language}` is the implementation's language, lowercase: `python`, `r`, or `julia`. The language token is **required** — viewers cannot tell from `ggplot2` alone whether a chart is Python or R (`plotnine` is the Python ggplot port), and going forward every rendered title must surface the runtime language. Keep it lowercase to match the lowercase `{spec-id}` and `{library}` tokens.
 
 Examples:
 - `scatter-basic · python · matplotlib · anyplot.ai`
 - `bar-grouped · python · seaborn · anyplot.ai`
 - `heatmap-correlation · python · plotly · anyplot.ai`
 - `biplot-pca · r · ggplot2 · anyplot.ai`
+- `scatter-basic · julia · makie · anyplot.ai`
 
 **Optional descriptive prefix**: If the spec-id alone doesn't explain the example data well, add a descriptive title before it:
 
@@ -253,6 +259,14 @@ R (use `#'` Roxygen-style comments — R has no docstring syntax):
 #' Quality: {score}/100 | Created: {YYYY-MM-DD}
 ```
 
+Julia (use `#` comments — Julia has no Python-style docstring):
+```julia
+# anyplot.ai
+# {spec-id}: {Title}
+# Library: Makie.jl {lib_version} | Julia {jl_version}
+# Quality: {score}/100 | Created: {YYYY-MM-DD}
+```
+
 **During generation** (before review): Use placeholder values
 ```python
 """ anyplot.ai
@@ -281,6 +295,15 @@ Must pass all code quality criteria (CQ-01 through CQ-05) from `prompts/quality-
 - Using a non-`ragg` device for PNG output (Cairo path is not installed in CI)
 - Falling back to base-R `plot()` / `barplot()` when ggplot2 can't express something — return NOT_FEASIBLE instead
 - **Extra** roxygen blocks beyond the required 4-line header (see "Docstring Format" above). The R equivalent of the Python rule: the `#'`-prefixed header at the top of the file is **mandatory** (`impl-review.yml` rewrites it); don't add other `#'` blocks elsewhere.
+
+**Forbidden (Julia / Makie):**
+- Importing `Plots` — Plots.jl is the alternative ecosystem and is out of scope. Use CairoMakie only.
+- Calling `display(fig)` instead of `save(...)` — `display` opens an interactive backend, which CI doesn't have.
+- Using `GLMakie` or `WGLMakie` — interactive backends, out of scope. CairoMakie is the only allowed backend.
+- Wrapping the plot in a Julia function or module — keep it top-level, top-down, mirroring the Python/R rule.
+- Bare `@show` or expressions at script level that pollute stdout.
+- Falling back to shelling out to Python/R/matplotlib when CairoMakie can't express something — return NOT_FEASIBLE instead.
+- **Extra** `#`-comment blocks beyond the required 4-line header. The Julia equivalent of the Python/R rule: the leading `#` header is **mandatory** (`impl-review.yml` rewrites it); don't insert other multi-line `#` blocks at the top of the file.
 
 > If a library cannot implement a plot type natively, **do not** fall back to another library's **plotting functions** (e.g., don't use `plt.scatter()` inside plotnine). The implementation should **fail** rather than use workarounds. Each library should demonstrate only its own native plotting capabilities.
 
@@ -316,7 +339,7 @@ Must pass all code quality criteria (CQ-01 through CQ-05) from `prompts/quality-
 
 ### Feasibility Pre-Check (Static Libraries Only)
 
-Before generating code for **matplotlib**, **seaborn**, **plotnine**, or **ggplot2**:
+Before generating code for **matplotlib**, **seaborn**, **plotnine**, **ggplot2**, or **makie**:
 
 1. Check if the spec requires interactivity (hover, zoom, click, brush, animation, streaming)
 2. If the spec's PRIMARY value is its interactivity → **STOP**

--- a/prompts/quality-evaluator.md
+++ b/prompts/quality-evaluator.md
@@ -4,7 +4,7 @@
 
 ## Role
 
-You are a strict code reviewer for data visualizations. Most implementations are Python; ggplot2 is R. You evaluate plot implementations against `prompts/quality-criteria.md`.
+You are a strict code reviewer for data visualizations. Most implementations are Python; ggplot2 is R; Makie.jl is Julia. You evaluate plot implementations against `prompts/quality-criteria.md`.
 
 ## Two-Stage Evaluation
 
@@ -44,7 +44,7 @@ You evaluate implementations that passed all auto-reject checks. Focus purely on
 ## Input
 
 1. **Specification**: From `plots/{spec-id}/specification.md`
-2. **Code**: From `plots/{spec-id}/implementations/{language}/{library}{ext}` — `{ext}` is `.py` for python libraries and `.R` for ggplot2
+2. **Code**: From `plots/{spec-id}/implementations/{language}/{library}{ext}` — `{ext}` is `.py` for python libraries, `.R` for ggplot2, and `.jl` for makie
 3. **Previews**: BOTH theme renders of the plot image — `plot-light.png` and `plot-dark.png`. You must inspect both. For interactive libraries, also `plot-light.html` and `plot-dark.html`.
 4. **Library Rules**: From `prompts/library/{library}.md`
 5. **Style Guide** (canonical palette + theme tokens): `prompts/default-style-guide.md` — consult its "Categorical Palette", "Continuous Data", "Background", and "Theme-adaptive Chrome" sections for VQ-07 scoring.
@@ -168,7 +168,7 @@ You evaluate implementations that passed all auto-reject checks. Focus purely on
 
 ### Step 0a: Check for Fake Functionality (AR-08)
 
-**For static libraries (matplotlib, seaborn, plotnine, ggplot2) only:**
+**For static libraries (matplotlib, seaborn, plotnine, ggplot2, makie) only:**
 
 Scan the code and image for:
 - Simulated tooltips, hover states, or selection states
@@ -234,7 +234,7 @@ Not AR-09 (handle via VQ-05 instead): text overflowing its axis but staying on t
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All spec features present? |
 | SC-03 | Data Mapping | 3 | X/Y correctly assigned? All data visible? |
-| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r}). Legend labels correct? |
+| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r, julia}). Legend labels correct? |
 
 ### Step 4: Data Quality (15 pts)
 
@@ -340,9 +340,9 @@ These features **add significant value** in the HTML output. The PNG is just a s
 
 ## Static Libraries and Interactive Specs
 
-**For matplotlib, seaborn, plotnine, ggplot2:**
+**For matplotlib, seaborn, plotnine, ggplot2, makie:**
 
-These libraries produce static PNG only. When evaluating their implementations of specs that mention interactive features:
+These libraries produce static PNG only (Makie via the CairoMakie backend; GLMakie/WGLMakie are out of scope). When evaluating their implementations of specs that mention interactive features:
 
 1. **Do NOT penalize** for missing interactivity (hover, zoom, click) — these are static libraries
 2. **DO penalize** (AR-08) for **faking** interactivity — simulated tooltips, drawn buttons, etc.

--- a/prompts/workflow-prompts/ai-quality-review.md
+++ b/prompts/workflow-prompts/ai-quality-review.md
@@ -17,7 +17,7 @@ Evaluate if the **${LIBRARY}** implementation matches the specification for `${S
 - Note all required features
 
 ### 2. Read the Implementation
-`plots/${SPEC_ID}/implementations/${LANGUAGE}/${LIBRARY}${EXT}` — `${EXT}` is `.py` for python libraries (matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot) and `.R` for ggplot2
+`plots/${SPEC_ID}/implementations/${LANGUAGE}/${LIBRARY}${EXT}` — `${EXT}` is `.py` for python libraries (matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot), `.R` for ggplot2, and `.jl` for makie
 
 ### 3. Read Library-Specific Rules
 `prompts/library/${LIBRARY}.md`
@@ -106,7 +106,7 @@ Visually estimate from each PNG — no pixel measurement needed. These are soft 
 
 ### 6. Check for Auto-Reject (AR-08, AR-09)
 
-**AR-08 — Fake interactivity (static libraries only — matplotlib, seaborn, plotnine, ggplot2):**
+**AR-08 — Fake interactivity (static libraries only — matplotlib, seaborn, plotnine, ggplot2, makie):**
 
 Before scoring, check if the implementation fakes interactive features:
 - Simulated tooltips (annotation boxes styled as hover tooltips)
@@ -167,7 +167,7 @@ Read `prompts/quality-criteria.md` and evaluate:
 | SC-01 | Plot Type | 5 | Correct chart type? |
 | SC-02 | Required Features | 4 | All features from spec? |
 | SC-03 | Data Mapping | 3 | X/Y correct? Axes show all data? |
-| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r}). Legend labels match? |
+| SC-04 | Title & Legend | 3 | Title is `{spec-id} · {language} · {library} · anyplot.ai`, optionally prefixed with `{Descriptive Title} · ` (language ∈ {python, r, julia}). Legend labels match? |
 
 #### Data Quality (15 pts)
 | ID | Criterion | Max | Check |

--- a/prompts/workflow-prompts/impl-generate-claude.md
+++ b/prompts/workflow-prompts/impl-generate-claude.md
@@ -12,6 +12,7 @@ The `{EXT}` value depends on `{LANGUAGE}`:
 |----------|------|-----------------------|
 | `python` | `.py` | `python` (in `.venv`) |
 | `r`      | `.R`  | `Rscript`             |
+| `julia`  | `.jl` | `julia --project=.`   |
 
 ---
 
@@ -50,7 +51,7 @@ Read these files to understand the requirements:
 When regenerating an existing implementation, you MUST read these BEFORE writing any code:
 
 1. `/tmp/anyplot-prev-review.md` — structured review from the previous attempt (image description, strengths, weaknesses, failed criteria checklist). The workflow extracts this automatically from the previous `metadata/{LANGUAGE}/{LIBRARY}.yaml`.
-2. `plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}` — the previous implementation (`.py` for python, `.R` for r).
+2. `plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}` — the previous implementation (`.py` for python, `.R` for r, `.jl` for julia).
 
 **Default regen mindset: incremental improvement, not rewrite.**
 
@@ -107,7 +108,7 @@ entirely — there is nothing to apply.
 
 ### Feasibility Check (Static Libraries Only)
 
-If LIBRARY is **matplotlib**, **seaborn**, **plotnine**, or **ggplot2**, AND the specification mentions interactive features (hover, zoom, click, brush, animation, streaming):
+If LIBRARY is **matplotlib**, **seaborn**, **plotnine**, **ggplot2**, or **makie**, AND the specification mentions interactive features (hover, zoom, click, brush, animation, streaming):
 
 1. Is the spec's PRIMARY value its interactivity?
 2. If YES → Do NOT generate. Report: `NOT_FEASIBLE: {LIBRARY} cannot provide {required_feature} as static PNG.`
@@ -121,15 +122,16 @@ If LIBRARY is **matplotlib**, **seaborn**, **plotnine**, or **ggplot2**, AND the
 plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}
 ```
 
-where `{EXT}` is `.py` for `python` and `.R` for `r`.
+where `{EXT}` is `.py` for `python`, `.R` for `r`, and `.jl` for `julia`.
 
 The script MUST:
 - Follow the KISS structure: imports → data → plot → save
 - Read `ANYPLOT_THEME` from the environment (`"light"` or `"dark"`, default `"light"`) and render accordingly. The same single script file handles both themes.
   - Python: `os.getenv("ANYPLOT_THEME", "light")`
   - R: `Sys.getenv("ANYPLOT_THEME", "light")`
+  - Julia: `get(ENV, "ANYPLOT_THEME", "light")`
 - Save output as `plot-{THEME}.png` (theme-suffixed, based on the env var).
-- For interactive libraries (plotly, bokeh, altair, highcharts, pygal, letsplot): also save `plot-{THEME}.html`. ggplot2 is PNG-only, no HTML variant.
+- For interactive libraries (plotly, bokeh, altair, highcharts, pygal, letsplot): also save `plot-{THEME}.html`. ggplot2 and makie are PNG-only, no HTML variant.
 - Use `#009E73` (Okabe-Ito position 1) as the **first categorical series**, always. Multi-series follows the canonical order: `#D55E00`, `#0072B2`, `#CC79A7`, `#E69F00`, `#56B4E9`, `#F0E442`.
 - For continuous data: `viridis`/`cividis` (sequential) or `BrBG` (diverging). Never `jet`/`hsv`/`rainbow`.
 - Plot backgrounds: `#FAF8F1` (light) / `#1A1A17` (dark). Never pure `#FFFFFF` or `#000000`.
@@ -156,7 +158,14 @@ ANYPLOT_THEME=light Rscript {LIBRARY}.R
 ANYPLOT_THEME=dark  Rscript {LIBRARY}.R
 ```
 
-Both runs must succeed and produce `plot-light.png` / `plot-dark.png` (plus `plot-light.html` / `plot-dark.html` for interactive libs). If either fails, fix and try again (max 3 attempts).
+**Julia (`LANGUAGE=julia`)**:
+```bash
+cd plots/{SPEC_ID}/implementations/{LANGUAGE}
+ANYPLOT_THEME=light julia --project=. {LIBRARY}.jl
+ANYPLOT_THEME=dark  julia --project=. {LIBRARY}.jl
+```
+
+Both runs must succeed and produce `plot-light.png` / `plot-dark.png` (plus `plot-light.html` / `plot-dark.html` for interactive libs — ggplot2 and makie are PNG-only). If either fails, fix and try again (max 3 attempts).
 
 ### Step 3b: Canvas dimension self-check (Step 0 contract verification)
 
@@ -202,6 +211,13 @@ ggplot2 style (4-space indent, `<-` for assignment, `=` only in arguments). If
 `Rscript -e 'styler::style_file("plots/{SPEC_ID}/implementations/r/{LIBRARY}.R")'`
 — but a missing styler is not a failure.
 
+**Julia (`LANGUAGE=julia`)**: no formatter is required by CI. Follow idiomatic
+Julia style (4-space indent, no trailing whitespace, `lowercase_with_underscores`
+for variables and functions, `CamelCase` for types/modules). If `JuliaFormatter`
+is available, you may run
+`julia --project=. -e 'using JuliaFormatter; format_file("plots/{SPEC_ID}/implementations/julia/{LIBRARY}.jl")'`
+— but a missing formatter is not a failure.
+
 ## Step 6: Verify file exists (CRITICAL)
 
 Before committing, verify the implementation file exists:
@@ -210,7 +226,7 @@ Before committing, verify the implementation file exists:
 ls -la plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}
 ```
 
-`{EXT}` is `.py` for python, `.R` for r.
+`{EXT}` is `.py` for python, `.R` for r, `.jl` for julia.
 
 **If the file does NOT exist, you MUST go back to Step 2 and create it!**
 
@@ -239,8 +255,8 @@ Pass the multi-line message via `-F -` or a heredoc so git preserves the body.
 ## Final Check
 
 Before finishing, confirm:
-1. ✅ `plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}` exists (`.py` for python, `.R` for r)
-2. ✅ `plot-light.png` AND `plot-dark.png` were generated successfully (plus `plot-light.html` / `plot-dark.html` for interactive libs — ggplot2 is PNG-only)
+1. ✅ `plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}` exists (`.py` for python, `.R` for r, `.jl` for julia)
+2. ✅ `plot-light.png` AND `plot-dark.png` were generated successfully (plus `plot-light.html` / `plot-dark.html` for interactive libs — ggplot2 and makie are PNG-only)
 3. ✅ First categorical series renders in `#009E73` in both themes
 4. ✅ Changes were committed and pushed
 5. ✅ If regenerating: `/tmp/anyplot-prev-review.md` and the previous source file were read, and each weakness / failed criterion was either addressed or consciously kept (explained in the commit body)

--- a/prompts/workflow-prompts/impl-repair-claude.md
+++ b/prompts/workflow-prompts/impl-repair-claude.md
@@ -53,7 +53,7 @@ Adjust the canvas-controlling knobs of the relevant library family:
 ## Step 3: Read current implementation
 
 `plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}{EXT}` — `{EXT}` is `.py`
-for python libraries and `.R` for ggplot2.
+for python libraries, `.R` for ggplot2, and `.jl` for makie.
 
 **Do NOT read sibling-library implementations under
 `plots/{SPEC_ID}/implementations/`** (other libraries' source or `.yaml`).
@@ -86,6 +86,13 @@ ANYPLOT_THEME=light Rscript {LIBRARY}.R
 ANYPLOT_THEME=dark  Rscript {LIBRARY}.R
 ```
 
+**Julia (`LANGUAGE=julia`)**:
+```bash
+cd plots/{SPEC_ID}/implementations/{LANGUAGE}
+ANYPLOT_THEME=light julia --project=. {LIBRARY}.jl
+ANYPLOT_THEME=dark  julia --project=. {LIBRARY}.jl
+```
+
 Both renders must succeed.
 
 ## Step 6: Visual self-check
@@ -103,6 +110,10 @@ ruff check --fix plots/{SPEC_ID}/implementations/{LANGUAGE}/{LIBRARY}.py
 
 **R (`LANGUAGE=r`)**: no formatter is required by CI. Keep idiomatic ggplot2
 style (4-space indent, `<-` for assignment).
+
+**Julia (`LANGUAGE=julia`)**: no formatter is required by CI. Keep idiomatic
+Julia style (4-space indent, `lowercase_with_underscores` variables / functions,
+`CamelCase` types/modules).
 
 ## Step 8: Commit and push
 

--- a/prompts/workflow-prompts/impl-similarity-claude.md
+++ b/prompts/workflow-prompts/impl-similarity-claude.md
@@ -48,7 +48,7 @@ If a candidate cluster's identical signal is *only* one of the mandated items ab
 
 ## Step 4: Inspect ambiguous clusters (optional)
 
-If the `image_description` blobs for a candidate cluster don't conclusively show copying — e.g. you can't tell whether two libraries used the same random seed, or whether their domain is genuinely the same — you MAY use the Read tool on `plots/{SPEC_ID}/implementations/{language}/{library}{ext}` for **only those libraries inside the candidate cluster** to verify. (`{language}` is `python` for the Python libraries and `r` for ggplot2; `{ext}` is `.py` or `.R` accordingly.)
+If the `image_description` blobs for a candidate cluster don't conclusively show copying — e.g. you can't tell whether two libraries used the same random seed, or whether their domain is genuinely the same — you MAY use the Read tool on `plots/{SPEC_ID}/implementations/{language}/{library}{ext}` for **only those libraries inside the candidate cluster** to verify. (`{language}` is `python` for the Python libraries, `r` for ggplot2, and `julia` for makie; `{ext}` is `.py`, `.R`, or `.jl` accordingly.)
 
 **Do not read sibling source files for libraries that are not in a candidate cluster.** That wastes tokens and is not what this audit is for.
 

--- a/tests/unit/core/test_constants.py
+++ b/tests/unit/core/test_constants.py
@@ -30,13 +30,14 @@ class TestSupportedLibraries:
     """Tests for SUPPORTED_LIBRARIES constant."""
 
     def test_contains_expected_libraries(self) -> None:
-        """Should contain exactly the expected catalog of library IDs (9 Python + ggplot2)."""
+        """Should contain exactly the expected catalog of library IDs (9 Python + ggplot2 + makie)."""
         expected = {
             "altair",
             "bokeh",
             "ggplot2",
             "highcharts",
             "letsplot",
+            "makie",
             "matplotlib",
             "plotly",
             "plotnine",
@@ -74,6 +75,11 @@ class TestLibrariesMetadata:
         """ggplot2 is the catalog's first non-Python entry."""
         ggplot2 = next(lib for lib in LIBRARIES_METADATA if lib["id"] == "ggplot2")
         assert ggplot2["language_id"] == "r"
+
+    def test_makie_is_julia_language(self) -> None:
+        """Makie is the catalog's first Julia entry (Phase 5)."""
+        makie = next(lib for lib in LIBRARIES_METADATA if lib["id"] == "makie")
+        assert makie["language_id"] == "julia"
 
 
 class TestInteractiveLibraries:
@@ -217,9 +223,9 @@ class TestIsInteractiveLibrary:
 class TestSupportedLanguages:
     """Tests for SUPPORTED_LANGUAGES + LANGUAGES_METADATA."""
 
-    def test_contains_python_and_r(self) -> None:
-        """Catalog currently supports Python and R."""
-        assert SUPPORTED_LANGUAGES == {"python", "r"}
+    def test_contains_python_r_and_julia(self) -> None:
+        """Catalog currently supports Python, R, and Julia."""
+        assert SUPPORTED_LANGUAGES == {"python", "r", "julia"}
 
     def test_metadata_ids_match_supported(self) -> None:
         """Every LANGUAGES_METADATA entry must appear in SUPPORTED_LANGUAGES."""
@@ -236,6 +242,7 @@ class TestSupportedLanguages:
         """LANGUAGE_FILE_EXTENSIONS exposes the same data as a mapping."""
         assert LANGUAGE_FILE_EXTENSIONS["python"] == ".py"
         assert LANGUAGE_FILE_EXTENSIONS["r"] == ".R"
+        assert LANGUAGE_FILE_EXTENSIONS["julia"] == ".jl"
 
     def test_every_library_references_known_language(self) -> None:
         """No library may point at a language we don't list in LANGUAGES_METADATA."""


### PR DESCRIPTION
Closes #7612.

Adds **Julia** as anyplot's third language with **Makie.jl** (CairoMakie backend) as its first library entry. Generalizes the multi-language plumbing introduced for R/ggplot2 in #6944 + follow-ups (#6947, #6961, #7066) so every `python | r` dispatch now handles `python | r | julia` uniformly.

## Phase ordering — heads-up

This ships **Phase 5 (Julia) before Phases 1+2 (JavaScript family)**, which the issue called out explicitly. The multi-language pipeline is already proven on R; shipping Julia next provides a cheap second non-Python validation that surfaces multi-language gaps the JS work would otherwise hit cold. The JavaScript phases remain planned in unchanged order. See `docs/concepts/library-expansion.md` §9.

## Why Makie over Plots.jl

Distinct scientific stack (not a wrapper), ~45 % share within Julia, MIT-licensed. CairoMakie is the right backend for CI — pure-Cairo, headless, no GPU / GLFW window. `PlotlyJS.jl` is a plotly.js wrapper (already covered via Python Plotly). Plots.jl is the alternative; revisit only if Plausible data flips. `GLMakie` / `WGLMakie` interactive backends are out of scope; `INTERACTIVE_LIBRARIES` intentionally excludes Makie.

## What's in the PR

### Constants + registry

- `core/constants.py`: add `julia` language, `makie` library
- `tests/unit/core/test_constants.py`: assert `julia` + `makie`

### CI runtime

- `.github/actions/setup-julia/action.yml`: install Julia 1.11, restore from `Project.toml` / `Manifest.toml`, smoke-test a CairoMakie render
- `Project.toml`: pin CairoMakie + Makie + dataset packages (CSV, Colors, ColorSchemes, DataFrames, PalmerPenguins, RDatasets, Random, Statistics)

**`Manifest.toml` is intentionally not committed** — it gets resolved by the first CI run; the action falls back to `Pkg.add(...)` when `Manifest.toml` is absent so first-run doesn't hard-fail. (Same model as `renv.lock` had pre-bump on the R rollout.)

### Workflows

Each workflow derives `LANGUAGE` + `EXT` from `LIBRARY` via a case statement. Every case now has `matplotlib→python`, `ggplot2→r`, `makie→julia`:

- `impl-generate.yml`, `impl-repair.yml`, `impl-review.yml`, `impl-merge.yml`: add the `makie→julia` arm; install `setup-julia` when `language==julia`; detect Julia version via `julia -e 'print(VERSION)'`; detect Makie version via `Pkg.dependencies()`
- `impl-review.yml`:
  - extend canvas-gate library-cause map with a Makie entry (`Figure(resolution=(1600,900)) + px_per_unit=2` → 3200×1800; `resolution=(1200,1200)` → 2400×2400)
  - extend header-rewrite step to handle `#`-prefixed Julia comment blocks, with prepend fallback when missing (same fix as #6947 did for Python / R)
- `bulk-generate.yml`: add `makie` to `library` choices and `ALL_LIBRARIES`
- `impl-merge.yml`: completion total now derives from the actual library list rather than hardcoding 9

### Prompts

- **`prompts/library/makie.md`** (new): no-workarounds policy, NOT_FEASIBLE for primary-interactivity specs, canvas hard rule, `ANYPLOT_THEME` mapping, forbidden patterns (no `Plots.jl`, no `display(fig)`, no `GLMakie`/`WGLMakie`), `# `-comment header style
- `plot-generator.md`: extend lead, available environment, forbidden patterns with Julia/Makie section
- `quality-evaluator.md`, `workflow-prompts/ai-quality-review.md`: extend the AR-08 static-libraries list with `makie`; extend the language allow-list with `julia`
- `workflow-prompts/impl-generate-claude.md`, `impl-repair-claude.md`: add the `julia | .jl | julia --project=.` row to the (language, ext, runner) table; add Julia run + format sections
- `workflow-prompts/impl-similarity-claude.md`: third arm for `julia` in the `{language}` mapping

### Frontend (avoids the two-follow-up-PR pattern from #6961 / #7066)

- `app/src/constants/index.ts`: add `makie` to `LIBRARIES`, `LIB_ABBREV: 'mk'`, `LIB_TO_LANG: 'julia'`, `LANG_DISPLAY: 'Julia'`, `LANG_EXT: 'jl'`
- `app/src/components/CodeHighlighter.tsx`: register `julia` Prism grammar
- `app/src/types/react-syntax-highlighter.d.ts`: declare the `prism/julia` module locally — **TS7016 fix in same PR, not deferred** (the issue specifically called this out as a gap not to repeat)
- `app/src/components/LibraryCard.tsx`: description for makie
- `app/src/components/PlotOfTheDay.tsx`, `PlotOfTheDayTerminal.tsx`: `julia --project=.` runner token + `.jl` extension when language is julia
- `app/src/pages/LibrariesPage.tsx`, `AboutPage.tsx`, `PlotsPage.tsx`: meta-description copy bumped to "Eleven libraries across Python, R, and Julia"
- `app/src/pages/DebugPage.tsx`: `makie` column in `SpecStatus` interface (the grid template uses `LIBRARIES.length` so the matrix grows automatically)

### Backend

- `api/routers/debug.py`: `SpecStatusItem` and `library_names` entries for makie
- `api/routers/specs.py`: doc comment updated to note `makie is Julia`

### Tests

- `app/src/components/CodeHighlighter.test.tsx`: julia-grammar case
- `app/src/hooks/useCodeFetch.test.ts`: julia `?language=` case + three-language cache-key test
- `app/src/pages/DebugPage.test.tsx`: `makie` field on fixture

### Docs

- `docs/concepts/library-expansion.md`: §1 current-state table grows to 11 entries; §8 Phase 5 marked **shipped**; §9 records the phase-skip rationale, Makie-over-Plots.jl decision, and CairoMakie-only scope
- `docs/reference/repository.md`: `implementations/` layout shows `python/` + `r/` + `julia/` siblings
- `docs/concepts/vision.md`, `docs/reference/style-guide.md`: pipeline-story copy ("eleven libraries in three languages")
- `docs/reference/plausible.md`: language slug list now includes `julia`
- `prompts/README.md`, `agentic/docs/project-guide.md`: Makie added

## Verified

- ✅ `core/constants.py` loads: `len(SUPPORTED_LIBRARIES)=11`, `SUPPORTED_LANGUAGES={'python','r','julia'}`
- ✅ `pytest tests/unit/core tests/unit/api/test_routers.py tests/unit/api/test_debug.py tests/unit/api/test_schemas.py` — **213 passed**, no regressions
- ✅ `Project.toml` valid TOML, deps load
- Frontend tests are wired but I couldn't run `yarn test` in this environment (no node_modules). Code follows the existing patterns from the R rollout.

## Post-merge follow-ups (called out in the issue)

1. Run `uv run python -m automation.scripts.label_manager sync` once so `library:makie`, `generate:makie`, `impl:makie:{pending,done,failed}` labels appear.
2. First CI run of `setup-julia` will resolve `Manifest.toml` — commit that lockfile in a tiny follow-up so subsequent runs use `Pkg.instantiate()` instead of the `Pkg.add` fallback.
3. Trigger `bulk-generate.yml -f library=makie` to fill the catalog (separate from this infra PR — the issue called this out as "Out of scope" / handled by the regular flow).
4. Optional `julia.anyplot.ai` marketing subdomain (mentioned in the issue's "Out of scope" section; small follow-up modeled on `python.anyplot.ai`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AzjPDEE5aY2LYR5tcK3faj)_