### PR TITLE
chore(palette): fix semantic anchors for 12 matplotlib impls

### DIFF
--- a/plots/bar-diverging/implementations/python/matplotlib.py
+++ b/plots/bar-diverging/implementations/python/matplotlib.py
@@ -42,9 +42,8 @@ sorted_indices = np.argsort(values)
 categories_sorted = [categories[i] for i in sorted_indices]
 values_sorted = values[sorted_indices]
 
-# Create colors using Okabe-Ito palette
-# #009E73 (position 1) for positive, #C475FD (position 2) for negative
-colors = ["#009E73" if v >= 0 else "#C475FD" for v in values_sorted]
+# imprint semantic anchors: green for positive, red for negative
+colors = ["#009E73" if v >= 0 else "#AE3030" for v in values_sorted]
 
 # Plot
 fig, ax = plt.subplots(figsize=(16, 9), facecolor=PAGE_BG)
@@ -87,7 +86,7 @@ ax.spines["bottom"].set_color(INK_SOFT)
 # Add legend
 legend_elements = [
     Patch(facecolor="#009E73", edgecolor=INK_SOFT, label="Positive (Satisfied)"),
-    Patch(facecolor="#C475FD", edgecolor=INK_SOFT, label="Negative (Dissatisfied)"),
+    Patch(facecolor="#AE3030", edgecolor=INK_SOFT, label="Negative (Dissatisfied)"),
 ]
 leg = ax.legend(handles=legend_elements, loc="lower right", fontsize=16)
 if leg:

--- a/plots/candlestick-volume/implementations/python/matplotlib.py
+++ b/plots/candlestick-volume/implementations/python/matplotlib.py
@@ -20,9 +20,9 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette
-UP_COLOR = "#009E73"  # Brand green (up days)
-DOWN_COLOR = "#C475FD"  # Vermillion (down days)
+# imprint semantic anchors
+UP_COLOR = "#009E73"  # green — up days
+DOWN_COLOR = "#AE3030"  # red — down days
 
 # Data - Generate realistic 60 trading days of OHLC data with volume
 np.random.seed(42)

--- a/plots/dashboard-metrics-tiles/implementations/python/matplotlib.py
+++ b/plots/dashboard-metrics-tiles/implementations/python/matplotlib.py
@@ -17,8 +17,8 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Status colors — semantic alarm indicators using Okabe-Ito positions 1, 5, 2
-STATUS_COLORS = {"good": "#009E73", "warning": "#AE3030", "critical": "#C475FD"}
+# Status colors — imprint semantic anchors (green / amber / red)
+STATUS_COLORS = {"good": "#009E73", "warning": "#DDCC77", "critical": "#AE3030"}
 STATUS_LABELS = {"good": "GOOD", "warning": "WARNING", "critical": "CRITICAL"}
 
 # Data

--- a/plots/gauge-basic/implementations/python/matplotlib.py
+++ b/plots/gauge-basic/implementations/python/matplotlib.py
@@ -19,10 +19,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-# Okabe-Ito zone colors (colorblind-safe red/yellow/green)
-ZONE_BAD = "#C475FD"  # vermillion
-ZONE_WARN = "#AE3030"  # orange
-ZONE_GOOD = "#009E73"  # bluish green (brand)
+# imprint semantic anchors (red / amber / green traffic-light)
+ZONE_BAD = "#AE3030"  # matte red — semantic bad
+ZONE_WARN = "#DDCC77"  # amber — semantic warning
+ZONE_GOOD = "#009E73"  # brand green — semantic good
 
 # Data
 value = 72  # Current sales value

--- a/plots/horizon-basic/implementations/python/matplotlib.py
+++ b/plots/horizon-basic/implementations/python/matplotlib.py
@@ -45,8 +45,8 @@ n_bands = 3
 band_height = 1.0
 
 # Color bases with theme-adaptive styling
