### PR TITLE
chore(palette): migrate plotnine impls from Okabe-Ito to imprint

### DIFF
--- a/plots/alluvial-basic/implementations/python/plotnine.py
+++ b/plots/alluvial-basic/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Voter migration between parties across 4 election cycles
 transitions = pd.DataFrame(
@@ -110,9 +110,9 @@ transitions = pd.DataFrame(
 
 # Party colors using Okabe-Ito palette
 party_colors = {
-    "Democrats": OKABE_ITO[0],  # #009E73 (bluish green)
-    "Republicans": OKABE_ITO[1],  # #D55E00 (vermillion)
-    "Independent": OKABE_ITO[2],  # #0072B2 (blue)
+    "Democrats": IMPRINT[0],  # #009E73 (bluish green)
+    "Republicans": IMPRINT[1],  # #C475FD (vermillion)
+    "Independent": IMPRINT[2],  # #4467A3 (blue)
 }
 
 parties = ["Democrats", "Republicans", "Independent"]

--- a/plots/andrews-curves/implementations/python/plotnine.py
+++ b/plots/andrews-curves/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data
 iris = load_iris()
@@ -85,7 +85,7 @@ plot = (
     ggplot(df, aes(x="t", y="value", color="species", group="observation"))
     + geom_line(alpha=0.4, size=0.8)
     + labs(title="andrews-curves · plotnine · anyplot.ai", x="t (radians)", y="Andrews Curve Value", color="Species")
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + theme_minimal()
     + anyplot_theme
     + theme(figure_size=(16, 9))

--- a/plots/area-cumulative-flow/implementations/python/plotnine.py
+++ b/plots/area-cumulative-flow/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data
 np.random.seed(42)
@@ -85,7 +85,7 @@ df["stage"] = pd.Categorical(df["stage"], categories=stage_order, ordered=True)
 
 # Colors assigned to visual layers (bottom → top): Done, Testing, Development, Analysis, Backlog
 visual_order = ["Done", "Testing", "Development", "Analysis", "Backlog"]
-stage_colors = dict(zip(visual_order, OKABE_ITO, strict=True))
+stage_colors = dict(zip(visual_order, IMPRINT, strict=True))
 
 # Annotation: pinpoint the Development bottleneck at day 55 (band midpoint in stacked space)
 idx = 55

--- a/plots/area-stacked-confidence/implementations/python/plotnine.py
+++ b/plots/area-stacked-confidence/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first three series)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly energy consumption forecast by source with prediction intervals
 np.random.seed(42)
@@ -118,7 +118,7 @@ df_areas = pd.concat(
 df_areas["series"] = pd.Categorical(df_areas["series"], categories=["Solar", "Wind", "Hydro"], ordered=True)
 
 # Color mapping using Okabe-Ito palette
-color_map = {"Solar": OKABE_ITO[0], "Wind": OKABE_ITO[1], "Hydro": OKABE_ITO[2]}
+color_map = {"Solar": IMPRINT[0], "Wind": IMPRINT[1], "Hydro": IMPRINT[2]}
 
 # Theme customization
 anyplot_theme = theme(

--- a/plots/area-stacked-percent/implementations/python/plotnine.py
+++ b/plots/area-stacked-percent/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first position is ALWAYS #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Market share evolution with more dramatic proportion shifts
 years = list(range(2015, 2025))
@@ -70,7 +70,7 @@ df["Category"] = pd.Categorical(
 plot = (
     ggplot(df, aes(x="Year", y="Percent", fill="Category"))
     + geom_area(position="stack", alpha=0.85)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_x_continuous(breaks=range(2015, 2025, 2))
     + scale_y_continuous(breaks=[0, 25, 50, 75, 100], labels=["0%", "25%", "50%", "75%", "100%"])
     + labs(

--- a/plots/area-stacked/implementations/python/plotnine.py
+++ b/plots/area-stacked/implementations/python/plotnine.py
@@ -61,7 +61,7 @@ source_order = ["Organic Search", "Direct", "Referral", "Social Media"]
 df["Source"] = pd.Categorical(df["Source"], categories=source_order, ordered=True)
 
 # Okabe-Ito palette
-colors = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+colors = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Theme
 anyplot_theme = theme(

--- a/plots/bar-diverging/implementations/python/plotnine.py
+++ b/plots/bar-diverging/implementations/python/plotnine.py
@@ -75,7 +75,7 @@ plot = (
     + geom_bar(stat="identity", width=0.7)
     + geom_hline(yintercept=0, color=INK_SOFT, size=0.8)
     + coord_flip()
-    + scale_fill_manual(values={"Positive": "#009E73", "Negative": "#D55E00"})
+    + scale_fill_manual(values={"Positive": "#009E73", "Negative": "#AE3030"})
     + labs(
         x="Product Category",
         y="Net Satisfaction Score (%)",

--- a/plots/bar-drilldown/implementations/python/plotnine.py
+++ b/plots/bar-drilldown/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — Annual retail revenue by category and subcategory ($ millions)
 data = {
@@ -77,7 +77,7 @@ plot = (
     + geom_col(width=0.72)
     + geom_text(aes(label="revenue"), va="bottom", nudge_y=0.5, size=9, color=INK_SOFT)
     + facet_wrap("~panel_label", ncol=2, scales="free")
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_y_continuous(expand=(0.08, 0))
     + labs(x="", y="Revenue ($ millions)", title="bar-drilldown · python · plotnine · anyplot.ai")
     + theme_minimal()

--- a/plots/bar-grouped/implementations/python/plotnine.py
+++ b/plots/bar-grouped/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product line
 data = {
@@ -76,7 +76,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="Quarter", y="Revenue", fill="Product"))
     + geom_bar(stat="identity", position=position_dodge(width=0.8), width=0.7)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(x="Quarter", y="Revenue ($ millions)", title="bar-grouped · plotnine · anyplot.ai", fill="Product Line")
     + anyplot_theme
 )

--- a/plots/bar-race-animated/implementations/python/plotnine.py
+++ b/plots/bar-race-animated/implementations/python/plotnine.py
@@ -37,12 +37,12 @@ NEUTRAL = "#1A1A1A" if THEME == "light" else "#E8E8E0"
 
 PALETTE = [
     "#009E73",  # TechCorp - bluish green
-    "#D55E00",  # DataFlow - vermillion
-    "#0072B2",  # CloudBase - blue
-    "#CC79A7",  # NetSys - reddish purple
-    "#E69F00",  # CodeLab - orange
-    "#56B4E9",  # AppStream - sky blue
-    "#F0E442",  # ByteWorks - yellow
+    "#C475FD",  # DataFlow - vermillion
+    "#4467A3",  # CloudBase - blue
+    "#BD8233",  # NetSys - reddish purple
+    "#AE3030",  # CodeLab - orange
+    "#2ABCCD",  # AppStream - sky blue
+    "#954477",  # ByteWorks - yellow
     NEUTRAL,  # DigiCore - adaptive neutral
 ]
 

--- a/plots/bar-spine/implementations/python/plotnine.py
+++ b/plots/bar-spine/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data — customer churn by subscription tier
 data = {
@@ -91,7 +91,7 @@ plot = (
     ggplot(df)
     + geom_rect(aes(xmin="xmin", xmax="xmax", ymin="ymin", ymax="ymax", fill="status"), color=PAGE_BG, size=0.5)
     + geom_text(aes(x="xcenter", y="ylabel", label="label"), color="white", size=11, fontweight="bold")
-    + scale_fill_manual(values={"Retained": OKABE_ITO[0], "Churned": OKABE_ITO[1]}, name="Status")
+    + scale_fill_manual(values={"Retained": IMPRINT[0], "Churned": IMPRINT[1]}, name="Status")
     + scale_x_continuous(breaks=x_breaks, labels=x_labels, limits=(0, 1), expand=(0, 0))
     + scale_y_continuous(
         breaks=[0, 0.25, 0.5, 0.75, 1.0], labels=["0%", "25%", "50%", "75%", "100%"], limits=(0, 1), expand=(0, 0)

--- a/plots/bar-stacked-percent/implementations/python/plotnine.py
+++ b/plots/bar-stacked-percent/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Market share by quarter for tech companies
 quarters = ["Q1 2023", "Q2 2023", "Q3 2023", "Q4 2023", "Q1 2024", "Q2 2024"]
@@ -80,7 +80,7 @@ df["Quarter"] = pd.Categorical(df["Quarter"], categories=quarters, ordered=True)
 df["Company"] = pd.Categorical(df["Company"], categories=companies_ordered, ordered=True)
 
 # Color mapping with Okabe-Ito palette
-color_map = {"Others": OKABE_ITO[3], "Xiaomi": OKABE_ITO[2], "Samsung": OKABE_ITO[1], "Apple": OKABE_ITO[0]}
+color_map = {"Others": IMPRINT[3], "Xiaomi": IMPRINT[2], "Samsung": IMPRINT[1], "Apple": IMPRINT[0]}
 
 # Theme-adaptive colors for legend and text
 anyplot_theme = theme(

--- a/plots/bar-stacked/implementations/python/plotnine.py
+++ b/plots/bar-stacked/implementations/python/plotnine.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Quarterly sales by product category
 data = {
@@ -58,7 +58,7 @@ plot = (
     ggplot(df, aes(x="Quarter", y="Sales", fill="Category"))
     + geom_bar(stat="identity", position="stack", width=0.7)
     + geom_text(aes(label="Sales"), position=position_stack(vjust=0.5), size=12, color="white", fontweight="bold")
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(title="bar-stacked · plotnine · anyplot.ai", x="Quarter", y="Sales (thousands USD)", fill="Category")
     + theme_minimal()
     + theme(

--- a/plots/biplot-pca/implementations/python/plotnine.py
+++ b/plots/biplot-pca/implementations/python/plotnine.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first 3 for species)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Load Iris dataset
 iris = load_iris()
@@ -140,7 +140,7 @@ plot = (
     # Theme
     + theme_minimal()
     + anyplot_theme
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
 )
 
 # Save

--- a/plots/box-grouped/implementations/python/plotnine.py
+++ b/plots/box-grouped/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Employee performance scores by department and experience level
 np.random.seed(42)
@@ -96,7 +96,7 @@ plot = (
     + geom_boxplot(
         position=position_dodge2(preserve="single", padding=0.1), width=0.7, outlier_size=3, outlier_alpha=0.7
     )
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(
         x="Department",
         y="Performance Score (0-100)",

--- a/plots/box-horizontal/implementations/python/plotnine.py
+++ b/plots/box-horizontal/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Response times (ms) by service type
 np.random.seed(42)
@@ -89,7 +89,7 @@ plot = (
     ggplot(df, aes(x="Service", y="Response Time", fill="Service"))
     + geom_boxplot(alpha=0.8, size=0.8, outlier_size=3, outlier_alpha=0.7)
     + coord_flip()
-    + scale_fill_manual(values=OKABE_ITO[: len(services)])
+    + scale_fill_manual(values=IMPRINT[: len(services)])
     + labs(title="box-horizontal · plotnine · anyplot.ai", x="Service Type", y="Response Time (ms)")
     + theme_minimal()
     + anyplot_theme

--- a/plots/box-notched/implementations/python/plotnine.py
+++ b/plots/box-notched/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - clinical trial outcomes across treatment groups
 np.random.seed(42)
@@ -58,7 +58,7 @@ df["group"] = pd.Categorical(df["group"], categories=groups, ordered=True)
 plot = (
     ggplot(df, aes(x="group", y="score", fill="group"))
     + geom_boxplot(notch=True, notchwidth=0.5, outlier_size=3, outlier_alpha=0.7, size=0.9)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(x="Treatment Group", y="Clinical Score", title="box-notched · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/bubble-map-geographic/implementations/python/plotnine.py
+++ b/plots/bubble-map-geographic/implementations/python/plotnine.py
@@ -272,7 +272,7 @@ df_continents = pd.DataFrame(continents)
 
 # Okabe-Ito canonical order mapped to regions alphabetically:
 # Africa, Asia, Europe, N. America, Oceania, S. America
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Create the bubble map
 plot = (
@@ -290,7 +290,7 @@ plot = (
     + geom_point(aes(x="longitude", y="latitude", color="region", size="population"), data=df, alpha=0.7, stroke=0.5)
     # Scale size by area for accurate perception (bubble area proportional to value)
     + scale_size_area(max_size=20, name="Population (M)")
-    + scale_color_manual(values=OKABE_ITO, name="Region")
+    + scale_color_manual(values=IMPRINT, name="Region")
     + coord_fixed(ratio=1.0, xlim=(-180, 180), ylim=(-60, 80))
     + labs(
         title="World City Populations · bubble-map-geographic · python · plotnine · anyplot.ai",

--- a/plots/candlestick-volume/implementations/python/plotnine.py
+++ b/plots/candlestick-volume/implementations/python/plotnine.py
@@ -46,9 +46,9 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette: Up (green), Down (orange)
+# imprint semantic anchors: Up (green), Down (red)
 UP_COLOR = "#009E73"
-DOWN_COLOR = "#D55E00"
+DOWN_COLOR = "#AE3030"
 
 # Generate realistic OHLC data
 np.random.seed(42)

--- a/plots/cat-box-strip/implementations/python/plotnine.py
+++ b/plots/cat-box-strip/implementations/python/plotnine.py
@@ -36,7 +36,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Plant growth measurements across fertilizer types
 np.random.seed(42)
@@ -68,8 +68,8 @@ plot = (
     ggplot(df, aes(x="Fertilizer", y="Growth (cm)", fill="Fertilizer"))
     + geom_boxplot(alpha=0.7, width=0.6, outlier_shape="", size=1)
     + geom_jitter(aes(color="Fertilizer"), width=0.15, alpha=0.6, size=3, show_legend=False)
-    + scale_fill_manual(values=OKABE_ITO)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
+    + scale_color_manual(values=IMPRINT)
     + labs(x="Treatment Group", y="Plant Growth (cm)", title="cat-box-strip · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/chernoff-basic/implementations/python/plotnine.py
+++ b/plots/chernoff-basic/implementations/python/plotnine.py
@@ -127,7 +127,7 @@ for idx in range(len(sample_df)):
 plot_df = pd.DataFrame(all_data)
 
 # Okabe-Ito palette
-category_colors = {"Compact": "#009E73", "Sedan": "#D55E00", "SUV": "#0072B2"}
+category_colors = {"Compact": "#009E73", "Sedan": "#C475FD", "SUV": "#4467A3"}
 
 anyplot_theme = theme(
     figure_size=(16, 9),

--- a/plots/circlepacking-basic/implementations/python/plotnine.py
+++ b/plots/circlepacking-basic/implementations/python/plotnine.py
@@ -36,7 +36,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - for hierarchy levels
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Investment portfolio hierarchy
 # Format: (id, label, parent_id, value)
@@ -161,7 +161,7 @@ plot = (
     + geom_text(
         df_labels, aes(x="x", y="y", label="label", size="text_size"), color=INK, fontweight="bold", show_legend=False
     )
-    + scale_fill_manual(values=OKABE_ITO, labels=["Root", "Asset Classes", "Holdings"], name="Hierarchy Level")
+    + scale_fill_manual(values=IMPRINT, labels=["Root", "Asset Classes", "Holdings"], name="Hierarchy Level")
     + scale_size_identity()
     + coord_fixed(ratio=1)
     + labs(title="circlepacking-basic · plotnine · anyplot.ai")

--- a/plots/circos-basic/implementations/python/plotnine.py
+++ b/plots/circos-basic/implementations/python/plotnine.py
@@ -33,13 +33,13 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
-    "#E69F00",  # orange
-    "#56B4E9",  # sky blue
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
+    "#AE3030",  # orange
+    "#2ABCCD",  # sky blue
 ]
 
 # Data - Trade flows between world regions
@@ -68,7 +68,7 @@ flows = [
 segments = list(dict.fromkeys([f[0] for f in flows] + [f[1] for f in flows]))
 
 # Map segments to Okabe-Ito colors
-colors = {seg: OKABE_ITO[i % len(OKABE_ITO)] for i, seg in enumerate(segments)}
+colors = {seg: IMPRINT[i % len(IMPRINT)] for i, seg in enumerate(segments)}
 
 # Calculate total flow for each segment
 segment_totals = dict.fromkeys(segments, 0)

--- a/plots/coefficient-confidence/implementations/python/plotnine.py
+++ b/plots/coefficient-confidence/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Coefficients from a housing price regression model
 np.random.seed(42)
@@ -69,7 +69,7 @@ df["variable"] = pd.Categorical(
 
 # Theme-adaptive colors for significance
 sig_colors = {
-    "Significant": OKABE_ITO[0],  # Brand green
+    "Significant": IMPRINT[0],  # Brand green
     "Not Significant": INK_SOFT,  # Theme-adaptive soft ink
 }
 

--- a/plots/confusion-matrix/implementations/python/plotnine.py
+++ b/plots/confusion-matrix/implementations/python/plotnine.py
@@ -73,7 +73,7 @@ plot = (
     + geom_text(aes(label="Count", color="text_color"), size=20, fontweight="bold", show_legend=False)
     + scale_fill_gradient(
         low="#e8f4f8" if THEME == "light" else "#2a3f4f",
-        high="#08519c" if THEME == "light" else "#56b4e9",
+        high="#08519c" if THEME == "light" else "#2ABCCD",
         name="Sample Count",
     )
     + scale_color_identity()

--- a/plots/count-basic/implementations/python/plotnine.py
+++ b/plots/count-basic/implementations/python/plotnine.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Netflix user ratings from a streaming dataset
 ratings = ["5 Stars"] * 285 + ["4 Stars"] * 198 + ["3 Stars"] * 142 + ["2 Stars"] * 89 + ["1 Star"] * 56
@@ -49,7 +49,7 @@ plot = (
     ggplot(df, aes(x="Rating", fill="Rating"))
     + geom_bar(width=0.7, show_legend=False)
     + geom_text(aes(x="Rating", y="Count", label="Count"), data=count_df, size=14, va="bottom", nudge_y=8)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(x="Rating", y="Number of Responses", title="count-basic · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/dashboard-metrics-tiles/implementations/python/plotnine.py
+++ b/plots/dashboard-metrics-tiles/implementations/python/plotnine.py
@@ -34,11 +34,11 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 SPARKLINE_BG = "#EDEAE0" if THEME == "light" else "#2A2A26"
 
-# Okabe-Ito status colors
+# imprint semantic anchors
 STATUS_COLORS = {
-    "good": "#009E73",  # Okabe-Ito 1: bluish green
-    "warning": "#E69F00",  # Okabe-Ito 5: orange
-    "critical": "#D55E00",  # Okabe-Ito 2: vermillion
+    "good": "#009E73",  # green
+    "warning": "#DDCC77",  # amber
+    "critical": "#AE3030",  # red
 }
 
 np.random.seed(42)
@@ -91,9 +91,9 @@ for metric in metrics:
 
     # Context-aware change color: for error rate, up = bad
     if metric["name"] == "Error Rate":
-        change_color = "#D55E00" if change >= 0 else "#009E73"
+        change_color = "#C475FD" if change >= 0 else "#009E73"
     else:
-        change_color = "#009E73" if change >= 0 else "#D55E00"
+        change_color = "#009E73" if change >= 0 else "#C475FD"
 
     label_data.append(
         {

--- a/plots/dashboard-synchronized-crosshair/implementations/python/plotnine.py
+++ b/plots/dashboard-synchronized-crosshair/implementations/python/plotnine.py
@@ -36,7 +36,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # anyplot palette 1 — data lines
-ACCENT = "#B71D27"  # anyplot palette 3 — crosshair marker
+ACCENT = "#AE3030"  # anyplot palette 3 — crosshair marker
 
 # Data — seasonal stock: trend + annual cycle + quarterly earnings ripple + mild noise
 np.random.seed(42)

--- a/plots/dendrogram-radial/implementations/python/plotnine.py
+++ b/plots/dendrogram-radial/implementations/python/plotnine.py
@@ -38,7 +38,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: species morphological traits — 3 well-separated clades
 np.random.seed(42)
@@ -59,7 +59,7 @@ leaves_order = dend["leaves"]
 # Cluster assignment (3 clades)
 cluster_assign = fcluster(Z, 3, criterion="maxclust")
 clade_names = {1: "Clade I", 2: "Clade II", 3: "Clade III"}
-clade_colors = {"Clade I": OKABE_ITO[0], "Clade II": OKABE_ITO[1], "Clade III": OKABE_ITO[2]}
+clade_colors = {"Clade I": IMPRINT[0], "Clade II": IMPRINT[1], "Clade III": IMPRINT[2]}
 
 # Radial coordinate transforms:
 #   x position → angle (θ), evenly around the circle

--- a/plots/diagnostic-regression-panel/implementations/python/plotnine.py
+++ b/plots/diagnostic-regression-panel/implementations/python/plotnine.py
@@ -45,7 +45,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Data — materials-testing regression: tensile strength vs temperature and load
 # Three high-leverage observations at extreme temperatures reveal influential points

--- a/plots/donut-basic/implementations/python/plotnine.py
+++ b/plots/donut-basic/implementations/python/plotnine.py
@@ -42,7 +42,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 LABEL_ON_WEDGE = "#F0EFE8"
 
 # Okabe-Ito palette (first segment is always the brand green)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Annual budget allocation by department (USD thousands)
 categories = ["Engineering", "Marketing", "Operations", "Sales", "Support"]
@@ -61,7 +61,7 @@ label_rows = []
 pct_rows = []
 
 start_angle = math.pi / 2  # Start at 12 o'clock
-for category, value, color in zip(categories, values, OKABE_ITO, strict=True):
+for category, value, color in zip(categories, values, IMPRINT, strict=True):
     sweep = (value / total) * 2 * math.pi
     end_angle = start_angle - sweep  # Clockwise
 

--- a/plots/donut-nested/implementations/python/plotnine.py
+++ b/plots/donut-nested/implementations/python/plotnine.py
@@ -48,12 +48,12 @@ data = {
     "Sales": [("Commissions", 220), ("Travel", 110), ("Tools", 50)],
 }
 
-# Color families - first parent uses Okabe-Ito brand (#009E73), then positions 2-4
+# imprint families - parent + two lighter tonal shades for the outer ring
 color_families = {
-    "Engineering": ("#009E73", ["#009E73", "#2FA88A", "#59B5A1"]),  # Okabe-Ito pos 1
-    "Marketing": ("#C475FD", ["#C475FD", "#DC7925", "#E5934A"]),  # Okabe-Ito pos 2
-    "Operations": ("#4467A3", ["#4467A3", "#3589C8", "#5BA0DE"]),  # Okabe-Ito pos 3
-    "Sales": ("#BD8233", ["#BD8233", "#D98FB8", "#E6A5C9"]),  # Okabe-Ito pos 4
+    "Engineering": ("#009E73", ["#009E73", "#2DAE89", "#5BBFA0"]),  # imprint green
+    "Marketing": ("#C475FD", ["#C475FD", "#D195FE", "#DEB5FE"]),  # imprint lavender
+    "Operations": ("#4467A3", ["#4467A3", "#6883B6", "#8C9FC9"]),  # imprint blue
+    "Sales": ("#BD8233", ["#BD8233", "#CC9852", "#DBAE71"]),  # imprint ochre
 }
 
 # Calculate totals for each parent

--- a/plots/donut-nested/implementations/python/plotnine.py
+++ b/plots/donut-nested/implementations/python/plotnine.py
@@ -51,9 +51,9 @@ data = {
 # Color families - first parent uses Okabe-Ito brand (#009E73), then positions 2-4
 color_families = {
     "Engineering": ("#009E73", ["#009E73", "#2FA88A", "#59B5A1"]),  # Okabe-Ito pos 1
-    "Marketing": ("#D55E00", ["#D55E00", "#DC7925", "#E5934A"]),  # Okabe-Ito pos 2
-    "Operations": ("#0072B2", ["#0072B2", "#3589C8", "#5BA0DE"]),  # Okabe-Ito pos 3
-    "Sales": ("#CC79A7", ["#CC79A7", "#D98FB8", "#E6A5C9"]),  # Okabe-Ito pos 4
+    "Marketing": ("#C475FD", ["#C475FD", "#DC7925", "#E5934A"]),  # Okabe-Ito pos 2
+    "Operations": ("#4467A3", ["#4467A3", "#3589C8", "#5BA0DE"]),  # Okabe-Ito pos 3
+    "Sales": ("#BD8233", ["#BD8233", "#D98FB8", "#E6A5C9"]),  # Okabe-Ito pos 4
 }
 
 # Calculate totals for each parent

--- a/plots/dot-matrix-proportional/implementations/python/plotnine.py
+++ b/plots/dot-matrix-proportional/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data – Household Solar Panel Adoption Survey (100 homes, 10×10 grid)
 categories = ["Fully Solar-Powered", "Partially Solar-Powered", "No Solar Panels"]
@@ -61,7 +61,7 @@ legend_labels = [f"{cat}  ({cnt})" for cat, cnt in zip(categories, counts, stric
 plot = (
     ggplot(df, aes(x="x", y="y", color="category"))
     + geom_point(size=9)
-    + scale_color_manual(values=OKABE_ITO, labels=legend_labels)
+    + scale_color_manual(values=IMPRINT, labels=legend_labels)
     + coord_fixed()
     + labs(
         title="dot-matrix-proportional · plotnine · anyplot.ai",

--- a/plots/drawdown-basic/implementations/python/plotnine.py
+++ b/plots/drawdown-basic/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-DRAWDOWN_COLOR = "#B71D27"  # anyplot red — semantic: losses / drawdown
+DRAWDOWN_COLOR = "#AE3030"  # anyplot red — semantic: losses / drawdown
 RECOVERY_COLOR = "#009E73"  # anyplot green — semantic: recovery / new high
 # Higher alpha in dark mode so ribbon remains visible over near-black background
 RIBBON_ALPHA = 0.30 if THEME == "light" else 0.55

--- a/plots/dumbbell-basic/implementations/python/plotnine.py
+++ b/plots/dumbbell-basic/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Employee satisfaction scores before and after workplace policy changes
 categories = ["Engineering", "Marketing", "Sales", "HR", "Finance", "Operations", "Customer Support", "Product"]
@@ -63,7 +63,7 @@ plot = (
         aes(x="start", xend="end", y="category", yend="category"), data=df_segments, color=INK_SOFT, size=1.5, alpha=0.6
     )
     + geom_point(aes(x="value", y="category", color="period"), data=df_points, size=7)
-    + scale_color_manual(values={"Before": OKABE_ITO[0], "After": OKABE_ITO[1]})
+    + scale_color_manual(values={"Before": IMPRINT[0], "After": IMPRINT[1]})
     + scale_x_continuous(limits=(30, 100), breaks=[30, 40, 50, 60, 70, 80, 90, 100])
     + labs(
         x="Satisfaction Score",

--- a/plots/elbow-curve/implementations/python/plotnine.py
+++ b/plots/elbow-curve/implementations/python/plotnine.py
@@ -33,9 +33,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
-BRAND = OKABE_ITO[0]  # #009E73 - first series always
-ACCENT = OKABE_ITO[1]  # #D55E00 - accent for annotation line
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
+BRAND = IMPRINT[0]  # #009E73 - first series always
+ACCENT = IMPRINT[1]  # #C475FD - accent for annotation line
 
 # Data - Simulate realistic K-means inertia values
 np.random.seed(42)

--- a/plots/errorbar-basic/implementations/python/plotnine.py
+++ b/plots/errorbar-basic/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data — three lab methods measured across six samples
 data = pd.DataFrame(
@@ -93,7 +93,7 @@ plot = (
     ggplot(data, aes(x="sample", y="measurement", color="method", group="method"))
     + geom_errorbar(aes(ymin="ymin", ymax="ymax"), width=0.35, size=1.4, position=dodge)
     + geom_point(size=5, position=dodge)
-    + scale_color_manual(values=OKABE_ITO, name="Method")
+    + scale_color_manual(values=IMPRINT, name="Method")
     + labs(x="Experimental Sample", y="Measurement Value (mg/L)", title="errorbar-basic · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/facet-grid/implementations/python/plotnine.py
+++ b/plots/facet-grid/implementations/python/plotnine.py
@@ -44,7 +44,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Student exam scores across teaching methods and subjects
 np.random.seed(42)
@@ -77,7 +77,7 @@ plot = (
     ggplot(df, aes(x="hours", y="score", color="method"))
     + geom_point(size=4, alpha=0.75)
     + facet_grid("subject ~ method", labeller="label_both")
-    + scale_color_manual(values=OKABE_ITO[:3])
+    + scale_color_manual(values=IMPRINT[:3])
     + labs(title="facet-grid · plotnine · anyplot.ai", x="Study Hours", y="Exam Score", color="Method")
     + theme_minimal()
     + theme(

--- a/plots/frequency-polygon-basic/implementations/python/plotnine.py
+++ b/plots/frequency-polygon-basic/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Response times by experimental condition
 np.random.seed(42)
@@ -71,7 +71,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="response_time", color="condition"))
     + geom_freqpoly(size=2, bins=25, alpha=0.9)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(
         x="Response Time (ms)",
         y="Frequency",

--- a/plots/frontier-efficient/implementations/python/plotnine.py
+++ b/plots/frontier-efficient/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data
 np.random.seed(42)
@@ -97,9 +97,9 @@ df_frontier = pd.DataFrame({"risk": frontier_risks, "return": frontier_returns})
 plot = (
     ggplot()
     + geom_point(df_portfolios, aes(x="risk", y="return", color="sharpe"), size=3, alpha=0.6)
-    + geom_line(df_frontier, aes(x="risk", y="return"), color=OKABE_ITO[0], size=2.5)
-    + annotate("point", x=min_var_risk, y=min_var_return, color=OKABE_ITO[4], size=6, shape="s")
-    + annotate("point", x=max_sharpe_risk, y=max_sharpe_return, color=OKABE_ITO[4], size=6, shape="D")
+    + geom_line(df_frontier, aes(x="risk", y="return"), color=IMPRINT[0], size=2.5)
+    + annotate("point", x=min_var_risk, y=min_var_return, color=IMPRINT[4], size=6, shape="s")
+    + annotate("point", x=max_sharpe_risk, y=max_sharpe_return, color=IMPRINT[4], size=6, shape="D")
     + annotate("text", x=min_var_risk + 0.012, y=min_var_return, label="Min Var", size=14, ha="left", color=INK)
     + annotate(
         "text", x=max_sharpe_risk + 0.012, y=max_sharpe_return, label="Max Sharpe", size=14, ha="left", color=INK

--- a/plots/funnel-basic/implementations/python/plotnine.py
+++ b/plots/funnel-basic/implementations/python/plotnine.py
@@ -35,10 +35,11 @@ THEME = os.getenv("ANYPLOT_THEME", "light")
 PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 
-# Okabe-Ito palette — first stage is brand green (#009E73)
+# imprint palette — first stage is brand green (#009E73)
 IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
-# Light orange (#AE3030) needs dark text for contrast; others use white.
-TEXT_ON_FILL = ["white", "white", "white", "white", INK]
+# Slot 1 (lavender) is the lightest hue and needs dark text; the others are
+# saturated/dark enough for white.
+TEXT_ON_FILL = ["white", INK, "white", "white", "white"]
 
 # Data — sales funnel example from specification
 stages = ["Awareness", "Interest", "Consideration", "Intent", "Purchase"]

--- a/plots/funnel-basic/implementations/python/plotnine.py
+++ b/plots/funnel-basic/implementations/python/plotnine.py
@@ -36,8 +36,8 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 
 # Okabe-Ito palette — first stage is brand green (#009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
-# Light orange (#E69F00) needs dark text for contrast; others use white.
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
+# Light orange (#AE3030) needs dark text for contrast; others use white.
 TEXT_ON_FILL = ["white", "white", "white", "white", INK]
 
 # Data — sales funnel example from specification
@@ -90,7 +90,7 @@ plot = (
         fontweight="bold",
         inherit_aes=False,
     )
-    + scale_fill_manual(values=OKABE_ITO[:n_stages], guide=None)
+    + scale_fill_manual(values=IMPRINT[:n_stages], guide=None)
     + scale_color_identity()
     + scale_y_reverse()
     + labs(title="funnel-basic · plotnine · anyplot.ai", x="", y="")

--- a/plots/gain-curve/implementations/python/plotnine.py
+++ b/plots/gain-curve/implementations/python/plotnine.py
@@ -76,7 +76,7 @@ df = pd.concat([df_model, df_random, df_perfect], ignore_index=True)
 plot = (
     ggplot(df, aes(x="percent_population", y="percent_positives", color="curve"))
     + geom_line(size=2.5)
-    + scale_color_manual(values={"Model": "#009E73", "Random": INK_MUTED, "Perfect": "#E69F00"})
+    + scale_color_manual(values={"Model": "#009E73", "Random": INK_MUTED, "Perfect": "#AE3030"})
     + scale_x_continuous(breaks=range(0, 101, 20), limits=(0, 100))
     + scale_y_continuous(breaks=range(0, 101, 20), limits=(0, 100))
     + labs(

--- a/plots/gantt-basic/implementations/python/plotnine.py
+++ b/plots/gantt-basic/implementations/python/plotnine.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (5 categories)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Software development project schedule
 data = {
@@ -95,11 +95,11 @@ df["task"] = pd.Categorical(df["task"], categories=df["task"].tolist(), ordered=
 
 # Map categories to Okabe-Ito colors
 category_colors = {
-    "Planning": OKABE_ITO[0],
-    "Design": OKABE_ITO[1],
-    "Development": OKABE_ITO[2],
-    "QA": OKABE_ITO[3],
-    "Deployment": OKABE_ITO[4],
+    "Planning": IMPRINT[0],
+    "Design": IMPRINT[1],
+    "Development": IMPRINT[2],
+    "QA": IMPRINT[3],
+    "Deployment": IMPRINT[4],
 }
 
 # Current date marker

--- a/plots/gauge-basic/implementations/python/plotnine.py
+++ b/plots/gauge-basic/implementations/python/plotnine.py
@@ -39,10 +39,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-# Okabe-Ito zone colors (colorblind-safe red/yellow/green)
-ZONE_BAD = "#D55E00"  # vermillion
-ZONE_WARN = "#E69F00"  # orange
-ZONE_GOOD = "#009E73"  # bluish green (brand)
+# imprint semantic anchors (red / amber / green traffic-light)
+ZONE_BAD = "#AE3030"  # matte red
+ZONE_WARN = "#DDCC77"  # amber
+ZONE_GOOD = "#009E73"  # brand green
 
 # Data
 value = 72

--- a/plots/histogram-density/implementations/python/plotnine.py
+++ b/plots/histogram-density/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - bimodal distribution for compelling visualization
 np.random.seed(42)

--- a/plots/histogram-overlapping/implementations/python/plotnine.py
+++ b/plots/histogram-overlapping/implementations/python/plotnine.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Response times (ms) for three user groups
 np.random.seed(42)
@@ -72,7 +72,7 @@ anyplot_theme = pn.theme(
 plot = (
     pn.ggplot(df, pn.aes(x="response_time", fill="user_group"))
     + pn.geom_histogram(alpha=0.6, bins=30, position="identity")
-    + pn.scale_fill_manual(values=OKABE_ITO)
+    + pn.scale_fill_manual(values=IMPRINT)
     + pn.labs(
         x="Response Time (ms)", y="Frequency", title="histogram-overlapping · plotnine · pyplots.ai", fill="User Group"
     )

--- a/plots/histogram-returns-distribution/implementations/python/plotnine.py
+++ b/plots/histogram-returns-distribution/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - 252 trading days with slight fat tails (mixture of normals)
 np.random.seed(42)
@@ -69,16 +69,16 @@ df_normal = pd.DataFrame({"x": x_range, "y": normal_scaled})
 stats_label = f"Mean: {mean_ret:.2f}%\nStd Dev: {std_ret:.2f}%\nSkewness: {skewness:.2f}\nExc. Kurtosis: {kurtosis:.2f}"
 
 # Okabe-Ito fill: center green (pos 1), both tails vermillion (pos 2)
-fill_colors = {"Left Tail": OKABE_ITO[1], "Center": OKABE_ITO[0], "Right Tail": OKABE_ITO[1]}
+fill_colors = {"Left Tail": IMPRINT[1], "Center": IMPRINT[0], "Right Tail": IMPRINT[1]}
 
 # Plot
 plot = (
     ggplot(df, aes(x="returns", fill="region"))
     + geom_histogram(bins=30, color=PAGE_BG, alpha=0.85, size=0.3)
-    + geom_line(data=df_normal, mapping=aes(x="x", y="y"), color=OKABE_ITO[2], size=1.2, inherit_aes=False)
+    + geom_line(data=df_normal, mapping=aes(x="x", y="y"), color=IMPRINT[2], size=1.2, inherit_aes=False)
     + geom_vline(xintercept=mean_ret, linetype="dashed", color=INK, size=0.8)
-    + geom_vline(xintercept=lower_tail, linetype="dotted", color=OKABE_ITO[1], size=0.8)
-    + geom_vline(xintercept=upper_tail, linetype="dotted", color=OKABE_ITO[1], size=0.8)
+    + geom_vline(xintercept=lower_tail, linetype="dotted", color=IMPRINT[1], size=0.8)
+    + geom_vline(xintercept=upper_tail, linetype="dotted", color=IMPRINT[1], size=0.8)
     + scale_fill_manual(values=fill_colors, name="Region")
     + annotate(
         "label",

--- a/plots/histogram-stacked/implementations/python/plotnine.py
+++ b/plots/histogram-stacked/implementations/python/plotnine.py
@@ -29,7 +29,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Plant growth measurements across different soil types
 np.random.seed(42)
@@ -67,7 +67,7 @@ plot = (
     ggplot(df, aes(x="height", fill="soil_type"))
     + geom_histogram(bins=20, position="stack", alpha=0.85, color=PAGE_BG, size=0.4)
     + labs(x="Plant Height (cm)", y="Frequency", title="histogram-stacked · plotnine · anyplot.ai", fill="Soil Type")
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + theme_minimal()
     + anyplot_theme
 )

--- a/plots/histogram-stepwise/implementations/python/plotnine.py
+++ b/plots/histogram-stepwise/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Response times (ms) for two server configurations
 np.random.seed(42)
@@ -73,7 +73,7 @@ plot = (
     + labs(
         x="Response Time (ms)", y="Frequency", title="histogram-stepwise · plotnine · anyplot.ai", color="Configuration"
     )
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + theme(
         figure_size=(16, 9),
         plot_background=element_rect(fill=PAGE_BG, color=PAGE_BG),

--- a/plots/hive-basic/implementations/python/plotnine.py
+++ b/plots/hive-basic/implementations/python/plotnine.py
@@ -31,8 +31,8 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-COLOR_2 = "#D55E00"
-COLOR_3 = "#0072B2"
+COLOR_2 = "#C475FD"
+COLOR_3 = "#4467A3"
 
 np.random.seed(42)
 

--- a/plots/ice-basic/implementations/python/plotnine.py
+++ b/plots/ice-basic/implementations/python/plotnine.py
@@ -37,7 +37,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-VERMILLION = "#D55E00"
+VERMILLION = "#C475FD"
 
 # Data — synthetic housing dataset
 np.random.seed(42)

--- a/plots/icicle-basic/implementations/python/plotnine.py
+++ b/plots/icicle-basic/implementations/python/plotnine.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for hierarchy levels
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: File system hierarchy with sizes (MB)
 data = [
@@ -119,7 +119,7 @@ while layout_queue:
 rect_df = pd.DataFrame(rects)
 
 # Color palette by depth using Okabe-Ito
-colors = {0: OKABE_ITO[0], 1: OKABE_ITO[1], 2: OKABE_ITO[2], 3: OKABE_ITO[3], 4: OKABE_ITO[4], 5: OKABE_ITO[5]}
+colors = {0: IMPRINT[0], 1: IMPRINT[1], 2: IMPRINT[2], 3: IMPRINT[3], 4: IMPRINT[4], 5: IMPRINT[5]}
 rect_df["fill_color"] = rect_df["depth"].map(colors)
 
 # Calculate label positions and widths
@@ -163,12 +163,12 @@ plot = (
     )
     + scale_fill_manual(
         values={
-            "Level 0 (Root)": OKABE_ITO[0],
-            "Level 1 (Folders)": OKABE_ITO[1],
-            "Level 2 (Subfolders)": OKABE_ITO[2],
-            "Level 3 (Groups)": OKABE_ITO[3],
-            "Level 4 (Items)": OKABE_ITO[4],
-            "Level 5 (Leaf)": OKABE_ITO[5],
+            "Level 0 (Root)": IMPRINT[0],
+            "Level 1 (Folders)": IMPRINT[1],
+            "Level 2 (Subfolders)": IMPRINT[2],
+            "Level 3 (Groups)": IMPRINT[3],
+            "Level 4 (Items)": IMPRINT[4],
+            "Level 5 (Leaf)": IMPRINT[5],
         },
         name="Hierarchy Level",
     )

--- a/plots/indicator-bollinger/implementations/python/plotnine.py
+++ b/plots/indicator-bollinger/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Close price - first series
-BAND_COLOR = "#0072B2"  # Bollinger bands - second series
+BAND_COLOR = "#4467A3"  # Bollinger bands - second series
 
 # Data - Generate realistic stock price with Bollinger Bands
 np.random.seed(42)

--- a/plots/indicator-macd/implementations/python/plotnine.py
+++ b/plots/indicator-macd/implementations/python/plotnine.py
@@ -37,8 +37,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"
-ORANGE = "#D55E00"
-BLUE = "#0072B2"
+OCHRE = "#BD8233"  # imprint ochre - categorical contrast against BRAND green
+BLUE = "#4467A3"
 RED = "#D62728"
 GREEN = "#2CA02C"
 
@@ -79,7 +79,7 @@ anyplot_theme = theme(
     legend_title=element_text(color=INK, size=16),
 )
 
-color_map = {"MACD": BLUE, "Signal": ORANGE}
+color_map = {"MACD": BLUE, "Signal": OCHRE}
 fill_map = {"positive": GREEN, "negative": RED}
 
 plot = (

--- a/plots/indicator-sma/implementations/python/plotnine.py
+++ b/plots/indicator-sma/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
-GOLDEN_COLOR = "#AE3030"  # amber — Okabe-Ito position 5, "golden" signal
+GOLDEN_COLOR = "#DDCC77"  # imprint amber — "golden cross" semantic
 DEATH_COLOR = INK_SOFT  # muted gray — "death" signal, theme-adaptive
 
 # Data — bull market (days 1–150) followed by bear market (days 150–300),

--- a/plots/indicator-sma/implementations/python/plotnine.py
+++ b/plots/indicator-sma/implementations/python/plotnine.py
@@ -31,8 +31,8 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
-GOLDEN_COLOR = "#E69F00"  # amber — Okabe-Ito position 5, "golden" signal
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
+GOLDEN_COLOR = "#AE3030"  # amber — Okabe-Ito position 5, "golden" signal
 DEATH_COLOR = INK_SOFT  # muted gray — "death" signal, theme-adaptive
 
 # Data — bull market (days 1–150) followed by bear market (days 150–300),
@@ -71,7 +71,7 @@ df_long["series"] = df_long["series"].map(series_labels)
 series_order = ["Price", "SMA 20", "SMA 50", "SMA 200"]
 df_long["series"] = pd.Categorical(df_long["series"], categories=series_order, ordered=True)
 
-colors = {"Price": OKABE_ITO[0], "SMA 20": OKABE_ITO[1], "SMA 50": OKABE_ITO[2], "SMA 200": OKABE_ITO[3]}
+colors = {"Price": IMPRINT[0], "SMA 20": IMPRINT[1], "SMA 50": IMPRINT[2], "SMA 200": IMPRINT[3]}
 
 # Separate data to draw SMAs behind price line at different thicknesses
 price_data = df_long[df_long["series"] == "Price"]

--- a/plots/kagi-basic/implementations/python/plotnine.py
+++ b/plots/kagi-basic/implementations/python/plotnine.py
@@ -32,9 +32,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-# Okabe-Ito palette (green for yang/bullish, orange-red for yin/bearish)
+# imprint semantic anchors (green for yang/bullish, red for yin/bearish)
 YANG_COLOR = "#009E73"
-YIN_COLOR = "#D55E00"
+YIN_COLOR = "#AE3030"
 
 # Generate synthetic stock price data
 np.random.seed(42)

--- a/plots/learning-curve-basic/implementations/python/plotnine.py
+++ b/plots/learning-curve-basic/implementations/python/plotnine.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Underfitting scenario with different seed and pattern
 np.random.seed(123)
@@ -75,7 +75,7 @@ df_val = pd.DataFrame(
 df = pd.concat([df_train, df_val], ignore_index=True)
 
 # Colors: Okabe-Ito brand green for training, second color for validation
-colors = {"Training Score": OKABE_ITO[0], "Validation Score": OKABE_ITO[1]}
+colors = {"Training Score": IMPRINT[0], "Validation Score": IMPRINT[1]}
 
 # Custom theme
 anyplot_theme = theme(

--- a/plots/line-annotated-events/implementations/python/plotnine.py
+++ b/plots/line-annotated-events/implementations/python/plotnine.py
@@ -62,8 +62,8 @@ events["y_pos"] = y_min + events["y_offset"] * y_range
 plot = (
     ggplot(df, aes(x="date", y="value"))
     + geom_line(color="#009E73", size=1.2, alpha=0.9)
-    + geom_vline(aes(xintercept="event_date"), data=events, color="#D55E00", linetype="dashed", size=1.0, alpha=0.8)
-    + geom_point(aes(x="event_date", y="y_pos"), data=events, color="#D55E00", size=4, shape="D")
+    + geom_vline(aes(xintercept="event_date"), data=events, color="#C475FD", linetype="dashed", size=1.0, alpha=0.8)
+    + geom_point(aes(x="event_date", y="y_pos"), data=events, color="#C475FD", size=4, shape="D")
     + geom_text(
         aes(x="event_date", y="y_pos", label="event_label"),
         data=events,

--- a/plots/line-loss-training/implementations/python/plotnine.py
+++ b/plots/line-loss-training/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 TRAINING_COLOR = "#009E73"  # bluish green
-VALIDATION_COLOR = "#D55E00"  # vermillion
+VALIDATION_COLOR = "#C475FD"  # vermillion
 
 # Data - Simulated training history with typical loss curve behavior
 np.random.seed(42)

--- a/plots/line-markers/implementations/python/plotnine.py
+++ b/plots/line-markers/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data: Monthly temperature readings from two weather stations
 np.random.seed(42)
@@ -77,7 +77,7 @@ plot = (
     ggplot(df, aes(x="Month_Num", y="Temperature", color="Station", shape="Station"))
     + geom_line(size=1.5, alpha=0.85)
     + geom_point(size=5, alpha=0.9)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + scale_shape_manual(values=["o", "s"])
     + labs(
         x="Month",

--- a/plots/line-multi/implementations/python/plotnine.py
+++ b/plots/line-multi/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Monthly sales for 4 product lines over 12 months
 np.random.seed(42)
@@ -62,10 +62,10 @@ df["Product"] = pd.Categorical(
 
 # Map Okabe-Ito colors to products
 color_map = {
-    "Electronics": OKABE_ITO[0],
-    "Clothing": OKABE_ITO[1],
-    "Furniture": OKABE_ITO[2],
-    "Accessories": OKABE_ITO[3],
+    "Electronics": IMPRINT[0],
+    "Clothing": IMPRINT[1],
+    "Furniture": IMPRINT[2],
+    "Accessories": IMPRINT[3],
 }
 
 # Create plot

--- a/plots/line-stock-comparison/implementations/python/plotnine.py
+++ b/plots/line-stock-comparison/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -77,7 +77,7 @@ plot = (
     + geom_ribbon(
         data=spy_ribbon_df,
         mapping=aes(x="date", ymin="ymin", ymax="ymax"),
-        fill=ANYPLOT_PALETTE[3],
+        fill=IMPRINT[3],
         alpha=0.08,
         inherit_aes=False,
     )
@@ -86,7 +86,7 @@ plot = (
     + geom_line(data=spy_df, size=1.6)
     + geom_point(data=last_df, size=2.5, show_legend=False)
     + geom_text(data=last_df, mapping=aes(x="label_date", label="label"), size=7, ha="left", show_legend=False)
-    + scale_color_manual(values=ANYPLOT_PALETTE)
+    + scale_color_manual(values=IMPRINT)
     + scale_x_date(date_labels="%b '%y", date_breaks="2 months", limits=[dates[0], x_max])
     + labs(
         x="Date",

--- a/plots/line-styled/implementations/python/plotnine.py
+++ b/plots/line-styled/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - quarterly product performance over 3 years
 np.random.seed(42)
@@ -56,10 +56,10 @@ df = pd.DataFrame(
 # Define line styles and colors using Okabe-Ito palette
 linetype_values = {"Product A": "solid", "Product B": "dashed", "Product C": "dotted", "Product D": "dashdot"}
 color_values = {
-    "Product A": OKABE_ITO[0],
-    "Product B": OKABE_ITO[1],
-    "Product C": OKABE_ITO[2],
-    "Product D": OKABE_ITO[3],
+    "Product A": IMPRINT[0],
+    "Product B": IMPRINT[1],
+    "Product C": IMPRINT[2],
+    "Product D": IMPRINT[3],
 }
 
 # Theme-adaptive styling

--- a/plots/line-timeseries-rolling/implementations/python/plotnine.py
+++ b/plots/line-timeseries-rolling/implementations/python/plotnine.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00"]  # brand green, vermillion
+IMPRINT = ["#009E73", "#C475FD"]  # brand green, vermillion
 
 # Data - Daily temperature readings with 7-day rolling average
 np.random.seed(42)
@@ -60,7 +60,7 @@ df_long["series"] = pd.Categorical(
 plot = (
     pn.ggplot(df_long, pn.aes(x="date", y="value", color="series", alpha="series", size="series"))
     + pn.geom_line()
-    + pn.scale_color_manual(values={"Daily Temperature": OKABE_ITO[0], "7-Day Rolling Average": OKABE_ITO[1]})
+    + pn.scale_color_manual(values={"Daily Temperature": IMPRINT[0], "7-Day Rolling Average": IMPRINT[1]})
     + pn.scale_alpha_manual(values={"Daily Temperature": 0.5, "7-Day Rolling Average": 1.0})
     + pn.scale_size_manual(values={"Daily Temperature": 0.8, "7-Day Rolling Average": 2.0})
     + pn.guides(alpha="none", size="none")

--- a/plots/logistic-regression/implementations/python/plotnine.py
+++ b/plots/logistic-regression/implementations/python/plotnine.py
@@ -34,10 +34,10 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette
-FAIL_COLOR = "#D55E00"  # Okabe-Ito position 2
-PASS_COLOR = "#009E73"  # Okabe-Ito position 1
-CURVE_COLOR = "#0072B2"  # Okabe-Ito position 3
+# imprint semantic anchors
+FAIL_COLOR = "#AE3030"  # imprint red - fail
+PASS_COLOR = "#009E73"  # imprint green - pass
+CURVE_COLOR = "#4467A3"  # imprint blue - regression curve
 
 # Data - Exam score vs Pass/Fail outcome
 np.random.seed(42)

--- a/plots/lollipop-grouped/implementations/python/plotnine.py
+++ b/plots/lollipop-grouped/implementations/python/plotnine.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1, 2, 3)
-COLORS = ["#009E73", "#D55E00", "#0072B2"]
+COLORS = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product line across regions
 np.random.seed(42)

--- a/plots/manhattan-gwas/implementations/python/plotnine.py
+++ b/plots/manhattan-gwas/implementations/python/plotnine.py
@@ -156,7 +156,7 @@ plot = (
     + geom_point(size=1.5, alpha=0.7)
     + geom_hline(yintercept=genome_wide_threshold, linetype="dashed", color="#E31A1C", size=1)
     + geom_hline(yintercept=suggestive_threshold, linetype="dotted", color="#FF7F00", size=0.8)
-    + scale_color_manual(values={"odd": "#0072B2", "even": "#D55E00"})
+    + scale_color_manual(values={"odd": "#4467A3", "even": "#C475FD"})
     + scale_x_continuous(breaks=chr_ticks, labels=chr_labels)
     + scale_y_continuous(limits=(0, max(df["neg_log_p"]) * 1.05))
     + labs(x="Chromosome", y="-log₁₀(p-value)", title="manhattan-gwas · plotnine · anyplot.ai")

--- a/plots/map-drilldown-geographic/implementations/python/plotnine.py
+++ b/plots/map-drilldown-geographic/implementations/python/plotnine.py
@@ -302,7 +302,7 @@ plot = (
         aes(x="lon", y="lat", group="state", fill="value"), data=df_states, color=PAGE_BG, size=1.5, alpha=0.92
     )
     + geom_polygon(aes(x="lon", y="lat", group="state"), data=df_top3, color="#99B314", fill="none", size=2.5)
-    + geom_polygon(aes(x="lon", y="lat", group="state"), data=df_bottom3, color="#B71D27", fill="none", size=2.5)
+    + geom_polygon(aes(x="lon", y="lat", group="state"), data=df_bottom3, color="#AE3030", fill="none", size=2.5)
     + geom_text(
         aes(x="lon", y="lat", label="label"),
         data=df_labels,
@@ -328,7 +328,7 @@ plot = (
     + coord_fixed(ratio=1.3)
     + annotate("text", x=-125, y=50, label=breadcrumb_text, size=9, color=INK, fontweight="bold", ha="left")
     + annotate("text", x=-74, y=25.5, label="▲ Top 3", size=8, color="#99B314", ha="right", fontweight="bold")
-    + annotate("text", x=-74, y=23.5, label="▼ Bottom 3", size=8, color="#B71D27", ha="right", fontweight="bold")
+    + annotate("text", x=-74, y=23.5, label="▼ Bottom 3", size=8, color="#AE3030", ha="right", fontweight="bold")
     + labs(title="map-drilldown-geographic · python · plotnine · anyplot.ai", x="Longitude", y="Latitude")
     + theme(
         figure_size=(8, 4.5),

--- a/plots/map-marker-clustered/implementations/python/plotnine.py
+++ b/plots/map-marker-clustered/implementations/python/plotnine.py
@@ -41,7 +41,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # anyplot palette — first series is always #009E73
-CATEGORY_COLORS = {"Retail": "#009E73", "Restaurant": "#9418DB", "Service": "#B71D27", "Entertainment": "#16B8F3"}
+CATEGORY_COLORS = {"Retail": "#009E73", "Restaurant": "#C475FD", "Service": "#AE3030", "Entertainment": "#4467A3"}
 
 # Data: US West Coast retail store locations
 np.random.seed(42)
@@ -58,9 +58,9 @@ city_centers = {
 category_types = ["Retail", "Restaurant", "Service", "Entertainment"]
 city_weights = {
     "Seattle": [0.70, 0.10, 0.10, 0.10],  # Retail  → #009E73
-    "Portland": [0.10, 0.70, 0.10, 0.10],  # Restaurant → #9418DB
-    "San Francisco": [0.10, 0.10, 0.70, 0.10],  # Service → #B71D27
-    "Los Angeles": [0.10, 0.10, 0.10, 0.70],  # Entertainment → #16B8F3
+    "Portland": [0.10, 0.70, 0.10, 0.10],  # Restaurant → #C475FD
+    "San Francisco": [0.10, 0.10, 0.70, 0.10],  # Service → #AE3030
+    "Los Angeles": [0.10, 0.10, 0.10, 0.70],  # Entertainment → #4467A3
     "San Diego": [0.70, 0.10, 0.10, 0.10],  # Retail → #009E73 (far from Seattle)
 }
 

--- a/plots/mosaic-categorical/implementations/python/plotnine.py
+++ b/plots/mosaic-categorical/implementations/python/plotnine.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Titanic survival data by passenger class
 data = {
@@ -98,7 +98,7 @@ rate_labels = pd.DataFrame(
 )
 
 # Okabe-Ito: green → Survived (first series), vermillion → Did Not Survive
-colors = {"Survived": OKABE_ITO[0], "Did Not Survive": OKABE_ITO[1]}
+colors = {"Survived": IMPRINT[0], "Did Not Survive": IMPRINT[1]}
 
 # scale_x_continuous / scale_y_continuous give explicit domain + expansion control —
 # avoids clipping the below-axis class and rate labels

--- a/plots/network-basic/implementations/python/plotnine.py
+++ b/plots/network-basic/implementations/python/plotnine.py
@@ -58,7 +58,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: social network with 20 people in 4 communities
 np.random.seed(42)
@@ -181,7 +181,7 @@ edge_df = pd.DataFrame(
     ]
 )
 
-group_colors = {"Team A": OKABE_ITO[0], "Team B": OKABE_ITO[1], "Team C": OKABE_ITO[2], "Team D": OKABE_ITO[3]}
+group_colors = {"Team A": IMPRINT[0], "Team B": IMPRINT[1], "Team C": IMPRINT[2], "Team D": IMPRINT[3]}
 
 # Hub nodes for emphasis — top 20% by degree
 hub_threshold = node_df["degree"].quantile(0.8)

--- a/plots/network-bipartite/implementations/python/plotnine.py
+++ b/plots/network-bipartite/implementations/python/plotnine.py
@@ -41,7 +41,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 COLOR_GENE = "#009E73"  # Okabe-Ito position 1
-COLOR_DISEASE = "#0072B2"  # Okabe-Ito position 3
+COLOR_DISEASE = "#4467A3"  # Okabe-Ito position 3
 
 # Data: gene–disease association network in bioinformatics
 genes = ["BRCA1", "TP53", "PTEN", "EGFR", "KRAS", "PIK3CA", "APC", "RB1", "VHL", "CDKN2A", "MLH1", "ERBB2"]

--- a/plots/network-force-directed/implementations/python/plotnine.py
+++ b/plots/network-force-directed/implementations/python/plotnine.py
@@ -38,7 +38,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette — first series is always #009E73
 DEPARTMENT_NAMES = ["Engineering", "Design", "Marketing", "Sales"]
-DEPARTMENT_COLORS = {"Engineering": "#009E73", "Design": "#D55E00", "Marketing": "#0072B2", "Sales": "#CC79A7"}
+DEPARTMENT_COLORS = {"Engineering": "#009E73", "Design": "#C475FD", "Marketing": "#4467A3", "Sales": "#BD8233"}
 
 np.random.seed(42)
 

--- a/plots/network-hierarchical/implementations/python/plotnine.py
+++ b/plots/network-hierarchical/implementations/python/plotnine.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Software company organizational hierarchy (22 employees, 4 levels)
 nodes = [
@@ -120,10 +120,10 @@ level_names = {0: "Level 0: CEO", 1: "Level 1: VPs", 2: "Level 2: Directors", 3:
 
 # Map level names to Okabe-Ito colors
 level_colors = {
-    "Level 0: CEO": OKABE_ITO[0],
-    "Level 1: VPs": OKABE_ITO[1],
-    "Level 2: Directors": OKABE_ITO[2],
-    "Level 3: Team": OKABE_ITO[3],
+    "Level 0: CEO": IMPRINT[0],
+    "Level 1: VPs": IMPRINT[1],
+    "Level 2: Directors": IMPRINT[2],
+    "Level 3: Team": IMPRINT[3],
 }
 
 # Node sizes by level

--- a/plots/network-transport-static/implementations/python/plotnine.py
+++ b/plots/network-transport-static/implementations/python/plotnine.py
@@ -135,9 +135,9 @@ routes["edge_label"] = routes["route_id"] + " | " + routes["dep"] + "→" + rout
 
 # Color palette for route types
 route_colors = {
-    "RE": "#0072B2",  # Blue - Express
-    "RB": "#E69F00",  # Orange - Regional
-    "AE": "#D55E00",  # Vermillion - Airport
+    "RE": "#4467A3",  # Blue - Express
+    "RB": "#AE3030",  # Orange - Regional
+    "AE": "#C475FD",  # Vermillion - Airport
     "S": "#009E73",  # Green - Local (first series brand color)
 }
 

--- a/plots/network-weighted/implementations/python/plotnine.py
+++ b/plots/network-weighted/implementations/python/plotnine.py
@@ -138,7 +138,7 @@ plot = (
     ggplot()
     # Draw edges with thickness mapped to trade weight
     + geom_segment(
-        data=edges, mapping=aes(x="x", y="y", xend="xend", yend="yend", size="weight"), color="#0072B2", alpha=0.55
+        data=edges, mapping=aes(x="x", y="y", xend="xend", yend="yend", size="weight"), color="#4467A3", alpha=0.55
     )
     # Draw nodes with size mapped to weighted degree - larger for better visibility
     + geom_point(

--- a/plots/ohlc-bar/implementations/python/plotnine.py
+++ b/plots/ohlc-bar/implementations/python/plotnine.py
@@ -31,9 +31,9 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito palette for up/down distinction
-UP_COLOR = "#009E73"  # Position 1: bluish green
-DOWN_COLOR = "#D55E00"  # Position 2: vermillion
+# imprint semantic anchors for up/down distinction
+UP_COLOR = "#009E73"  # green - up bars
+DOWN_COLOR = "#AE3030"  # red - down bars
 
 # Data - Generate 50 days of realistic stock OHLC data
 np.random.seed(42)

--- a/plots/parallel-basic/implementations/python/plotnine.py
+++ b/plots/parallel-basic/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data — synthetic iris-like measurements, 50 samples per species (balanced)
 np.random.seed(42)
@@ -68,7 +68,7 @@ df_long["dim_num"] = df_long["dimension"].map(dim_map)
 
 # Okabe-Ito colors — first series always #009E73
 species_order = ["Setosa", "Versicolor", "Virginica"]
-colors = {sp: OKABE_ITO[i] for i, sp in enumerate(species_order)}
+colors = {sp: IMPRINT[i] for i, sp in enumerate(species_order)}
 
 # Plot
 plot = (

--- a/plots/parallel-categories-basic/implementations/python/plotnine.py
+++ b/plots/parallel-categories-basic/implementations/python/plotnine.py
@@ -37,14 +37,14 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for categorical data
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # Brand green - first series
-    "#D55E00",  # Vermillion
-    "#0072B2",  # Blue
-    "#CC79A7",  # Reddish purple
-    "#E69F00",  # Orange
-    "#56B4E9",  # Sky blue
-    "#F0E442",  # Yellow
+    "#C475FD",  # Vermillion
+    "#4467A3",  # Blue
+    "#BD8233",  # Reddish purple
+    "#AE3030",  # Orange
+    "#2ABCCD",  # Sky blue
+    "#954477",  # Yellow
 ]
 
 # Data - Customer journey data with multiple categorical dimensions
@@ -103,8 +103,8 @@ dimensions = [
 
 # Color by outcome - using Okabe-Ito palette
 outcome_colors = {
-    "Purchased": OKABE_ITO[0],  # Brand green
-    "Abandoned": OKABE_ITO[2],  # Blue
+    "Purchased": IMPRINT[0],  # Brand green
+    "Abandoned": IMPRINT[2],  # Blue
 }
 
 # Layout parameters

--- a/plots/parliament-basic/implementations/python/plotnine.py
+++ b/plots/parliament-basic/implementations/python/plotnine.py
@@ -32,13 +32,13 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
-    "#E69F00",  # orange
-    "#56B4E9",  # sky blue
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
+    "#AE3030",  # orange
+    "#2ABCCD",  # sky blue
 ]
 
 # Data - fictional parliament with neutral party names
@@ -53,7 +53,7 @@ parties = [
 
 # Assign Okabe-Ito colors to parties
 for i, party in enumerate(parties):
-    party["color"] = OKABE_ITO[i % len(OKABE_ITO)]
+    party["color"] = IMPRINT[i % len(IMPRINT)]
 
 total_seats = sum(p["seats"] for p in parties)
 

--- a/plots/pdp-basic/implementations/python/plotnine.py
+++ b/plots/pdp-basic/implementations/python/plotnine.py
@@ -33,7 +33,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2 for rug
+ACCENT = "#C475FD"  # Okabe-Ito position 2 for rug
 
 # Data - Train a model and compute partial dependence
 np.random.seed(42)

--- a/plots/point-and-figure-basic/implementations/python/plotnine.py
+++ b/plots/point-and-figure-basic/implementations/python/plotnine.py
@@ -39,8 +39,8 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-X_COLOR = "#009E73"  # Okabe-Ito position 1 - rising columns
-O_COLOR = "#D55E00"  # Okabe-Ito position 2 - falling columns (colorblind-safe vs pure red)
+X_COLOR = "#009E73"  # imprint green - rising columns
+O_COLOR = "#AE3030"  # imprint red - falling columns
 
 # Data
 np.random.seed(42)

--- a/plots/polar-bar/implementations/python/plotnine.py
+++ b/plots/polar-bar/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Wind direction frequencies (8 compass directions)
 directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
@@ -116,14 +116,14 @@ radius_label_df = pd.DataFrame(radius_labels)
 
 # Color palette - first direction uses brand green, rest alternate through Okabe-Ito
 colors = {
-    "N": OKABE_ITO[0],
-    "NE": OKABE_ITO[1],
-    "E": OKABE_ITO[2],
-    "SE": OKABE_ITO[3],
-    "S": OKABE_ITO[4],
-    "SW": OKABE_ITO[5],
-    "W": OKABE_ITO[6],
-    "NW": OKABE_ITO[0],
+    "N": IMPRINT[0],
+    "NE": IMPRINT[1],
+    "E": IMPRINT[2],
+    "SE": IMPRINT[3],
+    "S": IMPRINT[4],
+    "SW": IMPRINT[5],
+    "W": IMPRINT[6],
+    "NW": IMPRINT[0],
 }
 
 # Plot

--- a/plots/polar-line/implementations/python/plotnine.py
+++ b/plots/polar-line/implementations/python/plotnine.py
@@ -38,7 +38,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Hourly activity patterns for two weeks
 np.random.seed(42)
@@ -99,7 +99,7 @@ plot = (
     ggplot(df, aes(x="x", y="y", color="week", order="order"))
     + geom_path(size=1.5, alpha=0.8)
     + geom_point(size=3.5, alpha=0.7)
-    + scale_color_manual(values=OKABE_ITO[:2])
+    + scale_color_manual(values=IMPRINT[:2])
     + xlim(-80, 80)
     + ylim(-80, 80)
     + labs(title="polar-line · plotnine · anyplot.ai", x="", y="", color="Period")

--- a/plots/polar-scatter/implementations/python/plotnine.py
+++ b/plots/polar-scatter/implementations/python/plotnine.py
@@ -47,7 +47,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Wind measurements with prevailing directions
 np.random.seed(42)
@@ -121,9 +121,9 @@ radius_label_df = pd.DataFrame(radius_labels)
 
 # Color palette for time of day (Okabe-Ito colors)
 colors = {
-    "Morning": OKABE_ITO[0],  # #009E73 brand green
-    "Afternoon": OKABE_ITO[1],  # #D55E00 vermillion
-    "Evening": OKABE_ITO[2],  # #0072B2 blue
+    "Morning": IMPRINT[0],  # #009E73 brand green
+    "Afternoon": IMPRINT[1],  # #C475FD vermillion
+    "Evening": IMPRINT[2],  # #4467A3 blue
 }
 
 # Plot

--- a/plots/precision-recall/implementations/python/plotnine.py
+++ b/plots/precision-recall/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2 for baseline
+ACCENT = "#C475FD"  # Okabe-Ito position 2 for baseline
 
 # Data - Simulated binary classification results
 np.random.seed(42)

--- a/plots/pyramid-basic/implementations/python/plotnine.py
+++ b/plots/pyramid-basic/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data
 age_groups = ["0-9", "10-19", "20-29", "30-39", "40-49", "50-59", "60-69", "70-79", "80+"]
@@ -86,7 +86,7 @@ plot = (
     + geom_text(
         data=df_peak, mapping=aes(x="age_group", y="label_y", label="label"), color=INK_SOFT, size=13, inherit_aes=False
     )
-    + scale_fill_manual(values={"Male": OKABE_ITO[0], "Female": OKABE_ITO[1]})
+    + scale_fill_manual(values={"Male": IMPRINT[0], "Female": IMPRINT[1]})
     + scale_y_continuous(labels=lambda breaks: [f"{abs(int(b)):,}" for b in breaks])
     + labs(
         x="Age Group",

--- a/plots/radar-basic/implementations/python/plotnine.py
+++ b/plots/radar-basic/implementations/python/plotnine.py
@@ -41,7 +41,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#C8C8C0" if THEME == "light" else "#3A3A35"
 
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data — employee performance metrics
 categories = ["Technical", "Communication", "Leadership", "Creativity", "Teamwork", "Problem Solving"]
@@ -103,8 +103,8 @@ plot = (
     + geom_line(aes(x="x", y="y", color="series", group="series"), data=df, size=1.5)
     + geom_point(aes(x="x", y="y", color="series"), data=df[df["order"] < n], size=5)
     + geom_text(aes(x="x", y="y", label="label"), data=label_df, size=16, color=INK)
-    + scale_fill_manual(values=OKABE_ITO)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
+    + scale_color_manual(values=IMPRINT)
     + scale_x_continuous(limits=(-150, 150))
     + scale_y_continuous(limits=(-150, 150))
     + labs(title="radar-basic · plotnine · anyplot.ai", fill="Employee", color="Employee")

--- a/plots/radar-multi/implementations/python/plotnine.py
+++ b/plots/radar-multi/implementations/python/plotnine.py
@@ -51,7 +51,7 @@ products = {
 }
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Create angles for each category (evenly spaced around circle)
 angles = [i * 2 * math.pi / n for i in range(n)]
@@ -121,8 +121,8 @@ plot = (
     # Category labels
     + geom_text(aes(x="x", y="y", label="label"), data=label_df, size=5, color=INK)
     # Apply Okabe-Ito colors
-    + scale_fill_manual(values=OKABE_ITO)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
+    + scale_color_manual(values=IMPRINT)
     # Axis scaling
     + scale_x_continuous(limits=(-150, 150))
     + scale_y_continuous(limits=(-150, 150))

--- a/plots/range-interval/implementations/python/plotnine.py
+++ b/plots/range-interval/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#E69F00"  # Okabe-Ito position 5
+ACCENT = "#AE3030"  # Okabe-Ito position 5
 
 # Data - Monthly temperature ranges (high/low) for a weather station
 months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]

--- a/plots/renko-basic/implementations/python/plotnine.py
+++ b/plots/renko-basic/implementations/python/plotnine.py
@@ -35,9 +35,9 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-# Okabe-Ito colors for direction
-BULLISH = "#009E73"  # Position 1 - brand green
-BEARISH = "#D55E00"  # Position 2 - vermillion
+# imprint semantic anchors for direction
+BULLISH = "#009E73"  # green - up bricks
+BEARISH = "#AE3030"  # red - down bricks
 
 # Data - Generate stock price data
 np.random.seed(42)

--- a/plots/residual-plot/implementations/python/plotnine.py
+++ b/plots/residual-plot/implementations/python/plotnine.py
@@ -32,10 +32,10 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # Brand green (normal points)
-    "#D55E00",  # Vermillion (outliers)
-    "#0072B2",  # Blue (LOWESS line)
+    "#C475FD",  # Vermillion (outliers)
+    "#4467A3",  # Blue (LOWESS line)
 ]
 
 # Data - Generate realistic regression data with better labels
@@ -92,8 +92,8 @@ plot = (
     + geom_hline(yintercept=2 * std_resid, color=INK_SOFT, size=0.8, linetype="dashed", alpha=0.5)
     + geom_hline(yintercept=-2 * std_resid, color=INK_SOFT, size=0.8, linetype="dashed", alpha=0.5)
     + geom_point(size=4, alpha=0.7)
-    + geom_smooth(aes(group=1), method="lowess", color=OKABE_ITO[2], size=1.5, se=False, span=0.5)
-    + scale_color_manual(values={"Normal": OKABE_ITO[0], "Outlier": OKABE_ITO[1]}, name="Point Type")
+    + geom_smooth(aes(group=1), method="lowess", color=IMPRINT[2], size=1.5, se=False, span=0.5)
+    + scale_color_manual(values={"Normal": IMPRINT[0], "Outlier": IMPRINT[1]}, name="Point Type")
     + labs(x="Fitted Values ($)", y="Residuals ($)", title="residual-plot · plotnine · anyplot.ai")
     + theme_minimal()
     + anyplot_theme

--- a/plots/roc-curve/implementations/python/plotnine.py
+++ b/plots/roc-curve/implementations/python/plotnine.py
@@ -41,7 +41,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Simulate ROC curve from good and moderate classifiers
 np.random.seed(42)
@@ -94,7 +94,7 @@ plot = (
     ggplot(df, aes(x="fpr", y="tpr", color="Model"))
     + geom_abline(intercept=0, slope=1, linetype="dashed", color=INK_SOFT, size=1, alpha=0.5)
     + geom_line(size=2.5, alpha=0.9)
-    + scale_color_manual(values=OKABE_ITO[:2])
+    + scale_color_manual(values=IMPRINT[:2])
     + scale_x_continuous(limits=(0, 1), breaks=np.arange(0, 1.1, 0.2))
     + scale_y_continuous(limits=(0, 1), breaks=np.arange(0, 1.1, 0.2))
     + coord_fixed(ratio=1)

--- a/plots/sankey-basic/implementations/python/plotnine.py
+++ b/plots/sankey-basic/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Energy flow from sources to sectors
 flows = pd.DataFrame(
@@ -100,7 +100,7 @@ for tgt in targets:
     current_y = current_y - height - node_gap
 
 # Okabe-Ito colors for sources; theme-adaptive neutral for targets
-source_colors_map = {"Coal": OKABE_ITO[0], "Gas": OKABE_ITO[1], "Nuclear": OKABE_ITO[2], "Renewables": OKABE_ITO[3]}
+source_colors_map = {"Coal": IMPRINT[0], "Gas": IMPRINT[1], "Nuclear": IMPRINT[2], "Renewables": IMPRINT[3]}
 target_colors_map = {"Industrial": INK_SOFT, "Commercial": INK_SOFT, "Residential": INK_SOFT}
 
 # Build node rectangles dataframe

--- a/plots/scatter-animated-controls/implementations/python/plotnine.py
+++ b/plots/scatter-animated-controls/implementations/python/plotnine.py
@@ -36,7 +36,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 REFERENCE_LINE = "#CCB8B0" if THEME == "light" else "#3A3935"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 np.random.seed(42)
 
@@ -87,7 +87,7 @@ plot = (
     + geom_hline(aes(yintercept=median_life), color=REFERENCE_LINE, size=0.5, alpha=0.4, linetype="dashed")
     + geom_path(aes(group="entity"), color=INK_SOFT, size=0.3, alpha=0.15, linetype="solid")
     + geom_point(alpha=0.7, stroke=0.8)
-    + scale_color_manual(values=OKABE_ITO, name="Region")
+    + scale_color_manual(values=IMPRINT, name="Region")
     + scale_size_continuous(range=(2.5, 9), name="Population\n(millions)")
     + facet_wrap("~year", nrow=2, ncol=3)
     + labs(

--- a/plots/scatter-categorical/implementations/python/plotnine.py
+++ b/plots/scatter-categorical/implementations/python/plotnine.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (canonical order)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -69,7 +69,7 @@ df = pd.DataFrame(
 plot = (
     ggplot(df, aes(x="Temperature (°C)", y="Growth Rate (cm/week)", color="Plant Species"))
     + geom_point(size=4, alpha=0.7)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(
         x="Temperature (°C)",
         y="Growth Rate (cm/week)",

--- a/plots/scatter-embedding/implementations/python/plotnine.py
+++ b/plots/scatter-embedding/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data
 np.random.seed(42)
@@ -72,7 +72,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="tsne_1", y="tsne_2", color="Cluster"))
     + geom_point(size=2.5, alpha=0.7)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(
         title="scatter-embedding · plotnine · anyplot.ai",
         subtitle="t-SNE (perplexity=30) · 1200 points · 6 clusters",

--- a/plots/scatter-map-geographic/implementations/python/plotnine.py
+++ b/plots/scatter-map-geographic/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ BASEMAP_EDGE = "#C0B5A8" if THEME == "light" else "#4A4945"
 GRID_COLOR = INK if THEME == "light" else INK
 ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: Major world cities with population and region
 cities_data = {
@@ -267,12 +267,12 @@ df_continents = pd.DataFrame(continents)
 
 # Define region colors using Okabe-Ito palette
 region_colors = {
-    "Africa": OKABE_ITO[0],
-    "Asia": OKABE_ITO[1],
-    "Europe": OKABE_ITO[2],
-    "N. America": OKABE_ITO[3],
-    "Oceania": OKABE_ITO[4],
-    "S. America": OKABE_ITO[5],
+    "Africa": IMPRINT[0],
+    "Asia": IMPRINT[1],
+    "Europe": IMPRINT[2],
+    "N. America": IMPRINT[3],
+    "Oceania": IMPRINT[4],
+    "S. America": IMPRINT[5],
 }
 
 # Create the geographic scatter map

--- a/plots/scatter-marginal/implementations/python/plotnine.py
+++ b/plots/scatter-marginal/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 SCATTER_COLOR = "#009E73"  # Brand green (position 1)
-MARGINAL_COLOR = "#D55E00"  # Vermillion (position 2)
+MARGINAL_COLOR = "#C475FD"  # Vermillion (position 2)
 
 # Data - Bivariate data with correlation
 np.random.seed(42)

--- a/plots/scatter-matrix-interactive/implementations/python/plotnine.py
+++ b/plots/scatter-matrix-interactive/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette (first series #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Iris dataset for multivariate analysis
 iris = load_iris()
@@ -103,8 +103,8 @@ plot = (
     + geom_point(data=scatter_df, mapping=aes(y="y", color="Species"), size=3.5, alpha=0.7)
     + geom_ribbon(data=density_df, mapping=aes(ymin="ymin", ymax="ymax", fill="Species"), alpha=0.5)
     + facet_grid("var_y ~ var_x", scales="free")
-    + scale_color_manual(values=OKABE_ITO)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
+    + scale_fill_manual(values=IMPRINT)
     + labs(title="scatter-matrix-interactive · python · plotnine · anyplot.ai", x="", y="")
     + theme_minimal()
     + theme(

--- a/plots/scatter-matrix/implementations/python/plotnine.py
+++ b/plots/scatter-matrix/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris-like data for multivariate visualization
 np.random.seed(42)
@@ -116,8 +116,8 @@ plot = (
     + geom_point(size=3.5, alpha=0.7)
     + geom_density(aes(x="x", fill="Species", color="Species"), data=diag_df, alpha=0.4)
     + facet_grid("var_y ~ var_x", scales="free", labeller="label_value")
-    + scale_color_manual(values=OKABE_ITO)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
+    + scale_fill_manual(values=IMPRINT)
     + labs(title="scatter-matrix · plotnine · anyplot.ai", x="", y="")
     + theme_minimal()
     + anyplot_theme

--- a/plots/scatter-regression-linear/implementations/python/plotnine.py
+++ b/plots/scatter-regression-linear/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First categorical series
-ACCENT = "#D55E00"  # Second series (for regression line)
+ACCENT = "#C475FD"  # Second series (for regression line)
 
 # Data - Study hours vs exam score relationship
 np.random.seed(42)

--- a/plots/scatter-regression-lowess/implementations/python/plotnine.py
+++ b/plots/scatter-regression-lowess/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Data - create complex non-linear relationship (crop yield vs temperature)
 np.random.seed(42)

--- a/plots/scatter-regression-polynomial/implementations/python/plotnine.py
+++ b/plots/scatter-regression-polynomial/implementations/python/plotnine.py
@@ -56,7 +56,7 @@ plot = (
     ggplot(df, aes(x="temperature", y="energy"))
     + geom_point(size=4, alpha=0.65, color=BRAND)
     + geom_smooth(
-        method="lm", formula="y ~ I(x) + I(x**2)", se=True, color="#D55E00", fill="#E69F00", alpha=0.25, size=2
+        method="lm", formula="y ~ I(x) + I(x**2)", se=True, color="#C475FD", fill="#AE3030", alpha=0.25, size=2
     )
     + annotate("text", x=38, y=115, label=annotation_text, ha="right", va="top", size=17, color=INK)
     + labs(

--- a/plots/scatter-text/implementations/python/plotnine.py
+++ b/plots/scatter-text/implementations/python/plotnine.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (categorical data only)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Simulated 2D projection of programming language embeddings
 np.random.seed(42)
@@ -63,11 +63,11 @@ df["y"] = df["y"] + np.random.normal(0, 0.1, len(df))
 
 # Map categories to Okabe-Ito colors
 category_colors = {
-    "General": OKABE_ITO[0],
-    "Systems": OKABE_ITO[1],
-    "Functional": OKABE_ITO[2],
-    "Web": OKABE_ITO[3],
-    "Data": OKABE_ITO[4],
+    "General": IMPRINT[0],
+    "Systems": IMPRINT[1],
+    "Functional": IMPRINT[2],
+    "Web": IMPRINT[3],
+    "Data": IMPRINT[4],
 }
 
 # Plot

--- a/plots/shap-waterfall/implementations/python/plotnine.py
+++ b/plots/shap-waterfall/implementations/python/plotnine.py
@@ -46,8 +46,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#C8C7C0" if THEME == "light" else "#2E2E2B"
 
-COLOR_POS = "#D55E00"  # Okabe-Ito vermillion — positive SHAP contributions
-COLOR_NEG = "#0072B2"  # Okabe-Ito blue — negative SHAP contributions
+COLOR_POS = "#AE3030"  # imprint red — positive SHAP contributions
+COLOR_NEG = "#4467A3"  # imprint blue — negative SHAP contributions
 
 # Data: credit scoring model — explaining a single loan approval prediction
 np.random.seed(42)

--- a/plots/silhouette-basic/implementations/python/plotnine.py
+++ b/plots/silhouette-basic/implementations/python/plotnine.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Clustering iris dataset into 3 groups
 np.random.seed(42)
@@ -107,7 +107,7 @@ plot = (
     + geom_vline(xintercept=avg_silhouette, color=INK_SOFT, linetype="dashed", size=1.2, alpha=0.6)
     + geom_text(aes(x="x", y="y", label="label"), data=annotation_df, size=12, ha="right", color=INK_SOFT)
     + geom_text(aes(x="x", y="y", label="label"), data=avg_label_df, size=11, ha="left", color=INK_SOFT)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(
         x="Silhouette Coefficient",
         y="Sample Index (sorted within cluster)",

--- a/plots/skewt-logp-atmospheric/implementations/python/plotnine.py
+++ b/plots/skewt-logp-atmospheric/implementations/python/plotnine.py
@@ -191,11 +191,11 @@ pressure_labels = [str(p) for p in pressure_breaks]
 LEGEND_ORDER = ["Temperature", "Dewpoint", "Isotherms (10°C)", "Dry Adiabats", "Moist Adiabats", "Mixing Ratios"]
 LINE_COLORS = {
     "Temperature": "#009E73",
-    "Dewpoint": "#D55E00",
-    "Isotherms (10°C)": "#0072B2",
-    "Dry Adiabats": "#CC79A7",
-    "Moist Adiabats": "#E69F00",
-    "Mixing Ratios": "#56B4E9",
+    "Dewpoint": "#C475FD",
+    "Isotherms (10°C)": "#4467A3",
+    "Dry Adiabats": "#BD8233",
+    "Moist Adiabats": "#AE3030",
+    "Mixing Ratios": "#2ABCCD",
 }
 LINE_STYLES = {
     "Temperature": "solid",
@@ -249,7 +249,7 @@ plot = (
         x=skew_transform(dewpoint_profile[np.argmin(np.abs(pressure_levels - 600))], 600) - 6,
         y=600,
         label="Td",
-        color="#D55E00",
+        color="#C475FD",
         size=12,
         fontweight="bold",
     )

--- a/plots/smith-chart-basic/implementations/python/plotnine.py
+++ b/plots/smith-chart-basic/implementations/python/plotnine.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data — Smith chart grid
 Z0 = 50
@@ -113,15 +113,15 @@ plot = (
     + geom_path(aes(x="x", y="y", group="grp"), data=reactance_df, color=INK_SOFT, size=0.4, alpha=0.4)
     + geom_path(aes(x="x", y="y"), data=boundary_df, color=INK, size=1.0)
     + geom_path(aes(x="x", y="y"), data=axis_df, color=INK_SOFT, size=0.5)
-    + geom_path(aes(x="x", y="y"), data=impedance_df, color=OKABE_ITO[0], size=1.5)
-    + geom_point(aes(x="x", y="y"), data=impedance_df, color=OKABE_ITO[0], size=2.5, alpha=0.65)
+    + geom_path(aes(x="x", y="y"), data=impedance_df, color=IMPRINT[0], size=1.5)
+    + geom_point(aes(x="x", y="y"), data=impedance_df, color=IMPRINT[0], size=2.5, alpha=0.65)
     + geom_segment(
-        aes(x="x", xend="xend", y="y", yend="yend"), data=arr_df, color=OKABE_ITO[0], size=2.0, arrow=arrow(length=0.10)
+        aes(x="x", xend="xend", y="y", yend="yend"), data=arr_df, color=IMPRINT[0], size=2.0, arrow=arrow(length=0.10)
     )
     + geom_text(aes(x="x_label", y="y_label", label="label"), data=labels_df, color=INK, size=9, fontweight="bold")
     + geom_text(aes(x="x", y="y", label="label"), data=r_labels_df, color=INK_MUTED, size=8)
-    + annotate("point", x=0, y=0, color=OKABE_ITO[1], size=4)
-    + annotate("text", x=0.15, y=-0.20, label="Z=Z₀", color=OKABE_ITO[1], size=9)
+    + annotate("point", x=0, y=0, color=IMPRINT[1], size=4)
+    + annotate("text", x=0.15, y=-0.20, label="Z=Z₀", color=IMPRINT[1], size=9)
     + coord_fixed(ratio=1, xlim=(-1.3, 1.3), ylim=(-1.3, 1.3))
     + scale_x_continuous(breaks=[])
     + scale_y_continuous(breaks=[])

--- a/plots/sn-curve-basic/implementations/python/plotnine.py
+++ b/plots/sn-curve-basic/implementations/python/plotnine.py
@@ -36,7 +36,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - S-N curve for steel specimen fatigue testing
 np.random.seed(42)
@@ -105,31 +105,31 @@ anyplot_theme = theme(
 plot = (
     ggplot()
     # ±2σ scatter band via geom_ribbon — idiomatic plotnine uncertainty visualization
-    + geom_ribbon(df_fit, aes(x="cycles", ymin="stress_lower", ymax="stress_upper"), fill=OKABE_ITO[0], alpha=0.12)
+    + geom_ribbon(df_fit, aes(x="cycles", ymin="stress_lower", ymax="stress_upper"), fill=IMPRINT[0], alpha=0.12)
     # Basquin fit line
-    + geom_line(df_fit, aes(x="cycles", y="stress"), color=OKABE_ITO[0], size=1.2, alpha=0.85)
+    + geom_line(df_fit, aes(x="cycles", y="stress"), color=IMPRINT[0], size=1.2, alpha=0.85)
     # Data points — shape mapped to type for runout vs failure distinction
-    + geom_point(df, aes(x="cycles", y="stress", shape="type"), color=OKABE_ITO[0], size=4.2, alpha=0.80)
+    + geom_point(df, aes(x="cycles", y="stress", shape="type"), color=IMPRINT[0], size=4.2, alpha=0.80)
     # geom_rug exposes marginal data density along both axes — distinctive plotnine feature
-    + geom_rug(df, aes(x="cycles", y="stress"), color=OKABE_ITO[0], alpha=0.35, size=0.5)
+    + geom_rug(df, aes(x="cycles", y="stress"), color=IMPRINT[0], alpha=0.35, size=0.5)
     # Reference lines with Okabe-Ito colors; endurance limit slightly thicker as focal point
-    + geom_hline(yintercept=ultimate_strength, linetype="dashed", color=OKABE_ITO[1], size=0.9, alpha=0.85)
-    + geom_hline(yintercept=yield_strength, linetype="dashed", color=OKABE_ITO[2], size=0.9, alpha=0.85)
-    + geom_hline(yintercept=endurance_limit, linetype="dashed", color=OKABE_ITO[3], size=1.2, alpha=0.90)
+    + geom_hline(yintercept=ultimate_strength, linetype="dashed", color=IMPRINT[1], size=0.9, alpha=0.85)
+    + geom_hline(yintercept=yield_strength, linetype="dashed", color=IMPRINT[2], size=0.9, alpha=0.85)
+    + geom_hline(yintercept=endurance_limit, linetype="dashed", color=IMPRINT[3], size=1.2, alpha=0.90)
     + annotate(
         "text",
         x=1e3,
         y=ultimate_strength + 20,
         label="Ultimate Strength (550 MPa)",
         size=10,
-        color=OKABE_ITO[1],
+        color=IMPRINT[1],
         ha="left",
     )
     + annotate(
-        "text", x=2e5, y=yield_strength + 20, label="Yield Strength (350 MPa)", size=10, color=OKABE_ITO[2], ha="left"
+        "text", x=2e5, y=yield_strength + 20, label="Yield Strength (350 MPa)", size=10, color=IMPRINT[2], ha="left"
     )
     + annotate(
-        "text", x=1e3, y=endurance_limit - 25, label="Endurance Limit (250 MPa)", size=10, color=OKABE_ITO[3], ha="left"
+        "text", x=1e3, y=endurance_limit - 25, label="Endurance Limit (250 MPa)", size=10, color=IMPRINT[3], ha="left"
     )
     # Logarithmic scales
     + scale_x_log10()

--- a/plots/span-basic/implementations/python/plotnine.py
+++ b/plots/span-basic/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Stock prices over 10 years with highlighted periods
 np.random.seed(42)
@@ -62,8 +62,8 @@ spans = pd.DataFrame(
 plot = (
     ggplot()
     + geom_rect(data=spans, mapping=aes(xmin="xmin", xmax="xmax", ymin="ymin", ymax="ymax", fill="label"), alpha=0.25)
-    + geom_line(data=df, mapping=aes(x="year", y="price"), color=OKABE_ITO[0], size=1.5)
-    + scale_fill_manual(values={"Recession Period": OKABE_ITO[1], "Risk Zone": OKABE_ITO[4]}, name="Highlighted Region")
+    + geom_line(data=df, mapping=aes(x="year", y="price"), color=IMPRINT[0], size=1.5)
+    + scale_fill_manual(values={"Recession Period": IMPRINT[1], "Risk Zone": IMPRINT[4]}, name="Highlighted Region")
     + labs(x="Year", y="Price ($)", title="span-basic · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/step-basic/implementations/python/plotnine.py
+++ b/plots/step-basic/implementations/python/plotnine.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Data - Monthly cumulative sales figures showing discrete jumps
 months = list(range(1, 13))

--- a/plots/strip-basic/implementations/python/plotnine.py
+++ b/plots/strip-basic/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Patient response times (seconds) across different drug treatments
 np.random.seed(42)
@@ -54,7 +54,7 @@ df = pd.DataFrame(data, columns=["treatment", "response_time"])
 plot = (
     ggplot(df, aes(x="treatment", y="response_time", color="treatment"))
     + geom_point(position=position_jitter(width=0.25, height=0, random_state=42), size=4, alpha=0.65)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(x="Treatment Group", y="Response Time (seconds)", title="strip-basic · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/subplot-grid/implementations/python/plotnine.py
+++ b/plots/subplot-grid/implementations/python/plotnine.py
@@ -36,7 +36,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 
 # Data - Product performance dashboard
 np.random.seed(42)
@@ -72,7 +72,7 @@ margin = 20 + 0.03 * units + np.random.randn(60) * 5
 df_scatter = pd.DataFrame({"units": units, "margin": margin})
 
 # Okabe-Ito palette for categorical data
-okabe_ito = [BRAND, SECONDARY, "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+okabe_ito = [BRAND, SECONDARY, "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Shared theme for all plots - sized for 4800x2700 canvas
 base_theme = theme_minimal() + theme(

--- a/plots/subplot-mosaic/implementations/python/plotnine.py
+++ b/plots/subplot-mosaic/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Product performance dashboard
 np.random.seed(42)
@@ -48,7 +48,7 @@ np.random.seed(42)
 n_days = 60
 days = np.arange(n_days)
 products = ["Alpha", "Beta", "Gamma"]
-colors_panel_a = OKABE_ITO[:3]
+colors_panel_a = IMPRINT[:3]
 
 df_overview = pd.concat(
     [
@@ -116,7 +116,7 @@ p_overview = (
 p_category = (
     ggplot(df_category, aes(x="quarter", y="revenue", fill="quarter"))
     + geom_bar(stat="identity", width=0.7, show_legend=False)
-    + scale_fill_manual(values=OKABE_ITO[:4])
+    + scale_fill_manual(values=IMPRINT[:4])
     + labs(x="Quarter", y="Revenue (k$)", title="Q Revenue")
     + theme_minimal()
     + anyplot_theme
@@ -126,7 +126,7 @@ p_category = (
 # Panel C: Units vs Margin - scatter (bottom-left)
 p_scatter = (
     ggplot(df_scatter, aes(x="units", y="margin"))
-    + geom_point(size=3, color=OKABE_ITO[0], alpha=0.7)
+    + geom_point(size=3, color=IMPRINT[0], alpha=0.7)
     + labs(x="Units Sold", y="Margin (%)", title="Margin Analysis")
     + theme_minimal()
     + anyplot_theme
@@ -147,7 +147,7 @@ p_heatmap = (
 # Panel E: Monthly Score - bar plot (bottom-right)
 p_monthly = (
     ggplot(df_monthly, aes(x="month", y="score"))
-    + geom_bar(stat="identity", fill=OKABE_ITO[0], width=0.6, show_legend=False)
+    + geom_bar(stat="identity", fill=IMPRINT[0], width=0.6, show_legend=False)
     + labs(x="Month", y="Score", title="Performance")
     + theme_minimal()
     + anyplot_theme

--- a/plots/sunburst-basic/implementations/python/plotnine.py
+++ b/plots/sunburst-basic/implementations/python/plotnine.py
@@ -38,7 +38,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 # Slightly lighter than PAGE_BG in dark mode so ring boundaries remain visible
 RING_SEP = PAGE_BG if THEME == "light" else "#2E2D2B"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: company annual budget by department → team ($M)
 hierarchy = {
@@ -63,7 +63,7 @@ for idx, (dept, teams) in enumerate(hierarchy.items()):
     pct = round(dept_total / total * 100)
     a0 = 2 * np.pi * cumsum / total - np.pi / 2
     a1 = 2 * np.pi * (cumsum + dept_total) / total - np.pi / 2
-    color = OKABE_ITO[idx]
+    color = IMPRINT[idx]
 
     # L1 arc polygon: inner arc → outer arc (reversed) → closed shape
     t = np.linspace(a0, a1, N_PTS)

--- a/plots/survival-kaplan-meier/implementations/python/plotnine.py
+++ b/plots/survival-kaplan-meier/implementations/python/plotnine.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data generation
 np.random.seed(42)
@@ -176,15 +176,15 @@ plot = (
 )
 
 if median_a is not None:
-    plot = plot + geom_vline(xintercept=median_a, linetype="dashed", color=OKABE_ITO[0], alpha=0.4, size=0.8)
+    plot = plot + geom_vline(xintercept=median_a, linetype="dashed", color=IMPRINT[0], alpha=0.4, size=0.8)
 
 if median_b is not None:
-    plot = plot + geom_vline(xintercept=median_b, linetype="dashed", color=OKABE_ITO[1], alpha=0.4, size=0.8)
+    plot = plot + geom_vline(xintercept=median_b, linetype="dashed", color=IMPRINT[1], alpha=0.4, size=0.8)
 
 plot = (
     plot
-    + scale_color_manual(values=OKABE_ITO)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
+    + scale_fill_manual(values=IMPRINT)
     + scale_y_continuous(limits=(0, 1.05), breaks=[0, 0.25, 0.5, 0.75, 1.0], labels=["0%", "25%", "50%", "75%", "100%"])
     + scale_x_continuous(limits=(0, None))
     + labs(

--- a/plots/swarm-basic/implementations/python/plotnine.py
+++ b/plots/swarm-basic/implementations/python/plotnine.py
@@ -33,7 +33,7 @@ THEME = os.getenv("ANYPLOT_THEME", "light")
 PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Patient biomarker levels across treatment groups
 np.random.seed(42)
@@ -61,7 +61,7 @@ plot = (
     ggplot(df, aes(x="treatment", y="biomarker", color="treatment"))
     + geom_point(position=position_jitter(width=0.3, height=0, random_state=42), size=3.5, alpha=0.75)
     + stat_summary(fun_y=np.median, geom="point", size=8, shape="D", color=INK)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(x="Treatment Group", y="Biomarker Level (ng/mL)", title="swarm-basic · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/timeline-basic/implementations/python/plotnine.py
+++ b/plots/timeline-basic/implementations/python/plotnine.py
@@ -40,7 +40,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Software development project milestones with varied timing
 data = {
@@ -103,10 +103,10 @@ df_below = df[df["y_offset"] == -1].copy()
 
 # Category colors - using Okabe-Ito palette
 category_colors = {
-    "Planning": OKABE_ITO[0],
-    "Development": OKABE_ITO[1],
-    "Testing": OKABE_ITO[2],
-    "Release": OKABE_ITO[3],
+    "Planning": IMPRINT[0],
+    "Development": IMPRINT[1],
+    "Testing": IMPRINT[2],
+    "Release": IMPRINT[3],
 }
 
 # Create timeline plot

--- a/plots/timeseries-forecast-uncertainty/implementations/python/plotnine.py
+++ b/plots/timeseries-forecast-uncertainty/implementations/python/plotnine.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette
-OKABE_ITO = {"Historical": "#009E73", "Forecast": "#D55E00"}
+IMPRINT = {"Historical": "#009E73", "Forecast": "#C475FD"}
 
 # Data - Monthly electricity demand with forecast
 np.random.seed(42)
@@ -88,7 +88,7 @@ annotation_x = forecast_start + pd.DateOffset(months=1)
 annotation_y = float(df_ci_95["ymax"].max()) + 5
 
 # CI fill colors (same hue; alpha per-geom creates visual depth difference)
-CI_COLORS = {"95% CI": OKABE_ITO["Forecast"], "80% CI": OKABE_ITO["Forecast"]}
+CI_COLORS = {"95% CI": IMPRINT["Forecast"], "80% CI": IMPRINT["Forecast"]}
 
 # Plot
 plot = (
@@ -106,7 +106,7 @@ plot = (
     # Forecast line (dashed)
     + geom_line(data=df_forecast, mapping=aes(x="date", y="value", color="series"), size=1.0, linetype="dashed")
     # Color mapping for lines
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     # Fill mapping for CI bands with legend entries
     + scale_fill_manual(values=CI_COLORS, name="CI bands")
     # Suppress "series" column header from color legend

--- a/plots/tree-phylogenetic/implementations/python/plotnine.py
+++ b/plots/tree-phylogenetic/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 np.random.seed(42)
 
@@ -252,16 +252,16 @@ df_leaves = pd.DataFrame({"x": [leaf_x[s] for s in species], "y": [leaf_y[s] for
 
 clade_colors = {
     "Root": "#999999",
-    "Strepsirrhini": OKABE_ITO[0],
-    "Haplorrhini": OKABE_ITO[1],
-    "Catarrhini": OKABE_ITO[2],
-    "Hylobatidae": OKABE_ITO[3],
-    "Hominoidea": OKABE_ITO[4],
-    "Cercopithecidae": OKABE_ITO[5],
-    "Homininae": OKABE_ITO[6],
-    "Ponginae": OKABE_ITO[0],
-    "Gorillini": OKABE_ITO[1],
-    "Hominini": OKABE_ITO[2],
+    "Strepsirrhini": IMPRINT[0],
+    "Haplorrhini": IMPRINT[1],
+    "Catarrhini": IMPRINT[2],
+    "Hylobatidae": IMPRINT[3],
+    "Hominoidea": IMPRINT[4],
+    "Cercopithecidae": IMPRINT[5],
+    "Homininae": IMPRINT[6],
+    "Ponginae": IMPRINT[0],
+    "Gorillini": IMPRINT[1],
+    "Hominini": IMPRINT[2],
 }
 
 df_segments["color"] = df_segments["clade"].map(clade_colors)
@@ -269,7 +269,7 @@ df_segments["color"] = df_segments["clade"].map(clade_colors)
 plot = (
     ggplot()
     + geom_segment(df_segments, aes(x="x", xend="xend", y="y", yend="yend", color="clade"), size=2.5)
-    + geom_point(df_leaves, aes(x="x", y="y"), size=5, color=OKABE_ITO[0])
+    + geom_point(df_leaves, aes(x="x", y="y"), size=5, color=IMPRINT[0])
     + geom_text(df_leaves, aes(x="x", y="y", label="species"), ha="left", nudge_x=0.02, size=14, color=INK)
     + scale_color_manual(values=clade_colors)
     + annotate("segment", x=0.0, xend=0.1, y=-0.8, yend=-0.8, size=2.5, color=INK_SOFT)

--- a/plots/venn-basic/implementations/python/plotnine.py
+++ b/plots/venn-basic/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first three colors for three-set Venn
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Three overlapping sets representing skills in a tech team
 # Set A: Python developers (100 people)
@@ -129,7 +129,7 @@ set_name_labels = [
 set_name_df = pd.DataFrame(set_name_labels)
 
 # Create color mapping dict for sets
-color_map = {"A": OKABE_ITO[0], "B": OKABE_ITO[1], "C": OKABE_ITO[2]}
+color_map = {"A": IMPRINT[0], "B": IMPRINT[1], "C": IMPRINT[2]}
 
 # Plot
 plot = (

--- a/plots/venn-labeled-items/implementations/python/plotnine.py
+++ b/plots/venn-labeled-items/implementations/python/plotnine.py
@@ -39,8 +39,8 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito categorical (positions 1, 2, 3)
 COLOR_A = "#009E73"  # brand green — ALWAYS first series
-COLOR_B = "#D55E00"  # vermillion
-COLOR_C = "#0072B2"  # blue
+COLOR_B = "#C475FD"  # vermillion
+COLOR_C = "#4467A3"  # blue
 
 # Symmetric three-circle Venn geometry
 RADIUS = 1.5

--- a/plots/violin-box/implementations/python/plotnine.py
+++ b/plots/violin-box/implementations/python/plotnine.py
@@ -24,7 +24,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data
 np.random.seed(42)
@@ -73,7 +73,7 @@ plot = (
     + plotnine.geom_boxplot(
         width=0.25, alpha=0.9, color=INK_SOFT, fill=ELEVATED_BG, size=0.6, outlier_size=4, outlier_alpha=0.7
     )
-    + plotnine.scale_fill_manual(values=OKABE_ITO, name="Product", guide=plotnine.guide_legend(nrow=1))
+    + plotnine.scale_fill_manual(values=IMPRINT, name="Product", guide=plotnine.guide_legend(nrow=1))
     + plotnine.labs(title="violin-box · plotnine · anyplot.ai", x="Product Category", y="Satisfaction Score (points)")
     + anyplot_theme
     + plotnine.theme(legend_position="top", legend_direction="horizontal")

--- a/plots/violin-grouped-swarm/implementations/python/plotnine.py
+++ b/plots/violin-grouped-swarm/implementations/python/plotnine.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Response times (ms) across task types and expertise levels
 np.random.seed(42)
@@ -62,8 +62,8 @@ plot = (
     ggplot(df, aes(x="task_type", y="response_time", fill="expertise"))
     + geom_violin(position=position_dodge(width=0.8), alpha=0.5, size=0.8)
     + geom_jitter(aes(color="expertise"), position=position_dodge(width=0.8), size=2.5, alpha=0.8)
-    + scale_fill_manual(values=OKABE_ITO, name="Expertise")
-    + scale_color_manual(values=OKABE_ITO, name="Expertise")
+    + scale_fill_manual(values=IMPRINT, name="Expertise")
+    + scale_color_manual(values=IMPRINT, name="Expertise")
     + guides(color="none")
     + labs(title="violin-grouped-swarm · Python · plotnine · anyplot.ai", x="Task Type", y="Response Time (ms)")
     + theme(

--- a/plots/violin-split/implementations/python/plotnine.py
+++ b/plots/violin-split/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73 (brand)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Employee satisfaction scores before and after training program
 np.random.seed(42)
@@ -69,7 +69,7 @@ plot = (
     ggplot(df, aes(x="category", y="value", fill="split_group"))
     + geom_violin(style="left-right", alpha=0.8, size=0.8, scale="width", trim=True)
     + geom_boxplot(width=0.15, alpha=0.9, outlier_alpha=0.5, outlier_size=2, size=0.6, position="identity")
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(x="Department", y="Satisfaction Score (0-100)", fill="Period", title="violin-split · plotnine · anyplot.ai")
     + theme_minimal()
     + theme(

--- a/plots/violin-swarm/implementations/python/plotnine.py
+++ b/plots/violin-swarm/implementations/python/plotnine.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Reaction times (ms) across 4 experimental conditions
 np.random.seed(42)

--- a/plots/volcano-basic/implementations/python/plotnine.py
+++ b/plots/volcano-basic/implementations/python/plotnine.py
@@ -89,9 +89,9 @@ df_labels = pd.concat([df_up, df_down])
 
 # Okabe-Ito palette (blue for down, gray for not significant, orange for up)
 color_map = {
-    "Down-regulated": "#0072B2",  # Okabe-Ito blue
+    "Down-regulated": "#4467A3",  # Okabe-Ito blue
     "Not significant": "#888888",  # neutral gray
-    "Up-regulated": "#E69F00",  # Okabe-Ito orange
+    "Up-regulated": "#AE3030",  # Okabe-Ito orange
 }
 
 # Create volcano plot

--- a/plots/voronoi-basic/implementations/python/plotnine.py
+++ b/plots/voronoi-basic/implementations/python/plotnine.py
@@ -172,12 +172,12 @@ df_points = pd.DataFrame({"x": x_points, "y": y_points})
 # Cell colors - diverse palette starting with Okabe-Ito positions
 colors_20 = [
     "#009E73",
-    "#D55E00",
-    "#0072B2",
-    "#CC79A7",
-    "#E69F00",
-    "#56B4E9",
-    "#F0E442",
+    "#C475FD",
+    "#4467A3",
+    "#BD8233",
+    "#AE3030",
+    "#2ABCCD",
+    "#954477",
     "#306998",
     "#8DD3C7",
     "#BEBADA",

--- a/plots/waffle-basic/implementations/python/plotnine.py
+++ b/plots/waffle-basic/implementations/python/plotnine.py
@@ -34,7 +34,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Budget allocation by category
 categories = ["Housing", "Food", "Transport", "Entertainment"]
@@ -57,7 +57,7 @@ df = pd.DataFrame(squares)
 df["category"] = pd.Categorical(df["category"], categories=category_order, ordered=True)
 
 # Create color mapping with Okabe-Ito palette
-color_map = dict(zip(category_order, OKABE_ITO, strict=True))
+color_map = dict(zip(category_order, IMPRINT, strict=True))
 value_map = dict(zip(categories, values, strict=True))
 
 # Build legend labels with percentages

--- a/plots/windrose-basic/implementations/python/plotnine.py
+++ b/plots/windrose-basic/implementations/python/plotnine.py
@@ -60,13 +60,13 @@ frequencies = {
 }
 
 # Colors for wind speed bins: cool (calm) to warm (strong) progression
-# Using perceptually-uniform colors appropriate for wind speed ranges
+# imprint anchors arranged to keep the intensity ramp monotonic
 speed_colors = {
-    "0-5": "#4467A3",  # Okabe-Ito blue (calm)
-    "5-10": "#2ABCCD",  # Okabe-Ito sky blue
-    "10-15": "#009E73",  # Okabe-Ito green
-    "15-20": "#AE3030",  # Okabe-Ito orange
-    "20+": "#C475FD",  # Okabe-Ito red-orange (strong)
+    "0-5": "#4467A3",  # imprint blue (calm)
+    "5-10": "#2ABCCD",  # imprint cyan
+    "10-15": "#009E73",  # imprint green (mid)
+    "15-20": "#DDCC77",  # imprint amber (caution)
+    "20+": "#AE3030",   # imprint red (strong, hottest)
 }
 
 # Calculate direction angles (N=top, clockwise)

--- a/plots/windrose-basic/implementations/python/plotnine.py
+++ b/plots/windrose-basic/implementations/python/plotnine.py
@@ -62,11 +62,11 @@ frequencies = {
 # Colors for wind speed bins: cool (calm) to warm (strong) progression
 # Using perceptually-uniform colors appropriate for wind speed ranges
 speed_colors = {
-    "0-5": "#0072B2",  # Okabe-Ito blue (calm)
-    "5-10": "#56B4E9",  # Okabe-Ito sky blue
+    "0-5": "#4467A3",  # Okabe-Ito blue (calm)
+    "5-10": "#2ABCCD",  # Okabe-Ito sky blue
     "10-15": "#009E73",  # Okabe-Ito green
-    "15-20": "#E69F00",  # Okabe-Ito orange
-    "20+": "#D55E00",  # Okabe-Ito red-orange (strong)
+    "15-20": "#AE3030",  # Okabe-Ito orange
+    "20+": "#C475FD",  # Okabe-Ito red-orange (strong)
 }
 
 # Calculate direction angles (N=top, clockwise)

--- a/plots/wordcloud-basic/implementations/python/plotnine.py
+++ b/plots/wordcloud-basic/implementations/python/plotnine.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for frequency tiers
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Word frequency data - technology survey responses
 np.random.seed(42)
@@ -111,13 +111,13 @@ df["y"] = [p[1] for p in positions]
 colors = []
 for freq in df["frequency"]:
     if freq >= 65:
-        colors.append(OKABE_ITO[0])  # Bluish green (brand) - highest
+        colors.append(IMPRINT[0])  # Bluish green (brand) - highest
     elif freq >= 35:
-        colors.append(OKABE_ITO[1])  # Vermillion - medium-high
+        colors.append(IMPRINT[1])  # Vermillion - medium-high
     elif freq >= 15:
-        colors.append(OKABE_ITO[2])  # Blue - medium-low
+        colors.append(IMPRINT[2])  # Blue - medium-low
     else:
-        colors.append(OKABE_ITO[3])  # Reddish purple - lowest
+        colors.append(IMPRINT[3])  # Reddish purple - lowest
 
 df["color"] = colors
 
@@ -127,7 +127,7 @@ legend_df = pd.DataFrame(
         "x": [92, 92, 92, 92],
         "y": [46, 42, 38, 34],
         "label": ["High (65+)", "Medium (35-64)", "Low-Med (15-34)", "Low (<15)"],
-        "color": OKABE_ITO,
+        "color": IMPRINT,
     }
 )
 


### PR DESCRIPTION
## Summary

- Positional hex replacement across **132 plotnine impls** with light+dark renders, moving them from Okabe-Ito + variant-D to **imprint**. Same pattern as #7776 (matplotlib) and #7779 (seaborn).
- Includes proactive **semantic-anchor fixes for 11 plotnine impls** where slot-1 (now lavender) carried explicit meaning. Variable `ORANGE` in indicator-macd renamed to `OCHRE` so the name matches the actual imprint hex.

## Semantic fixes (proactive)

| File | Fix |
|---|---|
| bar-diverging | "Negative" → red |
| candlestick-volume | DOWN_COLOR → red |
| dashboard-metrics-tiles | status warn → amber, critical → red |
| gauge-basic | ZONE_BAD/WARN → red/amber traffic-light |
| indicator-macd | ORANGE → OCHRE (var rename + #BD8233) |
| kagi-basic | YIN_COLOR → red |
| logistic-regression | FAIL_COLOR → red |
| ohlc-bar | DOWN_COLOR → red |
| point-and-figure-basic | O_COLOR → red |
| renko-basic | BEARISH → red |
| shap-waterfall | COLOR_POS → red (vs blue NEG) |

## Test plan

- [x] `ruff check .` + `ruff format --check .` green
- [ ] CI green
- [ ] Copilot triage
- [ ] After merge: Stage B for 132 plotnine impls → GCS production

🤖 Generated with [Claude Code](https://claude.com/claude-code)