### PR TITLE
fix(lint): remove duplicate matplotlib.py per-file-ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,6 @@ ignore = [
 "plots/*/implementations/python/altair.py" = ["E402"]
 "plots/*/implementations/python/plotnine.py" = ["E402"]
 "plots/*/implementations/python/bokeh.py" = ["E402"]
-"plots/*/implementations/python/matplotlib.py" = ["E402"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- PR #7619 (matplotlib map-projections) accidentally added a second `matplotlib.py` entry to `[tool.ruff.lint.per-file-ignores]` while the original was still on line 151.
- TOML parser rejects this as a redefined key, so both **CI: Lint and Format Check** and **Sync: PostgreSQL** have been red on `main` since the merge.
- Drop the duplicate. The remaining single entry preserves the E402 ignore.

## Test plan
- [x] `python -c "import tomllib; tomllib.loads(open('pyproject.toml').read())"` passes locally
- [ ] CI lint check passes
- [ ] Postgres sync workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)