### PR TITLE
chore(daily-regen): halve cadence to 10× daily

### DIFF
--- a/.github/workflows/daily-regen.yml
+++ b/.github/workflows/daily-regen.yml
@@ -13,12 +13,12 @@ run-name: "Scheduled regen (${{ github.event.inputs.specification_id || github.e
 # Sonnet for higher implementation quality; can be overridden per manual run.
 #
 # Triggers:
-#   - schedule: 20× daily (UTC, every hour except 18:00–21:00 UTC) → Sonnet
+#   - schedule: 10× daily (UTC, every 2 hours, skipping the 18–21 UTC window) → Sonnet
 #   - workflow_dispatch: manual, with inputs for spec id, model, count, dry-run
 
 on:
   schedule:
-    - cron: '0 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,22,23 * * *'
+    - cron: '0 0,2,4,6,8,10,12,14,16,22 * * *'
   workflow_dispatch:
     inputs:
       specification_id:


### PR DESCRIPTION
## Summary

- Halves the `daily-regen.yml` cron from 20× daily to 10× daily.
- New schedule: every 2 h on `0,2,4,6,8,10,12,14,16,22 UTC` — preserves the existing 18–21 UTC quiet block.
- No model change (still Sonnet by default; opus/haiku still available via `workflow_dispatch`).

## Note on workflow state

The workflow is currently **`disabled_manually`** in GitHub Actions (no schedule fire since 2026-05-23). This PR only changes the schedule definition. To resume firing on the new cadence, re-enable with:

```
gh workflow enable daily-regen.yml
```

## Test plan

- [x] cron pattern hand-validated: 10 entries, skips 18–21 UTC
- [ ] After merge + enable, observe the first scheduled fire lands on a `0,2,4,...,22` hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)