### PR TITLE
chore(scripts): savefig fallback + matplotlib add-on deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ plotting = [
     "scipy>=1.14.0",
     "scikit-learn>=1.6.0",
     "statsmodels>=0.14.0",
+    # matplotlib add-ons required by individual specs (cartopy: map-projections,
+    # wordcloud: wordcloud-basic, matplotlib-venn: venn-basic)
+    "cartopy>=0.24.0",
+    "wordcloud>=1.9.0",
+    "matplotlib-venn>=1.1.0",
 ]
 # Per-library dependencies for CI (minimal installs)
 lib-matplotlib = ["matplotlib>=3.10.9", "numpy>=2.4.6", "pandas>=3.0.3", "scipy>=1.14.0", "scikit-learn>=1.6.0", "statsmodels>=0.14.0"]

--- a/scripts/migrate_render_and_upload.py
+++ b/scripts/migrate_render_and_upload.py
@@ -217,14 +217,16 @@ def render(spec: str, language: str, library: str) -> tuple[Path, Path]:
 
     # Fallback: a handful of impls save to the impl directory (script_dir) instead
     # of cwd — e.g. lines like `plt.savefig(os.path.join(script_dir, f"plot-{theme}.png"))`.
-    # Move stray PNGs into the preview dir if found before checking existence.
+    # Move stray PNGs (and matching HTML sidecars for interactive libs) into the
+    # preview dir if found before checking existence.
     impl_dir = impl.parent
     for theme in ("light", "dark"):
-        target = preview / f"plot-{theme}.png"
-        if not target.is_file():
-            stray = impl_dir / f"plot-{theme}.png"
-            if stray.is_file():
-                stray.rename(target)
+        for ext in ("png", "html"):
+            target = preview / f"plot-{theme}.{ext}"
+            if not target.is_file():
+                stray = impl_dir / f"plot-{theme}.{ext}"
+                if stray.is_file():
+                    stray.rename(target)
 
     if not light_png.is_file() or not dark_png.is_file():
         raise RuntimeError(f"render incomplete in {preview} — missing light or dark PNG")

--- a/scripts/migrate_render_and_upload.py
+++ b/scripts/migrate_render_and_upload.py
@@ -214,6 +214,18 @@ def render(spec: str, language: str, library: str) -> tuple[Path, Path]:
 
     light_png = preview / "plot-light.png"
     dark_png = preview / "plot-dark.png"
+
+    # Fallback: a handful of impls save to the impl directory (script_dir) instead
+    # of cwd — e.g. lines like `plt.savefig(os.path.join(script_dir, f"plot-{theme}.png"))`.
+    # Move stray PNGs into the preview dir if found before checking existence.
+    impl_dir = impl.parent
+    for theme in ("light", "dark"):
+        target = preview / f"plot-{theme}.png"
+        if not target.is_file():
+            stray = impl_dir / f"plot-{theme}.png"
+            if stray.is_file():
+                stray.rename(target)
+
     if not light_png.is_file() or not dark_png.is_file():
         raise RuntimeError(f"render incomplete in {preview} — missing light or dark PNG")
     return light_png, dark_png


### PR DESCRIPTION
## Summary

Two small follow-ups uncovered while running Stage B of the imprint migration locally on the 137 matplotlib impls (PRs #7776 / #7777).

**1. `scripts/migrate_render_and_upload.py` — savefig fallback**

A handful of impls call `plt.savefig(os.path.join(script_dir, ...))` instead of plain `plt.savefig("plot-{theme}.png")`, so the PNG lands next to the impl file instead of inside `.regen-preview/{library}/`. Stage B now moves stray PNGs into the preview dir before checking for completeness — keeps the script compatible with these impls without rewriting them.

Affected on the matplotlib pass: `area-cumulative-flow`, `bar-spine`, `histogram-stepwise`, `indicator-macd`, `line-stepwise`, `linked-views-selection`. Likely a few more across other Python libraries once we run those.

**2. `pyproject.toml` — add cartopy / wordcloud / matplotlib-venn to `plotting` extra**

Three matplotlib add-ons that some specs depend on (`map-projections` → cartopy, `wordcloud-basic` → wordcloud, `venn-basic` → matplotlib-venn). Without them, `uv sync --extra plotting` produces a venv that can't render those three. CI paths are unaffected — the per-library `lib-matplotlib` extra is intentionally minimal.

## Result on the 137 matplotlib impls

After both fixes + a `--resume` rerun: **137 / 137 ✓** in GCS production. Without them the first run was 128 / 137 (the 9 failures above).

## Test plan

- [x] `ruff check .` + `ruff format --check .` green (matches CI)
- [ ] CI green (lint + tests + frontend-tests)
- [ ] Copilot triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)