### PR TITLE
fix(palette): lazy matplotlib import — unbreaks ggplot2 + makie impl-generate

### DIFF
--- a/core/palette.py
+++ b/core/palette.py
@@ -32,8 +32,14 @@ Layout
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
-from matplotlib.colors import LinearSegmentedColormap
+
+# matplotlib is a heavy optional dep — import lazily inside the cmap helpers so
+# that callers who only need the hex constants (core/images.py, R/Julia helper
+# scripts, etc.) don't pay for it. Type-check imports still get the real type.
+if TYPE_CHECKING:
+    from matplotlib.colors import LinearSegmentedColormap
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -137,9 +143,10 @@ palette = SimpleNamespace(
 # Sequential + diverging cmaps
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Sequential: brand-green → blue. Endpoints picked so the warm end is the
-# brand identity and the cool end is the deepest blue in the palette.
-imprint_seq: LinearSegmentedColormap = LinearSegmentedColormap.from_list("imprint_seq", [GREEN, BLUE])
+# Sequential + diverging cmaps. Constructed lazily on attribute access via
+# ``__getattr__`` below — keeps ``import core.palette`` matplotlib-free for
+# callers that only need the hex constants. Public names preserved:
+#   core.palette.imprint_seq, .imprint_div_light, .imprint_div_dark
 
 
 def diverging(theme: str = "light") -> LinearSegmentedColormap:
@@ -154,12 +161,30 @@ def diverging(theme: str = "light") -> LinearSegmentedColormap:
         On light bg, midpoint = warm cream #FAF8F1; on dark bg, midpoint
         = warm near-black #1A1A17.
     """
+    from matplotlib.colors import LinearSegmentedColormap
+
     midpoint = "#FAF8F1" if theme == "light" else "#1A1A17"
     return LinearSegmentedColormap.from_list(f"imprint_div_{theme}", [RED, midpoint, BLUE])
 
 
-imprint_div_light: LinearSegmentedColormap = diverging("light")
-imprint_div_dark: LinearSegmentedColormap = diverging("dark")
+def __getattr__(name: str):
+    # Lazy-construct the cmap module attributes on first access so importing
+    # this module does not require matplotlib.
+    if name == "imprint_seq":
+        from matplotlib.colors import LinearSegmentedColormap
+
+        cm = LinearSegmentedColormap.from_list("imprint_seq", [GREEN, BLUE])
+        globals()[name] = cm
+        return cm
+    if name == "imprint_div_light":
+        cm = diverging("light")
+        globals()[name] = cm
+        return cm
+    if name == "imprint_div_dark":
+        cm = diverging("dark")
+        globals()[name] = cm
+        return cm
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -172,9 +197,14 @@ def register_with_matplotlib() -> None:
 
     Idempotent — re-registering an existing cmap is silently skipped.
     """
+    # Resolve via module globals so the lazy ``__getattr__`` builds each cmap
+    # on first access (avoids a top-level matplotlib import here too).
+    import sys
+
     import matplotlib
 
-    for cm in (imprint_seq, imprint_div_light, imprint_div_dark):
+    mod = sys.modules[__name__]
+    for cm in (mod.imprint_seq, mod.imprint_div_light, mod.imprint_div_dark):
         try:
             matplotlib.colormaps.register(cm)
         except ValueError:
@@ -202,10 +232,11 @@ __all__ = [
     "muted_for",
     # named API
     "palette",
-    # cmaps
-    "imprint_seq",
-    "imprint_div_light",
-    "imprint_div_dark",
+    # cmaps — resolved lazily via module __getattr__ (avoids module-level
+    # matplotlib import; see explanation at top of file)
+    "imprint_seq",  # noqa: F822
+    "imprint_div_light",  # noqa: F822
+    "imprint_div_dark",  # noqa: F822
     "diverging",
     # mpl integration
     "register_with_matplotlib",

--- a/core/palette.py
+++ b/core/palette.py
@@ -167,9 +167,11 @@ def diverging(theme: str = "light") -> LinearSegmentedColormap:
     return LinearSegmentedColormap.from_list(f"imprint_div_{theme}", [RED, midpoint, BLUE])
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> LinearSegmentedColormap:
     # Lazy-construct the cmap module attributes on first access so importing
-    # this module does not require matplotlib.
+    # this module does not require matplotlib. The return annotation is a
+    # forward reference under `from __future__ import annotations`, so it
+    # does not trigger a runtime matplotlib import.
     if name == "imprint_seq":
         from matplotlib.colors import LinearSegmentedColormap
 


### PR DESCRIPTION
## Summary

- Fixes a regression from #7692 where `import core.images` started transitively requiring matplotlib via `core.palette`'s module-level `from matplotlib.colors import LinearSegmentedColormap`.
- That broke the `Process plot images (light + dark)` step in `impl-generate.yml` for **non-Python** libraries (ggplot2 / makie), where the runner only installs PIL helpers — not matplotlib. raincloud-basic R and Julia auto-failed 3× with `ModuleNotFoundError: No module named 'matplotlib'`.
- Keeps `core/palette.py` matplotlib-free at module level. Cmap factory (`diverging`) and `imprint_seq` / `imprint_div_{light,dark}` are constructed lazily on first attribute access via module `__getattr__`.

## Why this is the right layering

`core/images.py` is documented as PIL-only — the whole point of the reviewer feedback on #7692 was that importing it must not pull matplotlib in as a side effect. R/Julia plot scripts hardcode hex codes; they don't need matplotlib for rendering. But the workflow calls `python -m core.images process plot.png` afterwards to optimise the rendered PNG with PIL — and that's where the missing matplotlib bites.

## Public API preserved

- `from core.palette import imprint_seq` ✅ (lazy)
- `core.palette.imprint_seq.name == "imprint_seq"` ✅
- `register_with_matplotlib()` still registers all three cmaps ✅
- Re-import in same process still cached after first build ✅

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] Local smoke test: hex constants + lazy cmaps + register_with_matplotlib
- [x] Local smoke test simulating no-matplotlib env: `import core.images` succeeds, `LIBRARY_COLORS` populated
- [ ] CI green
- [ ] Re-trigger raincloud-basic ggplot2 + makie after merge — confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)