-pos_base = mcolors.to_rgb("#009E73")  # Okabe-Ito brand green for positive
-neg_base = mcolors.to_rgb("#C475FD")  # Okabe-Ito vermillion for negative
+pos_base = mcolors.to_rgb("#009E73")  # imprint green — positive
+neg_base = mcolors.to_rgb("#AE3030")  # imprint red — negative
 
 # Create figure
 fig, axes = plt.subplots(n_series, 1, figsize=(16, 9), sharex=True, facecolor=PAGE_BG)

--- a/plots/indicator-ema/implementations/python/matplotlib.py
+++ b/plots/indicator-ema/implementations/python/matplotlib.py
@@ -20,11 +20,11 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-# Okabe-Ito colors for EMAs
-EMA_SHORT_COLOR = "#009E73"  # Okabe-Ito pos 1 — 12-day EMA
-EMA_LONG_COLOR = "#C475FD"  # Okabe-Ito pos 2 — 26-day EMA
-GOLDEN_COLOR = "#AE3030"  # Okabe-Ito pos 5 — bullish crossover
-DEATH_COLOR = "#BD8233"  # Okabe-Ito pos 4 — bearish crossover
+# imprint palette — categorical EMAs + semantic crossover markers
+EMA_SHORT_COLOR = "#4467A3"  # imprint blue — 12-day EMA
+EMA_LONG_COLOR = "#BD8233"  # imprint ochre — 26-day EMA
+GOLDEN_COLOR = "#009E73"  # green — bullish crossover (semantic)
+DEATH_COLOR = "#AE3030"  # red — bearish crossover (semantic)
 
 # Data
 np.random.seed(42)

--- a/plots/indicator-macd/implementations/python/matplotlib.py
+++ b/plots/indicator-macd/implementations/python/matplotlib.py
@@ -22,11 +22,11 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette
-MACD_COLOR = "#4467A3"  # Blue (position 3)
-SIGNAL_COLOR = "#AE3030"  # Orange (position 5)
-POSITIVE_COLOR = "#009E73"  # Green (position 1)
-NEGATIVE_COLOR = "#C475FD"  # Red-orange (position 2)
+# imprint palette
+MACD_COLOR = "#4467A3"  # blue — MACD line
+SIGNAL_COLOR = "#BD8233"  # ochre — signal line (categorical contrast with MACD blue)
+POSITIVE_COLOR = "#009E73"  # green — histogram bars above zero
+NEGATIVE_COLOR = "#AE3030"  # red — histogram bars below zero
 
 # Generate synthetic stock price data and calculate MACD
 np.random.seed(42)

--- a/plots/indicator-rsi/implementations/python/matplotlib.py
+++ b/plots/indicator-rsi/implementations/python/matplotlib.py
@@ -65,8 +65,8 @@ df = pd.DataFrame({"date": rsi_dates, "rsi": rsi})
 fig, ax = plt.subplots(figsize=(16, 9), facecolor=PAGE_BG)
 ax.set_facecolor(PAGE_BG)
 
-# Shade overbought zone (70-100)
-ax.fill_between(df["date"], 70, 100, alpha=0.12, color="#C475FD")
+# Shade overbought zone (70-100) — imprint red, semantic danger
+ax.fill_between(df["date"], 70, 100, alpha=0.12, color="#AE3030")
 
 # Shade oversold zone (0-30)
 ax.fill_between(df["date"], 0, 30, alpha=0.12, color="#4467A3")

--- a/plots/kagi-basic/implementations/python/matplotlib.py
+++ b/plots/kagi-basic/implementations/python/matplotlib.py
@@ -20,8 +20,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Data colors (Okabe-Ito palette, theme-independent)
-COLOR_YANG = "#009E73"  # Okabe-Ito position 1 (green for bullish)
-COLOR_YIN = "#C475FD"  # Okabe-Ito position 2 (red for bearish)
+COLOR_YANG = "#009E73"  # imprint green — bullish
+COLOR_YIN = "#AE3030"  # imprint red — bearish
 
 # Generate synthetic stock price data
 np.random.seed(42)

