### PR TITLE
fix(impl-merge): clean up stale impl:LIB:failed label on successful merge

### DIFF
--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -297,10 +297,12 @@ jobs:
           # attempt errors out (e.g. environment setup failure); a later successful
           # retry merges via this workflow but historically didn't clean up :failed,
           # leaving the issue with both :done and :failed for the same library.
-          gh issue edit "$ISSUE" --remove-label "generate:${LIBRARY}" 2>/dev/null || true
-          gh issue edit "$ISSUE" --remove-label "impl:${LIBRARY}:pending" 2>/dev/null || true
-          gh issue edit "$ISSUE" --remove-label "impl:${LIBRARY}:failed" 2>/dev/null || true
-          gh issue edit "$ISSUE" --add-label "impl:${LIBRARY}:done"
+          # Single API call (comma-separated) — matches the pattern in
+          # impl-generate.yml and avoids the partial-update window of separate edits.
+          gh issue edit "$ISSUE" \
+            --remove-label "generate:${LIBRARY},impl:${LIBRARY}:pending,impl:${LIBRARY}:failed" \
+            --add-label "impl:${LIBRARY}:done" 2>/dev/null || \
+            gh issue edit "$ISSUE" --add-label "impl:${LIBRARY}:done"
 
       - name: Post success to issue
         if: steps.check.outputs.should_run == 'true' && steps.issue.outputs.number != ''

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -292,9 +292,14 @@ jobs:
           # Create labels if they don't exist
           gh label create "impl:${LIBRARY}:done" --color "0e8a16" --description "${LIBRARY} implementation merged" 2>/dev/null || true
 
-          # Remove trigger and pending, add done
+          # Remove trigger, pending, and any stale failed label from earlier attempts,
+          # then add done. The :failed label is added by impl-generate.yml when an
+          # attempt errors out (e.g. environment setup failure); a later successful
+          # retry merges via this workflow but historically didn't clean up :failed,
+          # leaving the issue with both :done and :failed for the same library.
           gh issue edit "$ISSUE" --remove-label "generate:${LIBRARY}" 2>/dev/null || true
           gh issue edit "$ISSUE" --remove-label "impl:${LIBRARY}:pending" 2>/dev/null || true
+          gh issue edit "$ISSUE" --remove-label "impl:${LIBRARY}:failed" 2>/dev/null || true
           gh issue edit "$ISSUE" --add-label "impl:${LIBRARY}:done"
 
       - name: Post success to issue


### PR DESCRIPTION
## Summary

- When impl-generate fails (e.g. environment setup error), it tags the parent issue with `impl:LIB:failed`.
- A subsequent successful retry merges via impl-merge.yml, but only removed `:pending` — leaving the stale `:failed` label.
- Add `--remove-label "impl:${LIBRARY}:failed"` to the canonical merge-time label sweep.

## Observed on #3802 (skewt-logp-atmospheric/makie)

First impl-generate attempt failed during *Setup Julia + Makie* (Project.toml declared the repo as a Julia package). PR #7614 fixed Project.toml; retry succeeded and PR #7615 merged via impl-merge.yml — but the issue closed with both `impl:makie:done` and `impl:makie:failed` for the same library. The stale label has been cleaned up on #3802 manually.

## Why this matters even though counts didn't break

The close-issue counting in impl-merge.yml uses `if/elif`, so `:done` wins and totals stayed correct here. But the labels themselves are a contract other readers consume — `sync_to_postgres.py`, the UI, future workflows. Better to keep the source of truth honest.

## Test plan

- [ ] CI passes
- [ ] Next impl-generate retry-after-failure run produces an issue with only `:done`, no stale `:failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)