### PR TITLE
fix(julia): drop name/uuid from Project.toml to make it environment-only

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,9 @@
-name = "anyplot"
-uuid = "5f9c7e1d-8b3d-4c1a-9f6e-1a2b3c4d5e6f"
-authors = ["anyplot contributors"]
-version = "0.1.0"
-
 # Julia runtime stack for the CairoMakie implementations.
+#
+# This is an *environment-only* project — no `name`/`uuid`/`version`. anyplot
+# is not a Julia package; it just consumes packages. Adding `name`/`uuid`
+# would make Julia try to precompile `anyplot` itself and fail because no
+# `src/anyplot.jl` exists.
 #
 # Reproducibility model — sibling of `renv.lock` for R:
 # - Project.toml lists the packages we depend on (this file).


### PR DESCRIPTION
## Summary

- First impl-generate run for `makie/skewt-logp-atmospheric` ([run 26311670534](https://github.com/MarkusNeusinger/anyplot/actions/runs/26311670534)) failed at the **Setup Julia + Makie** step. All 311 transitive deps precompiled cleanly, then Julia tried to precompile the project itself and bailed:
  ```
  ERROR: The following 1 direct dependency failed to precompile: anyplot
  Error: Missing source file for Base.PkgId(UUID("5f9c7e1d-…"), "anyplot")
  ```
- Root cause: `Project.toml` declared `name = "anyplot"` + `uuid = …` + `version = …`, which makes Julia treat the repo as a *package* and look for `src/anyplot.jl`. anyplot isn't a Julia package; it just consumes packages.
- Fix: remove `name`/`uuid`/`authors`/`version`. Turns `Project.toml` into an *environment-only* project (the standard pattern used by Julia's own docs/benchmark environments). `[deps]` and `[compat]` stay untouched, so dep resolution and reproducibility are unchanged.

This was hidden during PR #7613 because the `Setup Julia + Makie` action's smoke test only runs `using CairoMakie` and `save(...)` — Julia only attempts to precompile the active project itself when there are dependents being added to it, which happened on the first real impl-generate run.

## Test plan

- [ ] CI green
- [ ] After merge: re-trigger `gh workflow run impl-generate.yml -f specification_id=skewt-logp-atmospheric -f library=makie -f issue_number=3802` and verify `Setup Julia + Makie` completes past precompile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)