--- a/plots/ohlc-bar/implementations/python/matplotlib.py
+++ b/plots/ohlc-bar/implementations/python/matplotlib.py
@@ -20,9 +20,9 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette
-COLOR_UP = "#009E73"  # Brand green for up bars
-COLOR_DOWN = "#C475FD"  # Vermillion for down bars
+# imprint semantic anchors
+COLOR_UP = "#009E73"  # green — up bars
+COLOR_DOWN = "#AE3030"  # red — down bars
 
 # Data - Generate 45 trading days of synthetic stock OHLC data
 np.random.seed(42)

--- a/plots/point-and-figure-basic/implementations/python/matplotlib.py
+++ b/plots/point-and-figure-basic/implementations/python/matplotlib.py
@@ -25,9 +25,9 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito: green for rising (X), vermillion for falling (O)
+# imprint semantic anchors: green for rising (X), red for falling (O)
 X_COLOR = "#009E73"
-O_COLOR = "#C475FD"
+O_COLOR = "#AE3030"
 
 # Data: synthetic stock price with upward drift
 np.random.seed(42)

--- a/plots/renko-basic/implementations/python/matplotlib.py
+++ b/plots/renko-basic/implementations/python/matplotlib.py
@@ -18,9 +18,9 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette
-BULLISH = "#009E73"  # Green for upward
-BEARISH = "#C475FD"  # Vermillion (reddish) for downward
+# imprint semantic anchors
+BULLISH = "#009E73"  # green — upward
+BEARISH = "#AE3030"  # red — downward
 
 # Generate synthetic price data
 np.random.seed(42)

--- a/plots/shap-waterfall/implementations/python/matplotlib.py
+++ b/plots/shap-waterfall/implementations/python/matplotlib.py
@@ -19,8 +19,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-# Semantic direction colors — Okabe-Ito positions 2 and 3
-COLOR_POS = "#C475FD"  # vermillion: positive SHAP (pushes prediction up)
+# Semantic direction colors — imprint diverging anchors
+COLOR_POS = "#AE3030"  # red: positive SHAP (pushes prediction up)
 COLOR_NEG = "#4467A3"  # blue: negative SHAP (pushes prediction down)
 
 # Data — credit loan approval model, individual applicant explanation

--- a/plots/slope-basic/implementations/python/matplotlib.py
+++ b/plots/slope-basic/implementations/python/matplotlib.py
@@ -18,8 +18,8 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-COLOR_INC = "#009E73"  # Okabe-Ito pos 1 — increase (brand green)
-COLOR_DEC = "#C475FD"  # Okabe-Ito pos 2 — decrease (vermillion)
+COLOR_INC = "#009E73"  # imprint green — increase
+COLOR_DEC = "#AE3030"  # imprint red — decrease
 
 # Data
 products = ["Product A", "Product B", "Product C", "Product D", "Product E", "Product F", "Product G", "Product H"]

--- a/plots/waterfall-basic/implementations/python/matplotlib.py
+++ b/plots/waterfall-basic/implementations/python/matplotlib.py
@@ -18,10 +18,10 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette for waterfall categories
-INCREASE_COLOR = "#009E73"  # Brand green (position 1)
-DECREASE_COLOR = "#C475FD"  # Vermillion (position 2)
-TOTAL_COLOR = "#4467A3"  # Blue (position 3)
+# imprint semantic anchors for waterfall categories
+INCREASE_COLOR = "#009E73"  # green — increase
+DECREASE_COLOR = "#AE3030"  # red — decrease
+TOTAL_COLOR = "#4467A3"  # blue — total/baseline
 
 # Data: Project Budget Allocation (from initial budget to final allocation)
 # Different scenario from the original (avoiding Altair match)

