### PR TITLE
feat(watchdog): cover ai-approved / ai-rejected / no-label stuck PRs

### DIFF
--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -146,6 +146,62 @@ jobs:
                 -f attempt="$attempt"
               continue
             fi
+
+            # Case 3: ai-approved but never merged — impl-merge `pull_request: labeled`
+            #   event was lost. Re-dispatch impl-merge.yml manually.
+            if echo " $labels " | grep -q " ai-approved " \
+               && (( age > STALE_SEC )); then
+              marker="watchdog:merge-rescued"
+              if echo " $labels " | grep -q " $marker "; then
+                echo "::warning::PR #$num: ai-approved merge already rescued — needs manual attention"
+                continue
+              fi
+              ensure_label "$marker" "5319e7" "Watchdog re-dispatched impl-merge once"
+              if [[ "$DRY_RUN" != "true" ]]; then
+                gh pr edit "$num" --add-label "$marker" 2>/dev/null || true
+              fi
+              dispatch "PR #$num: merge (ai-approved stuck)" impl-merge.yml \
+                -f pr_number="$num"
+              continue
+            fi
+
+            # Case 4: ai-rejected but no ai-attempt-N label — impl-repair `labeled`
+            #   trigger inside impl-review.yml never fired. Re-dispatch attempt 1.
+            if echo " $labels " | grep -q " ai-rejected " \
+               && ! echo " $labels " | grep -qE " ai-attempt-[0-9]+ " \
+               && (( age > STALE_SEC )); then
+              marker="watchdog:repair-rescued-1"
+              if echo " $labels " | grep -q " $marker "; then
+                echo "::warning::PR #$num: ai-rejected initial-repair already rescued — needs manual attention"
+                continue
+              fi
+              ensure_label "$marker" "5319e7" "Watchdog re-dispatched repair attempt 1"
+              if [[ "$DRY_RUN" != "true" ]]; then
+                gh pr edit "$num" --add-label "$marker" 2>/dev/null || true
+              fi
+              dispatch "PR #$num: repair (initial, ai-rejected, no attempt label)" impl-repair.yml \
+                -f pr_number="$num" \
+                -f specification_id="$spec_id" \
+                -f library="$library" \
+                -f attempt="1"
+              continue
+            fi
+
+            # Case 5: implementation PR has NO labels at all — impl-review never started.
+            #   Happens when impl-generate.yml's repository_dispatch to impl-review didn't land.
+            if [[ -z "$labels" ]] && (( age > STALE_SEC )); then
+              marker="watchdog:review-bootstrap"
+              # No existing labels to check against marker — use PR comments instead?
+              # Simpler: just dispatch review. If review fails repeatedly, normal
+              # ai-review-failed flow (Case 1) takes over after that.
+              ensure_label "$marker" "5319e7" "Watchdog bootstrapped initial review"
+              if [[ "$DRY_RUN" != "true" ]]; then
+                gh pr edit "$num" --add-label "$marker" 2>/dev/null || true
+              fi
+              dispatch "PR #$num: review (never started, no labels)" impl-review.yml \
+                -f pr_number="$num"
+              continue
+            fi
           done < <(echo "$PRS_JSON" | jq -c '.[]')
 
           ##### B) Scan spec-ready issues for stuck generation ###############

--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -187,13 +187,22 @@ jobs:
               continue
             fi
 
-            # Case 5: implementation PR has NO labels at all — impl-review never started.
-            #   Happens when impl-generate.yml's repository_dispatch to impl-review didn't land.
-            if [[ -z "$labels" ]] && (( age > STALE_SEC )); then
+            # Case 5: implementation PR with only watchdog:* markers (or none) —
+            #   impl-review never started. Happens when impl-generate.yml's
+            #   repository_dispatch to impl-review didn't land.
+            #
+            #   We treat "labels are exactly watchdog:* markers, no review/repair
+            #   labels" as the same situation as "no labels at all" — without
+            #   that, our own previously-added marker would hide the PR from
+            #   detection. To keep the one-shot semantics ("rescue once, then
+            #   warn"), we check the marker explicitly.
+            non_marker_labels=$(echo " $labels " | tr ' ' '\n' | grep -v '^$' | grep -vE '^watchdog:' || true)
+            if [[ -z "$non_marker_labels" ]] && (( age > STALE_SEC )); then
               marker="watchdog:review-bootstrap"
-              # No existing labels to check against marker — use PR comments instead?
-              # Simpler: just dispatch review. If review fails repeatedly, normal
-              # ai-review-failed flow (Case 1) takes over after that.
+              if echo " $labels " | grep -q " $marker "; then
+                echo "::warning::PR #$num: review never started even after watchdog bootstrap — needs manual attention"
+                continue
+              fi
               ensure_label "$marker" "5319e7" "Watchdog bootstrapped initial review"
               if [[ "$DRY_RUN" != "true" ]]; then
                 gh pr edit "$num" --add-label "$marker" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Today we manually un-stuck ~18 PRs across the 6 regen waves because the watchdog only covered 2 of 4 failure modes that GitHub's `pull_request: labeled` event listener can drop.
- This adds the 3 missing cases so we don't have to do that by hand next time.

## Cases added

3. **`ai-approved` older than `STALE_HOURS`** → re-dispatch `impl-merge.yml` (e.g. today's #7625, #7644, #7636).
4. **`ai-rejected` with no `ai-attempt-N`** → re-dispatch `impl-repair.yml` with `attempt=1` (e.g. today's #7621, #7648).
5. **Implementation PR with no labels at all** → re-dispatch `impl-review.yml` (review never bootstrapped — e.g. today's #7654, #7677, #7663, #7647, #7658, #7635).

Each case uses a one-shot `watchdog:*-rescued` marker so a second miss flips the PR to "needs manual attention" rather than looping.

## Test plan
- [x] YAML validates (`python -c "import yaml; yaml.safe_load(...)"`)
- [ ] Manually trigger watchdog after merge — dry-run mode should list any currently-stuck PRs matching the new cases
- [ ] Wait for next 6h cron cycle to confirm no false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)