--- a/scripts/migrate_render_and_upload.py
+++ b/scripts/migrate_render_and_upload.py
@@ -10,8 +10,10 @@
 """Stage B of the imprint migration: re-render light+dark images locally and
 overwrite the GCS production bucket.
 
-For every (spec, language, library) listed in ``.migration-list.json`` (or
-discovered from a freshly-applied Stage A), this script:
+Targets are discovered from either git's working tree (``git diff --name-only HEAD``,
+the default — useful right after running Stage A) or from a specific commit
+(``--from-commit <sha>``, used after a squash-merge to re-render the files that
+just landed on ``main``). For every (spec, language, library) target, this script:
 
 1. Renders ``plot-light.png`` and ``plot-dark.png`` in ``.regen-preview/{library}/``
    by running the impl with ``ANYPLOT_THEME`` set to each theme.
@@ -155,6 +157,11 @@ def preflight(python_libs: set[str], needs_r: bool, needs_julia: bool, needs_sel
     if not gcloud_ok:
         notes.append("gcloud not authenticated → gcloud auth login")
 
+    gsutil_ok = _check_command(["gsutil", "version"])
+    if not gsutil_ok:
+        gcloud_ok = False
+        notes.append("gsutil not on PATH → install via 'gcloud components install gsutil'")
+
     return PreFlight(
         python_ok=python_ok,
         r_ok=r_ok,
@@ -288,17 +295,9 @@ def _key(spec: str, language: str, library: str) -> str:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _discover_targets_from_git(library_filter: str) -> list[tuple[str, str, str]]:
-    """Find (spec, language, library) from git's working tree — files modified vs HEAD."""
-    out = subprocess.run(
-        ["git", "diff", "--name-only", "HEAD"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+def _parse_changed_files(stdout: str, library_filter: str) -> list[tuple[str, str, str]]:
     targets: list[tuple[str, str, str]] = []
-    for line in out.stdout.splitlines():
+    for line in stdout.splitlines():
         # Expected: plots/{spec}/implementations/{language}/{library}.{ext}
         parts = line.split("/")
         if len(parts) != 5 or parts[0] != "plots" or parts[2] != "implementations":
@@ -312,6 +311,30 @@ def _discover_targets_from_git(library_filter: str) -> list[tuple[str, str, str]
             continue
         targets.append((spec, language, library))
     return targets
+
+
+def _discover_targets_from_git(library_filter: str) -> list[tuple[str, str, str]]:
+    """Find (spec, language, library) from git's working tree — files modified vs HEAD."""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return _parse_changed_files(out.stdout, library_filter)
+
+
+def _discover_targets_from_commit(commit: str, library_filter: str) -> list[tuple[str, str, str]]:
+    """Find (spec, language, library) from a specific commit's file list (squash-merge friendly)."""
+    out = subprocess.run(
+        ["git", "show", "--name-only", "--pretty=format:", commit],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return _parse_changed_files(out.stdout, library_filter)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -383,12 +406,20 @@ def process_one(spec: str, language: str, library: str, *, dry_run: bool, consol
     is_flag=True,
     help="Skip items already marked 'done' in .migration-progress.json.",
 )
-def main(library: str, spec: str | None, check_only: bool, dry_run: bool, skip_on_error: bool, resume: bool) -> None:
+@click.option(
+    "--from-commit",
+    default=None,
+    help="Discover targets from a specific commit (e.g. a squash-merge SHA) instead of the working tree.",
+)
+def main(library: str, spec: str | None, check_only: bool, dry_run: bool, skip_on_error: bool, resume: bool, from_commit: str | None) -> None:
     """Re-render and upload light/dark images for migrated impls."""
     console = Console()
 
     # Discover targets first so we know which langs to pre-flight.
-    targets = _discover_targets_from_git(library)
+    if from_commit:
+        targets = _discover_targets_from_commit(from_commit, library)
+    else:
+        targets = _discover_targets_from_git(library)
     if spec:
         targets = [t for t in targets if t[0] == spec]
 

--- a/scripts/migrate_to_imprint.py
+++ b/scripts/migrate_to_imprint.py
@@ -115,11 +115,12 @@ def _substitute(text: str) -> tuple[str, int]:
 def _rename_palette_constant(text: str) -> str:
     """Rename common old palette variable names to IMPRINT (Python, R, Julia).
 
-    Only renames identifiers that look like a standalone palette constant
-    (whole-word match, all-caps name). Conservative — does not touch
-    inline comments or string literals.
+    Whole-word ASCII boundary match. The regex is intentionally not
+    AST-aware, so occurrences of OKABE_ITO / ANYPLOT_PALETTE inside
+    comments or string literals are renamed too. That's fine for our
+    one-shot use case (the surrounding comments are about to become
+    stale anyway), but worth knowing for future reuse.
     """
-    # Whole-word, ASCII identifier boundary on both sides.
     for old in ("OKABE_ITO", "ANYPLOT_PALETTE"):
         text = re.sub(rf"\b{old}\b", "IMPRINT", text)
     return text


### PR DESCRIPTION
## Summary

Follow-up to #7776. The positional Okabe-Ito → imprint swap broke charts where the old hex carried **semantic** meaning (red = bad, green = good, amber = warning), not just categorical separation. Slot 1 became lavender, which silently turned "bearish" / "negative" / "critical" / "decrease" markers into purple.

Reaches for imprint **semantic anchors** (red `#AE3030`, amber `#DDCC77`, green `#009E73`) on the 12 matplotlib impls where the variable name or comment made the semantic intent explicit. Categorical, non-semantic uses of `#C475FD` (lavender) are left alone.

## Files touched

| File | Fix |
|---|---|
| gauge-basic | `ZONE_BAD` → red, `ZONE_WARN` → amber |
| dashboard-metrics-tiles | `STATUS_COLORS` warning → amber, critical → red |
| kagi-basic | `COLOR_YIN` (bearish) → red |
| point-and-figure-basic | `O_COLOR` (falling) → red |
| horizon-basic | `neg_base` (negative) → red |
| bar-diverging | negative bars + legend → red |
| renko-basic | `BEARISH` → red |
| slope-basic | `COLOR_DEC` → red |
| waterfall-basic | `DECREASE_COLOR` → red |
| shap-waterfall | `COLOR_POS` (positive SHAP) → red (against blue) |
| indicator-macd | `NEGATIVE_COLOR` → red; `SIGNAL` → ochre (re-establishes contrast vs the red NEGATIVE bars) |
| indicator-ema | `GOLDEN_COLOR` → green, `DEATH_COLOR` → red; short/long EMA → blue/ochre categorical |

Also addresses three nits on the helper scripts from the same review round:

- `migrate_to_imprint.py` — docstring for `_rename_palette_constant` no longer overstates the conservatism of the plain-regex rename
- `migrate_render_and_upload.py` — module docstring matches the actual target-discovery flow (working tree or `--from-commit`), drops a stale reference to a never-implemented `.migration-list.json`
- `migrate_render_and_upload.py` — pre-flight now also checks `gsutil version`, not just `gcloud auth list`

## What this PR doesn't do

Comment rot in the other ~125 untouched matplotlib impls (e.g. comments still saying "Okabe-Ito vermillion" next to imprint hex codes) is **deferred** — those refresh naturally on the next daily-regen cycle.

The image regeneration for **all** matplotlib impls (the 137 from #7776 + the 12 fixed here) hasn't run yet against GCS. That happens locally via `scripts/migrate_render_and_upload.py --from-commit <merge-sha> --library matplotlib` immediately after this PR merges.

## Test plan

- [x] `ruff check .` + `ruff format --check .` green (matches CI)
- [ ] CI green (lint + tests + frontend-tests)
- [ ] Copilot triage
- [ ] After merge: local Stage B for all 137+12 matplotlib impls → GCS production overwrite
- [ ] Spot-check gauge-basic, dashboard-metrics-tiles, kagi-basic on anyplot.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)