### PR TITLE
chore(palette): migrate bokeh impls from Okabe-Ito to imprint

### DIFF
--- a/plots/alluvial-basic/implementations/python/bokeh.py
+++ b/plots/alluvial-basic/implementations/python/bokeh.py
@@ -23,9 +23,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"
-OI_2 = "#D55E00"
-OI_3 = "#0072B2"
-OI_4 = "#CC79A7"
+OI_2 = "#C475FD"
+OI_3 = "#4467A3"
+OI_4 = "#BD8233"
 
 np.random.seed(42)
 

--- a/plots/andrews-curves/implementations/python/bokeh.py
+++ b/plots/andrews-curves/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data
 iris = load_iris()
@@ -98,7 +98,7 @@ for species_idx in range(3):
             data={"x": t_values, "y": curve_values, "species": [species_names[species_idx]] * len(t_values)}
         )
 
-        line = p.line(x="x", y="y", source=source, line_color=OKABE_ITO[species_idx], line_alpha=0.4, line_width=3)
+        line = p.line(x="x", y="y", source=source, line_color=IMPRINT[species_idx], line_alpha=0.4, line_width=3)
 
         if first_line is None:
             first_line = line

--- a/plots/area-cumulative-flow/implementations/python/bokeh.py
+++ b/plots/area-cumulative-flow/implementations/python/bokeh.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — 90-day Kanban board for a software delivery team
 np.random.seed(42)
@@ -86,7 +86,7 @@ p = figure(
 )
 
 # Stacked areas — each color corresponds to the matching stacker
-renderers = p.varea_stack(stackers=stages, x="date", color=OKABE_ITO, alpha=0.82, source=source)
+renderers = p.varea_stack(stackers=stages, x="date", color=IMPRINT, alpha=0.82, source=source)
 
 # Subtle boundary lines at each stage transition
 cum_vals = np.zeros(days)

--- a/plots/area-stacked-confidence/implementations/python/bokeh.py
+++ b/plots/area-stacked-confidence/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly energy consumption by source with uncertainty
 np.random.seed(42)
@@ -94,8 +94,8 @@ solar_band = Band(
     upper="y_upper",
     source=source_solar,
     fill_alpha=0.2,
-    fill_color=OKABE_ITO[0],
-    line_color=OKABE_ITO[0],
+    fill_color=IMPRINT[0],
+    line_color=IMPRINT[0],
     line_alpha=0.3,
 )
 p.add_layout(solar_band)
@@ -106,8 +106,8 @@ wind_band = Band(
     upper="y_upper",
     source=source_wind,
     fill_alpha=0.2,
-    fill_color=OKABE_ITO[1],
-    line_color=OKABE_ITO[1],
+    fill_color=IMPRINT[1],
+    line_color=IMPRINT[1],
     line_alpha=0.3,
 )
 p.add_layout(wind_band)
@@ -118,21 +118,21 @@ hydro_band = Band(
     upper="y_upper",
     source=source_hydro,
     fill_alpha=0.2,
-    fill_color=OKABE_ITO[2],
-    line_color=OKABE_ITO[2],
+    fill_color=IMPRINT[2],
+    line_color=IMPRINT[2],
     line_alpha=0.3,
 )
 p.add_layout(hydro_band)
 
 # Plot stacked areas using varea
-r_solar = p.varea(x="x", y1="base", y2="y", source=source_solar, fill_color=OKABE_ITO[0], fill_alpha=0.7)
-r_wind = p.varea(x="x", y1="base", y2="y", source=source_wind, fill_color=OKABE_ITO[1], fill_alpha=0.7)
-r_hydro = p.varea(x="x", y1="base", y2="y", source=source_hydro, fill_color=OKABE_ITO[2], fill_alpha=0.7)
+r_solar = p.varea(x="x", y1="base", y2="y", source=source_solar, fill_color=IMPRINT[0], fill_alpha=0.7)
+r_wind = p.varea(x="x", y1="base", y2="y", source=source_wind, fill_color=IMPRINT[1], fill_alpha=0.7)
+r_hydro = p.varea(x="x", y1="base", y2="y", source=source_hydro, fill_color=IMPRINT[2], fill_alpha=0.7)
 
 # Add center lines for each series for better visibility
-p.line(x="x", y="y", source=source_solar, line_color=OKABE_ITO[0], line_width=3, line_alpha=0.8)
-p.line(x="x", y="y", source=source_wind, line_color=OKABE_ITO[1], line_width=3, line_alpha=0.8)
-p.line(x="x", y="y", source=source_hydro, line_color=OKABE_ITO[2], line_width=3, line_alpha=0.8)
+p.line(x="x", y="y", source=source_solar, line_color=IMPRINT[0], line_width=3, line_alpha=0.8)
+p.line(x="x", y="y", source=source_wind, line_color=IMPRINT[1], line_width=3, line_alpha=0.8)
+p.line(x="x", y="y", source=source_hydro, line_color=IMPRINT[2], line_width=3, line_alpha=0.8)
 
 # Create legend outside plot area (bottom right)
 legend = Legend(

--- a/plots/area-stacked-percent/implementations/python/bokeh.py
+++ b/plots/area-stacked-percent/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series ALWAYS #009E73)
-COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 CATEGORIES = ["Product A", "Product B", "Product C", "Product D"]
 
 # Data - Market share evolution over time

--- a/plots/area-stacked/implementations/python/bokeh.py
+++ b/plots/area-stacked/implementations/python/bokeh.py
@@ -33,11 +33,11 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is #009E73)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
 ]
 
 # Data - Monthly revenue by product category over 2 years
@@ -92,7 +92,7 @@ for idx, (name, values) in enumerate(series_data):
         data={"x": x_values, "y1": y1, "y2": y2, "month": x_labels, "value": values, "name": [name] * len(x_values)}
     )
 
-    renderer = p.varea(x="x", y1="y1", y2="y2", source=source, fill_color=OKABE_ITO[idx], fill_alpha=0.85)
+    renderer = p.varea(x="x", y1="y1", y2="y2", source=source, fill_color=IMPRINT[idx], fill_alpha=0.85)
     legend_items.append((name, [renderer]))
 
     # Add HoverTool for this series

--- a/plots/bar-3d-categorical/implementations/python/bokeh.py
+++ b/plots/bar-3d-categorical/implementations/python/bokeh.py
@@ -32,7 +32,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: retail sales by product category and quarter (units in thousands)
 np.random.seed(42)
@@ -119,7 +119,7 @@ for j in range(n_qtr - 1, -1, -1):
     for i in range(n_prod):
         v = sales[i, j]
         h = v / v_max * H_SCALE
-        color = OKABE_ITO[j]
+        color = IMPRINT[j]
         x0, x1 = i + gap, i + gap + bar_w
         y0, y1 = j + gap, j + gap + bar_w
 
@@ -211,7 +211,7 @@ for j, qtr in enumerate(quarters):
         text=qtr,
         text_align="left",
         text_baseline="middle",
-        text_color=OKABE_ITO[j],
+        text_color=IMPRINT[j],
         text_font_size="22pt",
         text_font_style="bold",
     )

--- a/plots/bar-diverging/implementations/python/bokeh.py
+++ b/plots/bar-diverging/implementations/python/bokeh.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND_POS = "#009E73"  # Okabe-Ito position 1
-BRAND_NEG = "#D55E00"  # Okabe-Ito position 2
+BRAND_NEG = "#AE3030"  # imprint red — negative
 
 # Data - Customer satisfaction survey responses (Net Promoter Score style)
 categories = [

--- a/plots/bar-drilldown/implementations/python/bokeh.py
+++ b/plots/bar-drilldown/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: 3-level geographic sales hierarchy (Region → Country → City)
 hierarchy_data = {
@@ -103,7 +103,7 @@ source = ColumnDataSource(
         "names": init_names,
         "values": init_values,
         "ids": root_children,
-        "colors": [OKABE_ITO[i % len(OKABE_ITO)] for i in range(len(init_names))],
+        "colors": [IMPRINT[i % len(IMPRINT)] for i in range(len(init_names))],
         "has_children": [len(hierarchy_data[c].get("children", [])) > 0 for c in root_children],
         "label_y": [v + init_max * 0.025 for v in init_values],
     }
@@ -206,7 +206,7 @@ drill_callback = CustomJS(
         "state": state_source,
         "p": p,
         "hierarchy": hierarchy_data,
-        "okabe_ito": OKABE_ITO,
+        "okabe_ito": IMPRINT,
         "breadcrumb_div": breadcrumb_div,
         "back_button": back_button,
         "ink": INK,
@@ -268,7 +268,7 @@ drill_up_callback = CustomJS(
         "state": state_source,
         "p": p,
         "hierarchy": hierarchy_data,
-        "okabe_ito": OKABE_ITO,
+        "okabe_ito": IMPRINT,
         "breadcrumb_div": breadcrumb_div,
         "back_button": back_button,
         "ink": INK,

--- a/plots/bar-grouped/implementations/python/bokeh.py
+++ b/plots/bar-grouped/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product line (in thousands)
 categories = ["Q1", "Q2", "Q3", "Q4"]
@@ -34,7 +34,7 @@ data = {"Electronics": [245, 278, 312, 385], "Clothing": [180, 165, 210, 295], "
 # Create factors for grouped bars
 x = [(cat, group) for cat in categories for group in groups]
 values = [data[group][i] for i, cat in enumerate(categories) for group in groups]
-colors = [OKABE_ITO[groups.index(factor[1])] for factor in x]
+colors = [IMPRINT[groups.index(factor[1])] for factor in x]
 
 source = ColumnDataSource(data={"x": x, "values": values, "color": colors})
 

--- a/plots/bar-race-animated/implementations/python/bokeh.py
+++ b/plots/bar-race-animated/implementations/python/bokeh.py
@@ -25,14 +25,14 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: Streaming platform subscriber counts (millions) over 8 years
 np.random.seed(42)
 
 platforms = ["StreamMax", "ViewHub", "FlixNet", "WatchNow", "CineCloud", "MediaFlow"]
 years = list(range(2016, 2024))
-platform_colors = dict(zip(platforms, OKABE_ITO, strict=True))
+platform_colors = dict(zip(platforms, IMPRINT, strict=True))
 
 # Generate realistic growth patterns
 data_rows = []
@@ -167,7 +167,7 @@ legend_fig.yaxis.visible = False
 legend_fig.xgrid.grid_line_color = None
 legend_fig.ygrid.grid_line_color = None
 
-for i, (platform, color) in enumerate(zip(platforms, OKABE_ITO, strict=True)):
+for i, (platform, color) in enumerate(zip(platforms, IMPRINT, strict=True)):
     legend_fig.rect(x=[i + 0.12], y=[0.5], width=0.17, height=0.5, color=color, alpha=0.9)
     legend_fig.text(
         x=[i + 0.25], y=[0.5], text=[platform], text_font_size="20pt", text_color=INK_SOFT, text_baseline="middle"

--- a/plots/bar-spine/implementations/python/bokeh.py
+++ b/plots/bar-spine/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: project completion status by department
 np.random.seed(42)
@@ -90,7 +90,7 @@ for j, status in enumerate(statuses):
         right="right",
         bottom="bottom",
         top="top",
-        color=OKABE_ITO[j],
+        color=IMPRINT[j],
         line_color=PAGE_BG,
         line_width=2,
         alpha=0.92,

--- a/plots/bar-stacked-labeled/implementations/python/bokeh.py
+++ b/plots/bar-stacked-labeled/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Quarterly revenue by product category
 np.random.seed(42)
@@ -56,7 +56,7 @@ p = figure(
 bottoms = [0] * len(categories)
 
 # Plot stacked bars
-for _comp_idx, (comp, color) in enumerate(zip(components, OKABE_ITO, strict=True)):
+for _comp_idx, (comp, color) in enumerate(zip(components, IMPRINT, strict=True)):
     tops = [b + v for b, v in zip(bottoms, data[comp], strict=True)]
     source = ColumnDataSource(
         data={

--- a/plots/bar-stacked-percent/implementations/python/bokeh.py
+++ b/plots/bar-stacked-percent/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Market share of smartphone brands over quarters
 categories = ["Q1 2024", "Q2 2024", "Q3 2024", "Q4 2024", "Q1 2025"]
@@ -85,7 +85,7 @@ for i, comp in enumerate(components):
         bottom="bottom",
         source=source,
         width=0.7,
-        color=OKABE_ITO[i],
+        color=IMPRINT[i],
         legend_label=comp,
         line_color=PAGE_BG,
         line_width=2,

--- a/plots/bar-stacked/implementations/python/bokeh.py
+++ b/plots/bar-stacked/implementations/python/bokeh.py
@@ -30,12 +30,12 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Monthly energy consumption by source (in gigawatt-hours)
 months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 sources = ["Solar", "Wind", "Hydro", "Natural Gas"]
-colors = OKABE_ITO
+colors = IMPRINT
 
 data = {
     "Solar": [85, 92, 110, 125, 145, 165, 175, 160, 140, 115, 95, 80],

--- a/plots/biplot-pca/implementations/python/bokeh.py
+++ b/plots/biplot-pca/implementations/python/bokeh.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is ALWAYS #009E73 (brand)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris dataset
 iris = load_iris()
@@ -103,7 +103,7 @@ p.ygrid.grid_line_alpha = 0.10
 for i, name in enumerate(target_names):
     mask = y == i
     source = ColumnDataSource(data={"x": scores[mask, 0], "y": scores[mask, 1]})
-    p.scatter(x="x", y="y", source=source, size=20, alpha=0.7, color=OKABE_ITO[i], legend_label=name)
+    p.scatter(x="x", y="y", source=source, size=20, alpha=0.7, color=IMPRINT[i], legend_label=name)
 
 # Style legend
 if p.legend:

--- a/plots/bland-altman-basic/implementations/python/bokeh.py
+++ b/plots/bland-altman-basic/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 np.random.seed(42)
 n = 80

--- a/plots/box-horizontal/implementations/python/bokeh.py
+++ b/plots/box-horizontal/implementations/python/bokeh.py
@@ -40,7 +40,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"
-ALT_COLOR = "#D55E00"
+ALT_COLOR = "#C475FD"
 
 # Data - Response times (ms) by service type
 np.random.seed(42)

--- a/plots/box-notched/implementations/python/bokeh.py
+++ b/plots/box-notched/implementations/python/bokeh.py
@@ -31,12 +31,12 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
-    "#E69F00",  # orange
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
+    "#AE3030",  # orange
 ]
 
 # Data - Employee performance scores across departments
@@ -111,14 +111,14 @@ for i, cat in enumerate(categories):
     box_data["lower"].append(lower_whisker)
     box_data["notch_lower"].append(notch_lower)
     box_data["notch_upper"].append(notch_upper)
-    box_data["colors"].append(OKABE_ITO[i])
+    box_data["colors"].append(IMPRINT[i])
 
     # Find outliers
     outliers = values[(values < lower_fence) | (values > upper_fence)]
     for o in outliers:
         outlier_data["category"].append(cat)
         outlier_data["value"].append(o)
-        outlier_data["color"].append(OKABE_ITO[i])
+        outlier_data["color"].append(IMPRINT[i])
 
 # Create figure
 p = figure(

--- a/plots/bubble-map-geographic/implementations/python/bokeh.py
+++ b/plots/bubble-map-geographic/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (canonical order)
-OKABE = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+OKABE = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - World cities with population (in millions, 2024 estimates)
 cities = {

--- a/plots/candlestick-volume/implementations/python/bokeh.py
+++ b/plots/candlestick-volume/implementations/python/bokeh.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for up/down
 COLOR_UP = "#009E73"  # Green (Okabe-Ito position 1)
-COLOR_DOWN = "#D55E00"  # Orange (Okabe-Ito position 2)
+COLOR_DOWN = "#AE3030"  # imprint red — down days
 
 # Data - Generate 60 trading days of OHLC with volume
 np.random.seed(42)

--- a/plots/circlepacking-basic/implementations/python/bokeh.py
+++ b/plots/circlepacking-basic/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for hierarchy levels
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Build hierarchical data: Portfolio composition by asset class (in millions)
 hierarchy = [
@@ -193,7 +193,7 @@ labels = [n["label"] for n in all_circles]
 values = [n["value"] for n in all_circles]
 
 # Color by depth using Okabe-Ito palette
-colors = [OKABE_ITO[min(d, 2)] for d in depths]
+colors = [IMPRINT[min(d, 2)] for d in depths]
 depth_names = ["Portfolio", "Asset Class", "Investment"]
 depth_labels = [depth_names[min(d, 2)] for d in depths]
 
@@ -245,7 +245,7 @@ p.add_tools(hover)
 
 # Create legend for depth colors
 legend_items = []
-for color, name in zip(OKABE_ITO[:3], depth_names, strict=True):
+for color, name in zip(IMPRINT[:3], depth_names, strict=True):
     dummy_source = ColumnDataSource(data={"x": [-99999], "y": [-99999], "r": [10]})
     dummy_circle = p.circle(
         x="x", y="y", radius="r", fill_color=color, fill_alpha=0.7, line_color=INK_SOFT, source=dummy_source

--- a/plots/circos-basic/implementations/python/bokeh.py
+++ b/plots/circos-basic/implementations/python/bokeh.py
@@ -28,7 +28,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 np.random.seed(42)
 
@@ -102,7 +102,7 @@ for i, (start, end) in enumerate(segment_angles):
     ys = np.concatenate([outer_y, inner_y, [outer_y[0]]])
 
     source = ColumnDataSource(data={"xs": [xs], "ys": [ys]})
-    color = OKABE_ITO[i % len(OKABE_ITO)]
+    color = IMPRINT[i % len(IMPRINT)]
     p.patches(xs="xs", ys="ys", source=source, fill_color=color, line_color=INK_SOFT, line_width=1, alpha=0.85)
 
     mid_angle = (start + end) / 2
@@ -143,7 +143,7 @@ for i, (start, end) in enumerate(segment_angles):
     ys = np.concatenate([outer_y, inner_y, [outer_y[0]]])
 
     source = ColumnDataSource(data={"xs": [xs], "ys": [ys]})
-    color = OKABE_ITO[i % len(OKABE_ITO)]
+    color = IMPRINT[i % len(IMPRINT)]
     p.patches(xs="xs", ys="ys", source=source, fill_color=color, line_color=None, alpha=0.4)
 
 track_ref_theta = np.linspace(0, 2 * np.pi, 100)
@@ -210,7 +210,7 @@ for i in range(n_regions):
         ribbon_x = np.concatenate([curve1_x, arc_j_x, curve2_x, arc_i_x])
         ribbon_y = np.concatenate([curve1_y, arc_j_y, curve2_y, arc_i_y])
 
-        ribbon_color = OKABE_ITO[i % len(OKABE_ITO)]
+        ribbon_color = IMPRINT[i % len(IMPRINT)]
 
         source = ColumnDataSource(data={"xs": [ribbon_x], "ys": [ribbon_y]})
         p.patches(
@@ -229,7 +229,7 @@ legend_spacing = 0.15
 
 for i, region in enumerate(regions):
     y_pos = legend_y_start - i * legend_spacing
-    color = OKABE_ITO[i % len(OKABE_ITO)]
+    color = IMPRINT[i % len(IMPRINT)]
     p.rect(x=[legend_x], y=[y_pos], width=0.08, height=0.08, fill_color=color, line_color=None)
     p.text(
         x=[legend_x + 0.12],

--- a/plots/contour-decision-boundary/implementations/python/bokeh.py
+++ b/plots/contour-decision-boundary/implementations/python/bokeh.py
@@ -44,7 +44,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors for classes
-CLASS_COLORS = ["#009E73", "#D55E00"]  # Positions 1 and 2 of the palette
+CLASS_COLORS = ["#009E73", "#C475FD"]  # Positions 1 and 2 of the palette
 
 # Data - Generate synthetic classification data
 np.random.seed(42)

--- a/plots/contour-map-geographic/implementations/python/bokeh.py
+++ b/plots/contour-map-geographic/implementations/python/bokeh.py
@@ -170,16 +170,16 @@ labels = LabelSet(
 )
 p.add_layout(labels)
 
-# --- Approximate Pacific coastline (Okabe-Ito #0072B2: blue = water, semantically justified) ---
+# --- Approximate Pacific coastline (Okabe-Ito #4467A3: blue = water, semantically justified) ---
 coast_lons = [-125.0, -124.8, -124.5, -124.2, -124.0, -123.8, -124.0, -124.3, -124.5]
 coast_lats = [42.0, 43.5, 45.0, 46.0, 46.5, 47.5, 48.0, 48.5, 49.0]
-p.line(x=coast_lons, y=coast_lats, line_color="#0072B2", line_width=5, legend_label="Coastline (approx.)")
+p.line(x=coast_lons, y=coast_lats, line_color="#4467A3", line_width=5, legend_label="Coastline (approx.)")
 
 # --- Oregon / Washington state border (lat ≈ 46.2) for geographic context ---
 p.line(
     x=[lon_min, -124.0],
     y=[46.2, 46.2],
-    line_color="#D55E00",  # Okabe-Ito orange
+    line_color="#C475FD",  # Okabe-Ito orange
     line_width=3.5,
     line_dash="dashed",
     legend_label="OR / WA Border",

--- a/plots/dashboard-metrics-tiles/implementations/python/bokeh.py
+++ b/plots/dashboard-metrics-tiles/implementations/python/bokeh.py
@@ -33,10 +33,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito semantic colors for status and change indicators
-STATUS_COLORS = {"good": "#009E73", "warning": "#E69F00", "critical": "#D55E00"}
-SPARKLINE_COLOR = "#0072B2"  # Okabe-Ito position 3
+STATUS_COLORS = {"good": "#009E73", "warning": "#DDCC77", "critical": "#AE3030"}  # imprint semantic anchors
+SPARKLINE_COLOR = "#4467A3"  # Okabe-Ito position 3
 FAVORABLE_COLOR = "#009E73"  # Okabe-Ito position 1
-UNFAVORABLE_COLOR = "#D55E00"  # Okabe-Ito position 2
+UNFAVORABLE_COLOR = "#AE3030"  # imprint red — unfavorable
 
 # Metrics where a positive change is unfavorable
 UNFAVORABLE_WHEN_UP = {"Error Rate", "Response Time"}

--- a/plots/dashboard-synchronized-crosshair/implementations/python/bokeh.py
+++ b/plots/dashboard-synchronized-crosshair/implementations/python/bokeh.py
@@ -36,9 +36,9 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # anyplot palette — assigned across the three metric series
 C_PRICE = "#009E73"  # green  (position 1)
-C_VOLUME = "#9418DB"  # purple (position 2)
-C_RSI = "#16B8F3"  # sky blue (position 4)
-C_OVERBOUGHT = "#B71D27"  # red — semantic: danger / sell zone
+C_VOLUME = "#C475FD"  # purple (position 2)
+C_RSI = "#4467A3"  # sky blue (position 4)
+C_OVERBOUGHT = "#AE3030"  # red — semantic: danger / sell zone
 
 # Data — stock data over 200 trading days
 np.random.seed(42)

--- a/plots/datamatrix-basic/implementations/python/bokeh.py
+++ b/plots/datamatrix-basic/implementations/python/bokeh.py
@@ -175,8 +175,8 @@ p = figure(
     min_border_right=90,
 )
 
-OKABE_BLUE = "#0072B2"
-OKABE_ORANGE = "#D55E00"
+OKABE_BLUE = "#4467A3"
+OKABE_ORANGE = "#C475FD"
 OKABE_GREEN = "#009E73"
 
 # Structural zone overlays — drawn first so barcode modules render on top

--- a/plots/dendrogram-radial/implementations/python/bokeh.py
+++ b/plots/dendrogram-radial/implementations/python/bokeh.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data — gene expression clustering scenario (40 genes, 4 clusters)
 np.random.seed(42)
@@ -112,9 +112,9 @@ for row in Z:
     cl = get_leaf_cluster(left)
     cr = get_leaf_cluster(right)
     cp = get_leaf_cluster(parent_id)
-    color_left = OKABE_ITO[cl] if cl >= 0 else INK_SOFT
-    color_right = OKABE_ITO[cr] if cr >= 0 else INK_SOFT
-    color_arc = OKABE_ITO[cp] if cp >= 0 else INK_SOFT
+    color_left = IMPRINT[cl] if cl >= 0 else INK_SOFT
+    color_right = IMPRINT[cr] if cr >= 0 else INK_SOFT
+    color_arc = IMPRINT[cp] if cp >= 0 else INK_SOFT
 
     px_l, py_l = polar_to_xy(r_parent, a_left)
     cx_l, cy_l = polar_to_xy(node_radius[left], a_left)
@@ -153,7 +153,7 @@ for i, leaf_idx in enumerate(ordered_leaves):
     dx, dy = polar_to_xy(1.03, a)
     dot_xs.append(dx)
     dot_ys.append(dy)
-    dot_colors.append(OKABE_ITO[int(true_clusters[leaf_idx])])
+    dot_colors.append(IMPRINT[int(true_clusters[leaf_idx])])
 
 # Plot
 W, H = 2700, 2700
@@ -195,7 +195,7 @@ p.add_layout(labels_set)
 
 legend_items = []
 for c_idx in range(n_clusters):
-    r = p.scatter([], [], size=18, color=OKABE_ITO[c_idx], line_color=None)
+    r = p.scatter([], [], size=18, color=IMPRINT[c_idx], line_color=None)
     legend_items.append(LegendItem(label=f"Cluster {c_idx + 1}", renderers=[r]))
 
 legend = Legend(

--- a/plots/diagnostic-regression-panel/implementations/python/bokeh.py
+++ b/plots/diagnostic-regression-panel/implementations/python/bokeh.py
@@ -34,8 +34,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito pos 1 — scatter points
-ACCENT = "#D55E00"  # Okabe-Ito pos 2 — LOWESS / Q-Q reference line
-BLUE = "#0072B2"  # Okabe-Ito pos 3 — Cook's distance contours
+ACCENT = "#C475FD"  # Okabe-Ito pos 2 — LOWESS / Q-Q reference line
+BLUE = "#4467A3"  # Okabe-Ito pos 3 — Cook's distance contours
 
 # Data: Drug-response study — standardised predictors for controlled leverage
 np.random.seed(42)

--- a/plots/donut-basic/implementations/python/bokeh.py
+++ b/plots/donut-basic/implementations/python/bokeh.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette (first segment is always brand green)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — Annual budget allocation by department (USD thousands)
 categories = ["Engineering", "Operations", "Marketing", "Sales", "Support"]
@@ -33,7 +33,7 @@ angles = [v / total * 2 * pi for v in values]
 percentages = [f"{v / total * 100:.1f}%" for v in values]
 
 source = ColumnDataSource(
-    data={"category": categories, "value": values, "angle": angles, "color": OKABE_ITO[: len(categories)]}
+    data={"category": categories, "value": values, "angle": angles, "color": IMPRINT[: len(categories)]}
 )
 
 # Plot — square canvas for circular shapes

--- a/plots/donut-nested/implementations/python/bokeh.py
+++ b/plots/donut-nested/implementations/python/bokeh.py
@@ -37,9 +37,9 @@ data = {
 # Using consistent hue with varying lightness per department
 color_palettes = {
     "Engineering": ["#009E73", "#1ab98d", "#35d5a7", "#4ff1c1"],  # Greens (position 1)
-    "Marketing": ["#D55E00", "#e07714", "#eb8f28", "#f6a83c"],  # Oranges (position 2)
-    "Sales": ["#0072B2", "#1f8ac9", "#3ea2e0", "#5dbaf7"],  # Blues (position 3)
-    "Operations": ["#CC79A7", "#d98cbc", "#e69fd1", "#f3b2e6"],  # Purples (position 4)
+    "Marketing": ["#C475FD", "#e07714", "#eb8f28", "#f6a83c"],  # Oranges (position 2)
+    "Sales": ["#4467A3", "#1f8ac9", "#3ea2e0", "#5dbaf7"],  # Blues (position 3)
+    "Operations": ["#BD8233", "#d98cbc", "#e69fd1", "#f3b2e6"],  # Purples (position 4)
 }
 
 # Calculate totals and angles

--- a/plots/dot-matrix-proportional/implementations/python/bokeh.py
+++ b/plots/dot-matrix-proportional/implementations/python/bokeh.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (position 1 = brand green, always first series)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Exercise Frequency Survey, 200 respondents
 categories = ["Daily", "3–5 times/week", "1–2 times/week", "Rarely / Never"]
@@ -45,7 +45,7 @@ N_ROWS = 10  # 20 × 10 = 200 total dots
 # Build per-dot color list (filled left-to-right, top-to-bottom)
 dot_colors = []
 for i, cnt in enumerate(counts):
-    dot_colors.extend([OKABE_ITO[i]] * cnt)
+    dot_colors.extend([IMPRINT[i]] * cnt)
 
 # Compute grid coordinates (row 0 displayed at top → y = N_ROWS-1)
 xs, ys, colors = [], [], []
@@ -72,7 +72,7 @@ legend_items = []
 total = sum(counts)
 renderers = []
 for i, (cat, cnt) in enumerate(zip(categories, counts, strict=True)):
-    mask = [j for j, c in enumerate(colors) if c == OKABE_ITO[i]]
+    mask = [j for j, c in enumerate(colors) if c == IMPRINT[i]]
     pct = round(cnt / total * 100)
     src = ColumnDataSource(
         data={
@@ -83,7 +83,7 @@ for i, (cat, cnt) in enumerate(zip(categories, counts, strict=True)):
             "pct": [pct] * len(mask),
         }
     )
-    r = p.scatter("x", "y", source=src, color=OKABE_ITO[i], size=140, line_color=PAGE_BG, line_width=2)
+    r = p.scatter("x", "y", source=src, color=IMPRINT[i], size=140, line_color=PAGE_BG, line_width=2)
     renderers.append(r)
     legend_items.append(LegendItem(label=f"{cat}  ({cnt} · {pct}%)", renderers=[r]))
 

--- a/plots/drawdown-basic/implementations/python/bokeh.py
+++ b/plots/drawdown-basic/implementations/python/bokeh.py
@@ -33,8 +33,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # anyplot palette with semantic override: loss/drawdown → red
-DRAWDOWN_COLOR = "#B71D27"  # anyplot red (pos 3) — semantic: financial loss
-MAX_DD_COLOR = "#16B8F3"  # anyplot sky blue (pos 4) — contrasting accent
+DRAWDOWN_COLOR = "#AE3030"  # anyplot red (pos 3) — semantic: financial loss
+MAX_DD_COLOR = "#4467A3"  # anyplot sky blue (pos 4) — contrasting accent
 RECOVERY_COLOR = "#009E73"  # anyplot green (pos 1) — recovery / new highs
 
 # Data — simulate 3 years of daily portfolio returns

--- a/plots/dumbbell-basic/implementations/python/bokeh.py
+++ b/plots/dumbbell-basic/implementations/python/bokeh.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito 1 — "Before"
-ACCENT = "#D55E00"  # Okabe-Ito 2 — "After"
+ACCENT = "#C475FD"  # Okabe-Ito 2 — "After"
 
 # Data — Employee satisfaction scores before and after policy changes
 # (one department regressed, the rest improved by varying amounts)

--- a/plots/elbow-curve/implementations/python/bokeh.py
+++ b/plots/elbow-curve/implementations/python/bokeh.py
@@ -41,7 +41,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Generate realistic K-means inertia values
 np.random.seed(42)
@@ -101,8 +101,8 @@ p.scatter(
     x=[optimal_k],
     y=[optimal_inertia],
     size=28,
-    fill_color=OKABE_ITO[1],  # Vermillion
-    line_color=OKABE_ITO[1],
+    fill_color=IMPRINT[1],  # Vermillion
+    line_color=IMPRINT[1],
     line_width=3,
     fill_alpha=0.8,
     legend_label=f"Elbow Point (k={optimal_k})",

--- a/plots/errorbar-basic/implementations/python/bokeh.py
+++ b/plots/errorbar-basic/implementations/python/bokeh.py
@@ -21,7 +21,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito categorical palette (positions 1-6)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data — experimental measurements with associated uncertainties
 np.random.seed(42)
@@ -34,7 +34,7 @@ upper_errors = np.array([2.1, 3.5, 2.8, 2.8, 2.2, 2.5])
 
 upper = means + upper_errors
 lower = means - lower_errors
-colors = OKABE_ITO[: len(categories)]
+colors = IMPRINT[: len(categories)]
 
 source = ColumnDataSource(
     data={"categories": categories, "means": means, "upper": upper, "lower": lower, "colors": colors}

--- a/plots/facet-grid/implementations/python/bokeh.py
+++ b/plots/facet-grid/implementations/python/bokeh.py
@@ -26,10 +26,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
 ]
 
 # Data - Product performance across regions and seasons
@@ -58,7 +58,7 @@ for region in regions:
 df = pd.DataFrame(data)
 
 # Map regions to colors
-color_map = {"North": OKABE_ITO[0], "South": OKABE_ITO[1], "East": OKABE_ITO[2]}
+color_map = {"North": IMPRINT[0], "South": IMPRINT[1], "East": IMPRINT[2]}
 
 # Create grid of plots (rows=seasons, cols=regions)
 plots = []

--- a/plots/forest-basic/implementations/python/bokeh.py
+++ b/plots/forest-basic/implementations/python/bokeh.py
@@ -31,7 +31,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 
 # Data - Meta-analysis of blood pressure reduction trials
 np.random.seed(42)

--- a/plots/frequency-polygon-basic/implementations/python/bokeh.py
+++ b/plots/frequency-polygon-basic/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Three groups with different distributions
 np.random.seed(42)
@@ -71,19 +71,19 @@ source_c = ColumnDataSource(data={"x": x_extended, "y": y_c_extended})
 
 # Plot frequency polygons with fills
 # Group A - Okabe-Ito 1 (Morning Session)
-p.patch(x="x", y="y", source=source_a, fill_alpha=0.25, fill_color=OKABE_ITO[0], line_width=0)
-p.line(x="x", y="y", source=source_a, line_color=OKABE_ITO[0], line_width=3, legend_label="Morning Session")
-p.scatter(x=bin_centers, y=counts_a, size=15, color=OKABE_ITO[0], alpha=0.9)
+p.patch(x="x", y="y", source=source_a, fill_alpha=0.25, fill_color=IMPRINT[0], line_width=0)
+p.line(x="x", y="y", source=source_a, line_color=IMPRINT[0], line_width=3, legend_label="Morning Session")
+p.scatter(x=bin_centers, y=counts_a, size=15, color=IMPRINT[0], alpha=0.9)
 
 # Group B - Okabe-Ito 2 (Afternoon Session)
-p.patch(x="x", y="y", source=source_b, fill_alpha=0.25, fill_color=OKABE_ITO[1], line_width=0)
-p.line(x="x", y="y", source=source_b, line_color=OKABE_ITO[1], line_width=3, legend_label="Afternoon Session")
-p.scatter(x=bin_centers, y=counts_b, size=15, color=OKABE_ITO[1], alpha=0.9)
+p.patch(x="x", y="y", source=source_b, fill_alpha=0.25, fill_color=IMPRINT[1], line_width=0)
+p.line(x="x", y="y", source=source_b, line_color=IMPRINT[1], line_width=3, legend_label="Afternoon Session")
+p.scatter(x=bin_centers, y=counts_b, size=15, color=IMPRINT[1], alpha=0.9)
 
 # Group C - Okabe-Ito 3 (Evening Session)
-p.patch(x="x", y="y", source=source_c, fill_alpha=0.25, fill_color=OKABE_ITO[2], line_width=0)
-p.line(x="x", y="y", source=source_c, line_color=OKABE_ITO[2], line_width=3, legend_label="Evening Session")
-p.scatter(x=bin_centers, y=counts_c, size=15, color=OKABE_ITO[2], alpha=0.9)
+p.patch(x="x", y="y", source=source_c, fill_alpha=0.25, fill_color=IMPRINT[2], line_width=0)
+p.line(x="x", y="y", source=source_c, line_color=IMPRINT[2], line_width=3, legend_label="Evening Session")
+p.scatter(x=bin_centers, y=counts_c, size=15, color=IMPRINT[2], alpha=0.9)
 
 # Theme-adaptive styling
 p.background_fill_color = PAGE_BG

--- a/plots/frontier-efficient/implementations/python/bokeh.py
+++ b/plots/frontier-efficient/implementations/python/bokeh.py
@@ -30,8 +30,8 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT_1 = "#D55E00"  # Okabe-Ito position 2
-ACCENT_2 = "#0072B2"  # Okabe-Ito position 3
+ACCENT_1 = "#C475FD"  # Okabe-Ito position 2
+ACCENT_2 = "#4467A3"  # Okabe-Ito position 3
 
 # Asset data (5 assets)
 np.random.seed(42)

--- a/plots/gain-curve/implementations/python/bokeh.py
+++ b/plots/gain-curve/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series
-SECONDARY = "#D55E00"  # Second series
+SECONDARY = "#4467A3"  # imprint blue — perfect-model reference (red reserved for semantic bad)
 NEUTRAL = "#888888"  # Adaptive gray for reference
 
 # Data - Simulated customer response model

--- a/plots/gantt-basic/implementations/python/bokeh.py
+++ b/plots/gantt-basic/implementations/python/bokeh.py
@@ -54,7 +54,7 @@ df["end_ms"] = df["end"].astype("int64") // 10**6
 df["y"] = list(range(len(df) - 1, -1, -1))
 
 # Color mapping by category using Okabe-Ito palette
-okabe_ito = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+okabe_ito = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 categories = df["category"].unique().tolist()
 color_map = {cat: okabe_ito[i % len(okabe_ito)] for i, cat in enumerate(categories)}
 df["color"] = df["category"].map(color_map)

--- a/plots/gauge-basic/implementations/python/bokeh.py
+++ b/plots/gauge-basic/implementations/python/bokeh.py
@@ -20,9 +20,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito zones: low / mid / high (intuitive + colorblind-safe)
-ZONE_LOW = "#D55E00"  # vermillion
-ZONE_MID = "#E69F00"  # orange
-ZONE_HIGH = "#009E73"  # brand bluish green (Okabe-Ito position 1)
+ZONE_LOW = "#AE3030"  # imprint red — bad
+ZONE_MID = "#DDCC77"  # imprint amber — caution
+ZONE_HIGH = "#009E73"  # imprint green — good
 
 # Data
 value = 72

--- a/plots/hierarchy-toggle-view/implementations/python/bokeh.py
+++ b/plots/hierarchy-toggle-view/implementations/python/bokeh.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors for top-level departments; derived shades for sub-departments
-DEPT_COLORS = {"engineering": "#009E73", "marketing": "#D55E00", "operations": "#0072B2", "hr": "#CC79A7"}
+DEPT_COLORS = {"engineering": "#009E73", "marketing": "#C475FD", "operations": "#4467A3", "hr": "#BD8233"}
 SUB_COLORS = {
     "frontend": "#00C48D",
     "backend": "#007A58",

--- a/plots/histogram-density/implementations/python/bokeh.py
+++ b/plots/histogram-density/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series for histogram, second for PDF)
 COLOR_HIST = "#009E73"
-COLOR_PDF = "#D55E00"
+COLOR_PDF = "#C475FD"
 
 # Data - Test scores with normal-like distribution
 np.random.seed(42)

--- a/plots/histogram-kde/implementations/python/bokeh.py
+++ b/plots/histogram-kde/implementations/python/bokeh.py
@@ -36,7 +36,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
 HISTOGRAM_COLOR = "#009E73"  # Brand green
-KDE_COLOR = "#D55E00"  # Vermillion
+KDE_COLOR = "#C475FD"  # Vermillion
 
 # Data - Simulating stock returns distribution (realistic financial data)
 np.random.seed(42)

--- a/plots/histogram-overlapping/implementations/python/bokeh.py
+++ b/plots/histogram-overlapping/implementations/python/bokeh.py
@@ -31,8 +31,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (canonical order)
 BRAND = "#009E73"  # Position 1 - first series
-COLOR_2 = "#D55E00"  # Position 2
-COLOR_3 = "#0072B2"  # Position 3
+COLOR_2 = "#C475FD"  # Position 2
+COLOR_3 = "#4467A3"  # Position 3
 
 # Data - Employee response times (ms) by department
 np.random.seed(42)

--- a/plots/histogram-returns-distribution/implementations/python/bokeh.py
+++ b/plots/histogram-returns-distribution/implementations/python/bokeh.py
@@ -49,7 +49,7 @@ lower_tail = mean_return - 2 * std_return
 upper_tail = mean_return + 2 * std_return
 
 bar_colors = [
-    "#D55E00" if (edges[i] < lower_tail or edges[i + 1] > upper_tail) else "#009E73" for i in range(len(hist))
+    "#C475FD" if (edges[i] < lower_tail or edges[i + 1] > upper_tail) else "#009E73" for i in range(len(hist))
 ]
 
 hist_source = ColumnDataSource(
@@ -81,8 +81,8 @@ p = figure(
     min_border_right=50,
 )
 
-p.add_layout(BoxAnnotation(right=lower_tail, fill_alpha=0.10, fill_color="#D55E00"))
-p.add_layout(BoxAnnotation(left=upper_tail, fill_alpha=0.10, fill_color="#D55E00"))
+p.add_layout(BoxAnnotation(right=lower_tail, fill_alpha=0.10, fill_color="#C475FD"))
+p.add_layout(BoxAnnotation(left=upper_tail, fill_alpha=0.10, fill_color="#C475FD"))
 
 bars = p.quad(
     top="top",
@@ -99,7 +99,7 @@ bars = p.quad(
 hover = HoverTool(renderers=[bars], tooltips=[("Range", "@bin_left% – @bin_right%"), ("Density", "@density")])
 p.add_tools(hover)
 
-p.line(x="x", y="y", source=norm_source, line_color="#0072B2", line_width=5, legend_label="Normal Distribution")
+p.line(x="x", y="y", source=norm_source, line_color="#4467A3", line_width=5, legend_label="Normal Distribution")
 
 stats_text = f"Mean: {mean_return:.3f}%\nStd Dev: {std_return:.3f}%\nSkewness: {skewness:.3f}\nKurtosis: {kurtosis:.3f}"
 stats_label = Label(

--- a/plots/histogram-stacked/implementations/python/bokeh.py
+++ b/plots/histogram-stacked/implementations/python/bokeh.py
@@ -22,7 +22,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Simulating test scores from three different study groups
 np.random.seed(42)
@@ -87,7 +87,7 @@ p.vbar(
     bottom="bottom",
     width="width",
     source=source_c,
-    fill_color=OKABE_ITO[2],
+    fill_color=IMPRINT[2],
     line_color="white",
     line_width=2,
     alpha=0.9,
@@ -100,7 +100,7 @@ p.vbar(
     bottom="bottom",
     width="width",
     source=source_a,
-    fill_color=OKABE_ITO[0],
+    fill_color=IMPRINT[0],
     line_color="white",
     line_width=2,
     alpha=0.9,
@@ -113,7 +113,7 @@ p.vbar(
     bottom="bottom",
     width="width",
     source=source_b,
-    fill_color=OKABE_ITO[1],
+    fill_color=IMPRINT[1],
     line_color="white",
     line_width=2,
     alpha=0.9,

--- a/plots/histogram-stepwise/implementations/python/bokeh.py
+++ b/plots/histogram-stepwise/implementations/python/bokeh.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Two distributions with different spreads for comparison
 np.random.seed(42)
@@ -56,8 +56,8 @@ p = figure(
 )
 
 # Plot step histograms with Okabe-Ito colors
-line1 = p.line(x1, y1, line_width=4, color=OKABE_ITO[0], legend_label="Sensor A", alpha=0.85)
-line2 = p.line(x2, y2, line_width=4, color=OKABE_ITO[1], legend_label="Sensor B", alpha=0.85)
+line1 = p.line(x1, y1, line_width=4, color=IMPRINT[0], legend_label="Sensor A", alpha=0.85)
+line2 = p.line(x2, y2, line_width=4, color=IMPRINT[1], legend_label="Sensor B", alpha=0.85)
 
 # Add hover tooltips for interactivity
 hover1 = HoverTool(renderers=[line1], tooltips=[("Temperature (°C)", "$x{0.0}"), ("Frequency", "$y{0}")])

--- a/plots/hive-basic/implementations/python/bokeh.py
+++ b/plots/hive-basic/implementations/python/bokeh.py
@@ -24,10 +24,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
 ]
 
 # Data: Software module dependency network
@@ -138,7 +138,7 @@ for i, angle in enumerate(axis_angles):
     y_start = inner_radius * np.sin(angle)
     x_end = outer_radius * np.cos(angle)
     y_end = outer_radius * np.sin(angle)
-    p.line([x_start, x_end], [y_start, y_end], line_width=4, line_color=OKABE_ITO[i], line_alpha=0.6)
+    p.line([x_start, x_end], [y_start, y_end], line_width=4, line_color=IMPRINT[i], line_alpha=0.6)
 
     # Axis labels
     label_radius = outer_radius + 300
@@ -168,7 +168,7 @@ for source, target in edges:
     curve_x = (1 - t_vals) ** 2 * src_pos["x"] + 2 * (1 - t_vals) * t_vals * ctrl_x + t_vals**2 * tgt_pos["x"]
     curve_y = (1 - t_vals) ** 2 * src_pos["y"] + 2 * (1 - t_vals) * t_vals * ctrl_y + t_vals**2 * tgt_pos["y"]
 
-    edge_color = OKABE_ITO[src_pos["axis"]]
+    edge_color = IMPRINT[src_pos["axis"]]
     p.line(curve_x.tolist(), curve_y.tolist(), line_width=2, line_color=edge_color, line_alpha=0.4)
 
 # Draw nodes with larger sizes for visibility
@@ -186,7 +186,7 @@ for axis_id in range(n_axes):
         y="y",
         size="size",
         source=source,
-        fill_color=OKABE_ITO[axis_id],
+        fill_color=IMPRINT[axis_id],
         line_color=PAGE_BG,
         line_width=3,
         alpha=0.85,

--- a/plots/horizon-basic/implementations/python/bokeh.py
+++ b/plots/horizon-basic/implementations/python/bokeh.py
@@ -69,8 +69,8 @@ total_height = 2700
 individual_height = total_height // n_series  # ~450px per series
 
 # Okabe-Ito palette positions for color intensity (position 1 for primary, positions 2-3 for intensity)
-pos_colors = ["#56B4E9", "#0072B2", "#004494"]  # Light to dark blue (Okabe-Ito positions 6, 3, variant)
-neg_colors = ["#E69F00", "#D55E00", "#8B3A00"]  # Light to dark orange (Okabe-Ito positions 5, 2, variant)
+pos_colors = ["#2ABCCD", "#4467A3", "#004494"]  # Light to dark blue (Okabe-Ito positions 6, 3, variant)
+neg_colors = ["#E07070", "#AE3030", "#7A1F1F"]  # imprint red ramp (light → mid → dark)
 
 # Create individual horizon plots
 plots = []

--- a/plots/icicle-basic/implementations/python/bokeh.py
+++ b/plots/icicle-basic/implementations/python/bokeh.py
@@ -22,7 +22,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - File system hierarchy with nested folders and file sizes
 nodes = [
@@ -73,7 +73,7 @@ max_level = max(n["level"] for n in nodes)
 # Assign colors by level using Okabe-Ito palette
 level_colors = []
 for i in range(max_level + 1):
-    level_colors.append(OKABE_ITO[i % len(OKABE_ITO)])
+    level_colors.append(IMPRINT[i % len(IMPRINT)])
 
 
 # Calculate icicle layout (horizontal, top-down)

--- a/plots/indicator-bollinger/implementations/python/bokeh.py
+++ b/plots/indicator-bollinger/implementations/python/bokeh.py
@@ -31,8 +31,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-3)
 BRAND = "#009E73"  # Position 1 - first series (price)
-ACCENT_BLUE = "#0072B2"  # Position 3 - SMA and bands
-ACCENT_ORANGE = "#D55E00"  # Position 2 - optional
+ACCENT_BLUE = "#4467A3"  # Position 3 - SMA and bands
+ACCENT_ORANGE = "#C475FD"  # Position 2 - optional
 
 # Data - Generate synthetic stock price data
 np.random.seed(42)

--- a/plots/indicator-macd/implementations/python/bokeh.py
+++ b/plots/indicator-macd/implementations/python/bokeh.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 HIST_POSITIVE = "#009E73"  # Position 1 - brand green
 HIST_NEGATIVE = "#AE3030"  # imprint red — bars below zero
 MACD_LINE_COLOR = "#4467A3"  # Position 3 - blue
-SIGNAL_LINE_COLOR = "#AE3030"  # Position 5 - orange
+SIGNAL_LINE_COLOR = "#BD8233"  # imprint ochre — distinct from histogram bars
 
 # Data - Generate synthetic stock price data and calculate MACD
 np.random.seed(42)

--- a/plots/indicator-macd/implementations/python/bokeh.py
+++ b/plots/indicator-macd/implementations/python/bokeh.py
@@ -26,9 +26,9 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for MACD components
 HIST_POSITIVE = "#009E73"  # Position 1 - brand green
-HIST_NEGATIVE = "#D55E00"  # Position 2 - vermillion/orange
-MACD_LINE_COLOR = "#0072B2"  # Position 3 - blue
-SIGNAL_LINE_COLOR = "#E69F00"  # Position 5 - orange
+HIST_NEGATIVE = "#AE3030"  # imprint red — bars below zero
+MACD_LINE_COLOR = "#4467A3"  # Position 3 - blue
+SIGNAL_LINE_COLOR = "#AE3030"  # Position 5 - orange
 
 # Data - Generate synthetic stock price data and calculate MACD
 np.random.seed(42)

--- a/plots/indicator-sma/implementations/python/bokeh.py
+++ b/plots/indicator-sma/implementations/python/bokeh.py
@@ -26,9 +26,9 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-4)
 COLOR_CLOSE = "#009E73"  # brand green — close price (first series)
-COLOR_SMA20 = "#D55E00"  # vermillion
-COLOR_SMA50 = "#0072B2"  # blue
-COLOR_SMA200 = "#CC79A7"  # reddish purple
+COLOR_SMA20 = "#C475FD"  # vermillion
+COLOR_SMA50 = "#4467A3"  # blue
+COLOR_SMA200 = "#BD8233"  # reddish purple
 
 # Data — engineered to produce visible golden cross / death cross signals
 np.random.seed(42)

--- a/plots/kagi-basic/implementations/python/bokeh.py
+++ b/plots/kagi-basic/implementations/python/bokeh.py
@@ -36,7 +36,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 YANG_COLOR = "#009E73"  # First series - bluish green
-YIN_COLOR = "#D55E00"  # Second series - vermillion/red
+YIN_COLOR = "#AE3030"  # imprint red — bearish
 
 # Data generation
 np.random.seed(42)

--- a/plots/learning-curve-basic/implementations/python/bokeh.py
+++ b/plots/learning-curve-basic/implementations/python/bokeh.py
@@ -31,7 +31,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 TRAIN_COLOR = "#009E73"  # Position 1: brand green
-VAL_COLOR = "#D55E00"  # Position 2: vermillion
+VAL_COLOR = "#C475FD"  # Position 2: vermillion
 
 # Data - Simulate learning curve for a classification model
 np.random.seed(42)

--- a/plots/lift-curve/implementations/python/bokeh.py
+++ b/plots/lift-curve/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-SECONDARY = "#D55E00"  # Okabe-Ito position 2 (for baseline)
+SECONDARY = "#C475FD"  # Okabe-Ito position 2 (for baseline)
 
 # Data - Simulated customer response data for marketing campaign
 np.random.seed(42)

--- a/plots/line-loss-training/implementations/python/bokeh.py
+++ b/plots/line-loss-training/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 TRAIN_COLOR = "#009E73"  # bluish green - first series (brand)
-VAL_COLOR = "#D55E00"  # vermillion - second series
+VAL_COLOR = "#C475FD"  # vermillion - second series
 
 # Generate realistic neural network training data
 np.random.seed(42)

--- a/plots/line-markers/implementations/python/bokeh.py
+++ b/plots/line-markers/implementations/python/bokeh.py
@@ -60,8 +60,8 @@ p = figure(
 
 # Okabe-Ito color palette
 color_a = "#009E73"  # Okabe-Ito position 1 (bluish green)
-color_b = "#D55E00"  # Okabe-Ito position 2 (vermillion)
-color_c = "#0072B2"  # Okabe-Ito position 3 (blue)
+color_b = "#C475FD"  # Okabe-Ito position 2 (vermillion)
+color_c = "#4467A3"  # Okabe-Ito position 3 (blue)
 
 # Plot lines with markers - Station A (circles)
 line_a = p.line("x", "y", source=source_a, line_width=4, color=color_a, alpha=0.85)

--- a/plots/line-multi/implementations/python/bokeh.py
+++ b/plots/line-multi/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is #009E73)
-COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Monthly sales (thousands) for 4 product lines over 12 months
 np.random.seed(42)

--- a/plots/line-stock-comparison/implementations/python/bokeh.py
+++ b/plots/line-stock-comparison/implementations/python/bokeh.py
@@ -30,7 +30,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
 
 # Data — synthetic stock price paths via geometric Brownian motion
 n_days = 252
@@ -113,7 +113,7 @@ legend_items = []
 label_ms_offset = 8 * DAY_MS
 for i, symbol in enumerate(stocks):
     lw = 7 if symbol in (best, worst) else 4
-    line = p.line(x=df["date"], y=df[symbol], line_width=lw, line_color=ANYPLOT_PALETTE[i], alpha=0.9)
+    line = p.line(x=df["date"], y=df[symbol], line_width=lw, line_color=IMPRINT[i], alpha=0.9)
     legend_items.append((symbol, [line]))
 
     # End-of-series label showing symbol and final value with vertical alignment fix
@@ -123,7 +123,7 @@ for i, symbol in enumerate(stocks):
             x=final_date_ms + label_ms_offset,
             y=label_ys[symbol],
             text=f"{symbol} {final_vals[symbol]:.0f}",
-            text_color=ANYPLOT_PALETTE[i],
+            text_color=IMPRINT[i],
             text_font_size="28pt",
             text_font_style="bold",
             text_baseline="middle",

--- a/plots/line-styled/implementations/python/bokeh.py
+++ b/plots/line-styled/implementations/python/bokeh.py
@@ -24,11 +24,11 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
 ]
 
 # Data - Monthly performance metrics over a year
@@ -64,7 +64,7 @@ y_columns = ["cpu", "memory", "disk", "network"]
 # Create legend items
 legend_items = []
 
-for col, style, color, name in zip(y_columns, line_styles, OKABE_ITO, series_names, strict=True):
+for col, style, color, name in zip(y_columns, line_styles, IMPRINT, series_names, strict=True):
     # Add line with appropriate style
     line = p.line(x="month", y=col, source=source, line_width=6, color=color, line_dash=style)
 

--- a/plots/line-timeseries-rolling/implementations/python/bokeh.py
+++ b/plots/line-timeseries-rolling/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Simulated daily stock prices with 20-day rolling average
 np.random.seed(42)
@@ -68,7 +68,7 @@ p.line(
     source=source_raw,
     line_width=2,
     line_alpha=0.4,
-    line_color=OKABE_ITO[0],
+    line_color=IMPRINT[0],
     legend_label="Raw Data",
 )
 
@@ -78,7 +78,7 @@ p.line(
     y="rolling_avg",
     source=source_rolling,
     line_width=4,
-    line_color=OKABE_ITO[1],
+    line_color=IMPRINT[1],
     legend_label=f"{rolling_window}-Day Rolling Average",
 )
 

--- a/plots/linked-views-selection/implementations/python/bokeh.py
+++ b/plots/linked-views-selection/implementations/python/bokeh.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - using iris-like multivariate data
 np.random.seed(42)
@@ -54,7 +54,7 @@ source = ColumnDataSource(
 )
 
 # Color mapping for categories using Okabe-Ito
-color_palette = OKABE_ITO[:3]
+color_palette = IMPRINT[:3]
 color_mapper = factor_cmap("category", palette=color_palette, factors=categories)
 
 # Create scatter plot (main selection view)
@@ -74,7 +74,7 @@ scatter_renderer = scatter.scatter(
     size=15,
     color=color_mapper,
     alpha=0.8,
-    selection_color=OKABE_ITO[1],
+    selection_color=IMPRINT[1],
     selection_alpha=1.0,
     nonselection_alpha=0.15,
     nonselection_color=INK_SOFT,
@@ -120,7 +120,7 @@ histogram.quad(
     left="left",
     right="right",
     source=hist_source,
-    fill_color=OKABE_ITO[0],
+    fill_color=IMPRINT[0],
     line_color=PAGE_BG,
     alpha=0.8,
 )
@@ -210,7 +210,7 @@ scatter2.scatter(
     size=15,
     color=color_mapper,
     alpha=0.8,
-    selection_color=OKABE_ITO[1],
+    selection_color=IMPRINT[1],
     selection_alpha=1.0,
     nonselection_alpha=0.15,
     nonselection_color=INK_SOFT,

--- a/plots/logistic-regression/implementations/python/bokeh.py
+++ b/plots/logistic-regression/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors
 COLOR_0 = "#009E73"  # Class 0 - bluish green (brand color)
-COLOR_1 = "#D55E00"  # Class 1 - vermillion
+COLOR_1 = "#C475FD"  # Class 1 - vermillion
 
 # Data - Generate binary classification data
 np.random.seed(42)

--- a/plots/lollipop-grouped/implementations/python/bokeh.py
+++ b/plots/lollipop-grouped/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Quarterly revenue by product line across regions
 np.random.seed(42)
@@ -62,7 +62,7 @@ p = figure(
 # Plot lollipops for each series
 legend_items = []
 
-for series_idx, (series_name, color) in enumerate(zip(series_names, OKABE_ITO, strict=True)):
+for series_idx, (series_name, color) in enumerate(zip(series_names, IMPRINT, strict=True)):
     # Calculate x positions for this series
     x_pos = [i * (len(series_names) + 1) + series_idx for i in range(len(categories))]
     y_vals = data[series_name]

--- a/plots/manhattan-gwas/implementations/python/bokeh.py
+++ b/plots/manhattan-gwas/implementations/python/bokeh.py
@@ -26,8 +26,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for data colors
 CHROM_COLOR_1 = "#009E73"  # Okabe-Ito position 1 (first series)
-CHROM_COLOR_2 = "#D55E00"  # Okabe-Ito position 2 (alternating)
-SIG_COLOR = "#F0E442"  # Okabe-Ito position 7 (significant SNPs highlight)
+CHROM_COLOR_2 = "#C475FD"  # Okabe-Ito position 2 (alternating)
+SIG_COLOR = "#954477"  # Okabe-Ito position 7 (significant SNPs highlight)
 
 # Data - Simulated GWAS data with significant peaks
 np.random.seed(42)

--- a/plots/map-marker-clustered/implementations/python/bokeh.py
+++ b/plots/map-marker-clustered/implementations/python/bokeh.py
@@ -42,8 +42,8 @@ TILE_URL = (
     else "https://a.basemaps.cartocdn.com/dark_all/{Z}/{X}/{Y}.png"
 )
 
-# anyplot palette — canonical order
-IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
+# anyplot palette — canonical imprint slot order (green, lavender, blue, ochre)
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — coffee shop chain locations across NYC neighborhoods
 np.random.seed(42)

--- a/plots/map-marker-clustered/implementations/python/bokeh.py
+++ b/plots/map-marker-clustered/implementations/python/bokeh.py
@@ -43,7 +43,7 @@ TILE_URL = (
 )
 
 # anyplot palette — canonical order
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
 
 # Data — coffee shop chain locations across NYC neighborhoods
 np.random.seed(42)
@@ -63,7 +63,7 @@ neighborhoods = [
 
 categories = ["Coffee", "Express", "Roastery", "Reserve"]
 category_weights = [0.5, 0.3, 0.15, 0.05]
-category_colors = dict(zip(categories, ANYPLOT_PALETTE, strict=False))
+category_colors = dict(zip(categories, IMPRINT, strict=False))
 
 all_lats, all_lons, all_categories = [], [], []
 
@@ -131,7 +131,7 @@ p.add_tile(WMTSTileSource(url=TILE_URL, attribution="© OpenStreetMap contributo
 # Faint individual store markers
 individual_source = ColumnDataSource(data={"x": mercator_x, "y": mercator_y, "category": store_categories})
 p.scatter(
-    x="x", y="y", source=individual_source, size=8, fill_color=ANYPLOT_PALETTE[0], fill_alpha=0.20, line_color=None
+    x="x", y="y", source=individual_source, size=8, fill_color=IMPRINT[0], fill_alpha=0.20, line_color=None
 )
 
 # Per-category cluster renderers for legend (all 4 categories always present)

--- a/plots/map-route-path/implementations/python/bokeh.py
+++ b/plots/map-route-path/implementations/python/bokeh.py
@@ -117,14 +117,14 @@ p.scatter(
     legend_label="Start",
 )
 
-# End marker — Okabe-Ito #D55E00 (large square)
+# End marker — Okabe-Ito #C475FD (large square)
 end_src = ColumnDataSource(data={"x": [x_coords[-1]], "y": [y_coords[-1]]})
 p.scatter(
     x="x",
     y="y",
     source=end_src,
     size=32,
-    fill_color="#D55E00",
+    fill_color="#C475FD",
     line_color=PAGE_BG,
     line_width=3,
     marker="square",

--- a/plots/marimekko-basic/implementations/python/bokeh.py
+++ b/plots/marimekko-basic/implementations/python/bokeh.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-4)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Market share across regions with varying market sizes
 regions = ["North America", "Europe", "Asia Pacific", "Latin America"]
@@ -59,7 +59,7 @@ for region in regions:
         rect_y.append(current_y + height / 2)
         rect_widths.append(bar_width * 0.98)
         rect_heights.append(height)
-        rect_colors.append(OKABE_ITO[i])
+        rect_colors.append(IMPRINT[i])
         rect_products.append(product)
         rect_regions.append(region)
         rect_values.append(value)
@@ -174,7 +174,7 @@ for i, product in enumerate(products):
         right=legend_x + box_size / 2,
         top=legend_y_pos + box_size / 2,
         bottom=legend_y_pos - box_size / 2,
-        color=OKABE_ITO[i],
+        color=IMPRINT[i],
         line_color=PAGE_BG,
         line_width=2,
     )

--- a/plots/maze-circular/implementations/python/bokeh.py
+++ b/plots/maze-circular/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ sectors_per_ring = base_sectors[:rings]
 wall_color = INK
 wall_width = 5
 entry_color = "#009E73"  # Okabe-Ito position 1 (brand green)
-goal_color = "#E69F00"  # Okabe-Ito position 5 (orange)
+goal_color = "#AE3030"  # Okabe-Ito position 5 (orange)
 
 # Build maze cells: (ring, sector) -> {visited, walls}
 cells = {}

--- a/plots/mosaic-categorical/implementations/python/bokeh.py
+++ b/plots/mosaic-categorical/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-SURVIVAL_COLORS = {"Survived": "#009E73", "Did Not Survive": "#D55E00"}
+SURVIVAL_COLORS = {"Survived": "#009E73", "Did Not Survive": "#C475FD"}
 
 # Data - Titanic survival data (class vs survival)
 data = {
@@ -176,7 +176,7 @@ p.add_layout(x_axis_label)
 legend_y = 0.92
 legend_items = [
     {"color": "#009E73", "text": "Survived", "x": 0.38},
-    {"color": "#D55E00", "text": "Did Not Survive", "x": 0.58},
+    {"color": "#C475FD", "text": "Did Not Survive", "x": 0.58},
 ]
 for item in legend_items:
     p.quad(

--- a/plots/network-basic/implementations/python/bokeh.py
+++ b/plots/network-basic/implementations/python/bokeh.py
@@ -20,7 +20,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first 4 positions for the 4 communities
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: A small social network with 20 people in 4 communities
 np.random.seed(42)
@@ -160,7 +160,7 @@ for src, tgt in edges:
 # Nodes by group
 legend_items = []
 renderers_for_hover = []
-for group_id, (color, name) in enumerate(zip(OKABE_ITO, group_names, strict=True)):
+for group_id, (color, name) in enumerate(zip(IMPRINT, group_names, strict=True)):
     group_nodes = [node for node in nodes if node["group"] == group_id]
     node_x = [pos[node["id"]][0] for node in group_nodes]
     node_y = [pos[node["id"]][1] for node in group_nodes]

--- a/plots/network-bipartite/implementations/python/bokeh.py
+++ b/plots/network-bipartite/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 COLOR_A = "#009E73"  # Students - Okabe-Ito position 1
-COLOR_B = "#D55E00"  # Courses  - Okabe-Ito position 2
+COLOR_B = "#C475FD"  # Courses  - Okabe-Ito position 2
 
 # Data: student-course enrollment network
 np.random.seed(42)

--- a/plots/network-directed/implementations/python/bokeh.py
+++ b/plots/network-directed/implementations/python/bokeh.py
@@ -87,9 +87,9 @@ for i, node_id in enumerate(node_ids):
 # Okabe-Ito color palette for groups
 group_colors = {
     "core": BRAND,  # #009E73 - bluish green (Okabe-Ito position 1)
-    "infra": "#D55E00",  # vermillion
-    "shared": "#0072B2",  # blue
-    "dev": "#CC79A7",  # reddish purple
+    "infra": "#C475FD",  # vermillion
+    "shared": "#4467A3",  # blue
+    "dev": "#BD8233",  # reddish purple
 }
 
 # Prepare node data

--- a/plots/network-force-directed/implementations/python/bokeh.py
+++ b/plots/network-force-directed/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ np.random.seed(42)
 community_sizes = [18, 17, 15]
 community_names = ["Engineering", "Marketing", "Sales"]
 # Okabe-Ito positions 1, 2, 3
-community_colors = ["#009E73", "#D55E00", "#0072B2"]
+community_colors = ["#009E73", "#C475FD", "#4467A3"]
 
 nodes = []
 node_id = 0

--- a/plots/network-hierarchical/implementations/python/bokeh.py
+++ b/plots/network-hierarchical/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for level differentiation
-LEVEL_COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+LEVEL_COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Software project team hierarchy (24 employees, 4 levels)
 np.random.seed(42)

--- a/plots/network-transport-static/implementations/python/bokeh.py
+++ b/plots/network-transport-static/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 np.random.seed(42)
 
@@ -138,13 +138,13 @@ for route in routes:
 
     route_id = route["route_id"]
     if route_id.startswith("RE"):
-        color = OKABE_ITO[0]
+        color = IMPRINT[0]
     elif route_id.startswith("S"):
-        color = OKABE_ITO[1]
+        color = IMPRINT[1]
     elif route_id.startswith("EX"):
-        color = OKABE_ITO[2]
+        color = IMPRINT[2]
     else:
-        color = OKABE_ITO[3]
+        color = IMPRINT[3]
 
     # Draw arrow - scaled for large canvas
     p.add_layout(
@@ -218,9 +218,9 @@ p.add_layout(labels)
 legend_x = 3750
 legend_y = 2400
 legend_items = [
-    ("Regional Express (RE)", OKABE_ITO[0]),
-    ("S-Bahn Local (S)", OKABE_ITO[1]),
-    ("Express (EX)", OKABE_ITO[2]),
+    ("Regional Express (RE)", IMPRINT[0]),
+    ("S-Bahn Local (S)", IMPRINT[1]),
+    ("Express (EX)", IMPRINT[2]),
 ]
 
 for i, (label, color) in enumerate(legend_items):

--- a/plots/parallel-categories-basic/implementations/python/bokeh.py
+++ b/plots/parallel-categories-basic/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Product purchase journey: Channel -> Category -> Outcome
 np.random.seed(42)
@@ -87,9 +87,9 @@ ribbon_colors = []
 
 # Color by first dimension (Channel) - using Okabe-Ito palette
 channel_colors = {
-    "Online": OKABE_ITO[0],  # #009E73
-    "Store": OKABE_ITO[1],  # #D55E00
-    "Mobile": OKABE_ITO[2],  # #0072B2
+    "Online": IMPRINT[0],  # #009E73
+    "Store": IMPRINT[1],  # #C475FD
+    "Mobile": IMPRINT[2],  # #4467A3
 }
 
 # Track running position within each category box
@@ -238,7 +238,7 @@ for dim in dimensions:
     p.add_layout(label)
 
 # Add legend - centered bottom for better balance
-legend_items = [("Online", OKABE_ITO[0]), ("Store", OKABE_ITO[1]), ("Mobile", OKABE_ITO[2])]
+legend_items = [("Online", IMPRINT[0]), ("Store", IMPRINT[1]), ("Mobile", IMPRINT[2])]
 legend_x_start = 0.8
 legend_y = -0.02
 for i, (name, color) in enumerate(legend_items):

--- a/plots/parliament-basic/implementations/python/bokeh.py
+++ b/plots/parliament-basic/implementations/python/bokeh.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Political parties left-to-right by political spectrum
 # Left parties first, then center, then right
@@ -71,7 +71,7 @@ for i in range(abs(diff)):
 # Build party assignment - each seat gets a party in order
 party_assignments = []
 for i, (party, seat_count) in enumerate(zip(parties, seats, strict=True)):
-    party_assignments.extend([(party, OKABE_ITO[i % len(OKABE_ITO)])] * seat_count)
+    party_assignments.extend([(party, IMPRINT[i % len(IMPRINT)])] * seat_count)
 
 # Generate seat positions - fill row by row
 x_positions = []
@@ -119,7 +119,7 @@ p.scatter(x="x", y="y", source=source, color="color", size=40, alpha=0.9, line_c
 
 # Create legend with party colors and counts below the chart
 legend_y_pos = -0.7
-for i, (party, seat_count, color) in enumerate(zip(parties, seats, OKABE_ITO[: len(parties)], strict=True)):
+for i, (party, seat_count, color) in enumerate(zip(parties, seats, IMPRINT[: len(parties)], strict=True)):
     # Horizontal spacing for legend items
     x_offset = -1.1 + i * 0.37
 

--- a/plots/pdp-basic/implementations/python/bokeh.py
+++ b/plots/pdp-basic/implementations/python/bokeh.py
@@ -44,7 +44,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Train a model and compute partial dependence
 np.random.seed(42)

--- a/plots/phase-diagram/implementations/python/bokeh.py
+++ b/plots/phase-diagram/implementations/python/bokeh.py
@@ -96,7 +96,7 @@ p.ygrid.grid_line_alpha = 0.10
 p.outline_line_color = INK_SOFT
 
 # Okabe-Ito colors for trajectories (first series is BRAND, then alternates)
-traj_colors = [BRAND, "#D55E00", "#0072B2", "#CC79A7"]
+traj_colors = [BRAND, "#C475FD", "#4467A3", "#BD8233"]
 
 color_mapper = LinearColorMapper(palette=Viridis256, low=0, high=1)
 

--- a/plots/pie-drilldown/implementations/python/bokeh.py
+++ b/plots/pie-drilldown/implementations/python/bokeh.py
@@ -69,12 +69,12 @@ hierarchy = {
 # Okabe-Ito palette - first series ALWAYS #009E73
 colors = [
     "#009E73",  # Teal Green (Operations)
-    "#D55E00",  # Vermillion (Marketing)
-    "#0072B2",  # Blue (Research)
-    "#CC79A7",  # Pink/Magenta (HR)
-    "#E69F00",  # Orange
-    "#56B4E9",  # Sky Blue
-    "#F0E442",  # Yellow
+    "#C475FD",  # Vermillion (Marketing)
+    "#4467A3",  # Blue (Research)
+    "#BD8233",  # Pink/Magenta (HR)
+    "#AE3030",  # Orange
+    "#2ABCCD",  # Sky Blue
+    "#954477",  # Yellow
 ]
 
 # Calculate values for root level children

--- a/plots/point-and-figure-basic/implementations/python/bokeh.py
+++ b/plots/point-and-figure-basic/implementations/python/bokeh.py
@@ -26,9 +26,9 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette positions used
 X_COLOR = "#009E73"  # position 1 — brand green, bullish X columns
-O_COLOR = "#D55E00"  # position 2 — vermillion, bearish O columns
-SUPPORT_COLOR = "#0072B2"  # position 3 — blue, ascending support line
-RESISTANCE_COLOR = "#CC79A7"  # position 4 — purple, descending resistance line
+O_COLOR = "#AE3030"  # imprint red — bearish O columns
+SUPPORT_COLOR = "#4467A3"  # position 3 — blue, ascending support line
+RESISTANCE_COLOR = "#BD8233"  # position 4 — purple, descending resistance line
 
 # Data
 np.random.seed(42)

--- a/plots/polar-bar/implementations/python/bokeh.py
+++ b/plots/polar-bar/implementations/python/bokeh.py
@@ -43,16 +43,16 @@ max_freq = frequencies.max()
 radii = frequencies / max_freq * 0.75  # Scale to 75% of plot radius
 
 # Colors - Use Okabe-Ito palette (first series is brand green)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # Brand green
-    "#D55E00",  # Vermillion
-    "#0072B2",  # Blue
-    "#CC79A7",  # Reddish purple
-    "#E69F00",  # Orange
-    "#56B4E9",  # Sky blue
-    "#F0E442",  # Yellow
+    "#C475FD",  # Vermillion
+    "#4467A3",  # Blue
+    "#BD8233",  # Reddish purple
+    "#AE3030",  # Orange
+    "#2ABCCD",  # Sky blue
+    "#954477",  # Yellow
 ]
-colors = [OKABE_ITO[i % len(OKABE_ITO)] for i in range(n_dirs)]
+colors = [IMPRINT[i % len(IMPRINT)] for i in range(n_dirs)]
 
 # Create figure (square for polar plot)
 p = figure(width=3600, height=3600, x_range=(-1.05, 1.05), y_range=(-1.05, 1.05), tools="", toolbar_location=None)

--- a/plots/polar-scatter/implementations/python/bokeh.py
+++ b/plots/polar-scatter/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (categorical)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Wind measurements with prevailing directions
 np.random.seed(42)
@@ -155,7 +155,7 @@ for i, cat in enumerate(["Morning", "Afternoon", "Evening"]):
     # Add hover tool for this renderer
     hover = HoverTool(tooltips=[("Direction", "@angle{0.0}°"), ("Speed", "@speed{0.0} m/s"), ("Category", "@category")])
 
-    r = p.scatter("x", "y", source=source, size=24, color=OKABE_ITO[i], alpha=0.75, line_color=PAGE_BG, line_width=2)
+    r = p.scatter("x", "y", source=source, size=24, color=IMPRINT[i], alpha=0.75, line_color=PAGE_BG, line_width=2)
     p.add_tools(hover)
     renderers.append(r)
     legend_items.append(LegendItem(label=cat, renderers=[r]))

--- a/plots/precision-recall/implementations/python/bokeh.py
+++ b/plots/precision-recall/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Generate imbalanced classification dataset
 np.random.seed(42)

--- a/plots/pyramid-basic/implementations/python/bokeh.py
+++ b/plots/pyramid-basic/implementations/python/bokeh.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 MALE_COLOR = "#009E73"  # Okabe-Ito position 1
-FEMALE_COLOR = "#D55E00"  # Okabe-Ito position 2
+FEMALE_COLOR = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Population by age group (in thousands)
 age_groups = ["0-9", "10-19", "20-29", "30-39", "40-49", "50-59", "60-69", "70-79", "80+"]

--- a/plots/radar-multi/implementations/python/bokeh.py
+++ b/plots/radar-multi/implementations/python/bokeh.py
@@ -21,7 +21,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Product comparison across 6 attributes
 categories = ["Performance", "Reliability", "Features", "Support", "Price Value", "Ease of Use"]
@@ -115,15 +115,15 @@ for idx, (product_name, values) in enumerate(products.items()):
     fill_renderer = p.patch(
         x_vals,
         y_vals,
-        fill_color=OKABE_ITO[idx],
+        fill_color=IMPRINT[idx],
         fill_alpha=0.25,
-        line_color=OKABE_ITO[idx],
+        line_color=IMPRINT[idx],
         line_width=4,
         line_alpha=0.9,
     )
 
     # Draw points at vertices
-    p.scatter(x_vals[:-1], y_vals[:-1], size=22, fill_color=OKABE_ITO[idx], line_color=PAGE_BG, line_width=3, alpha=0.9)
+    p.scatter(x_vals[:-1], y_vals[:-1], size=22, fill_color=IMPRINT[idx], line_color=PAGE_BG, line_width=3, alpha=0.9)
 
     legend_items.append((product_name, [fill_renderer]))
 

--- a/plots/range-interval/implementations/python/bokeh.py
+++ b/plots/range-interval/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Temperature ranges across months
 np.random.seed(42)

--- a/plots/renko-basic/implementations/python/bokeh.py
+++ b/plots/renko-basic/implementations/python/bokeh.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BULLISH_COLOR = "#009E73"  # Okabe-Ito position 1 — always first series (green)
-BEARISH_COLOR = "#D55E00"  # Okabe-Ito position 2 — vermillion
+BEARISH_COLOR = "#AE3030"  # imprint red — down bricks
 
 # Generate synthetic stock price data
 np.random.seed(42)

--- a/plots/residual-plot/implementations/python/bokeh.py
+++ b/plots/residual-plot/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 (residuals)
-OUTLIER_COLOR = "#D55E00"  # Okabe-Ito position 2 (outliers)
+OUTLIER_COLOR = "#C475FD"  # Okabe-Ito position 2 (outliers)
 
 # Data - Linear regression example with realistic housing price prediction
 np.random.seed(42)

--- a/plots/roc-curve/implementations/python/bokeh.py
+++ b/plots/roc-curve/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Simulated ROC curves for three classifiers with different performance levels
 np.random.seed(42)
@@ -81,9 +81,9 @@ random_line = p.line(
 )
 
 # Plot ROC curves with Okabe-Ito colors
-line_1 = p.line(x="fpr", y="tpr", source=source_1, line_width=5, line_color=OKABE_ITO[0], alpha=0.9)
-line_2 = p.line(x="fpr", y="tpr", source=source_2, line_width=5, line_color=OKABE_ITO[1], alpha=0.9)
-line_3 = p.line(x="fpr", y="tpr", source=source_3, line_width=5, line_color=OKABE_ITO[2], alpha=0.9)
+line_1 = p.line(x="fpr", y="tpr", source=source_1, line_width=5, line_color=IMPRINT[0], alpha=0.9)
+line_2 = p.line(x="fpr", y="tpr", source=source_2, line_width=5, line_color=IMPRINT[1], alpha=0.9)
+line_3 = p.line(x="fpr", y="tpr", source=source_3, line_width=5, line_color=IMPRINT[2], alpha=0.9)
 
 # Add HoverTool for interactivity
 hover = HoverTool(tooltips=[("FPR", "@fpr{0.00}"), ("TPR", "@tpr{0.00}")])

--- a/plots/sankey-basic/implementations/python/bokeh.py
+++ b/plots/sankey-basic/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first source always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Energy flow from sources to sectors (TWh)
 flows = [
@@ -52,7 +52,7 @@ for f in flows:
         targets.append(f["target"])
 
 # Source colors: Okabe-Ito in canonical order
-source_colors = {s: OKABE_ITO[i] for i, s in enumerate(sources)}
+source_colors = {s: IMPRINT[i] for i, s in enumerate(sources)}
 
 # Target node colors: slightly muted variants of INK_SOFT family
 target_node_colors = {"Industrial": "#5A6A7A", "Commercial": "#7A6A8A", "Residential": "#6A7A5A"}

--- a/plots/scatter-animated-controls/implementations/python/bokeh.py
+++ b/plots/scatter-animated-controls/implementations/python/bokeh.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (regions)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data: Simulated country metrics over 20 years (Gapminder-style)
 np.random.seed(42)
@@ -127,7 +127,7 @@ for year in years:
 
 # Define regions and color palette using Okabe-Ito
 regions_list = ["North", "South", "East", "West", "Central"]
-color_palette = OKABE_ITO
+color_palette = IMPRINT
 
 # Create figure
 p = figure(

--- a/plots/scatter-brush-zoom/implementations/python/bokeh.py
+++ b/plots/scatter-brush-zoom/implementations/python/bokeh.py
@@ -42,7 +42,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Generate clustered data for demonstrating brush selection
 np.random.seed(42)
@@ -89,7 +89,7 @@ p.toolbar.active_drag = box_select
 p.toolbar.active_scroll = wheel_zoom
 
 # Color mapping with Okabe-Ito palette
-color_map = factor_cmap("category", palette=OKABE_ITO, factors=labels)
+color_map = factor_cmap("category", palette=IMPRINT, factors=labels)
 
 # Scatter plot with selection styling
 p.scatter(
@@ -144,7 +144,7 @@ p.border_fill_color = PAGE_BG
 # Legend
 legend_items = []
 for i, label in enumerate(labels):
-    r = p.scatter([], [], fill_color=OKABE_ITO[i], line_color=PAGE_BG, size=15)
+    r = p.scatter([], [], fill_color=IMPRINT[i], line_color=PAGE_BG, size=15)
     legend_items.append(LegendItem(label=label, renderers=[r]))
 
 legend = Legend(items=legend_items, location="top_right")

--- a/plots/scatter-embedding/implementations/python/bokeh.py
+++ b/plots/scatter-embedding/implementations/python/bokeh.py
@@ -29,7 +29,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 CLUSTER_NAMES = [
     "Machine Learning",
     "Data Engineering",
@@ -99,7 +99,7 @@ p.xgrid.grid_line_alpha = 0.08
 p.ygrid.grid_line_alpha = 0.08
 
 # One scatter call per cluster so Bokeh assigns legend entries
-for i, (name, color) in enumerate(zip(CLUSTER_NAMES, OKABE_ITO, strict=False)):
+for i, (name, color) in enumerate(zip(CLUSTER_NAMES, IMPRINT, strict=False)):
     mask = labels == i
     source = ColumnDataSource(
         data={"x": embedding[mask, 0], "y": embedding[mask, 1], "cluster": [name] * int(mask.sum())}
@@ -117,7 +117,7 @@ for i, (name, color) in enumerate(zip(CLUSTER_NAMES, OKABE_ITO, strict=False)):
     )
 
 # Centroid annotations — label each cluster at its centre for storytelling
-for i, (name, color) in enumerate(zip(CLUSTER_NAMES, OKABE_ITO, strict=False)):
+for i, (name, color) in enumerate(zip(CLUSTER_NAMES, IMPRINT, strict=False)):
     mask = labels == i
     cx = float(embedding[mask, 0].mean())
     cy = float(embedding[mask, 1].mean())

--- a/plots/scatter-matrix-interactive/implementations/python/bokeh.py
+++ b/plots/scatter-matrix-interactive/implementations/python/bokeh.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Iris dataset
 iris = load_iris()
@@ -36,7 +36,7 @@ df["species"] = [iris.target_names[t] for t in iris.target]
 
 # Color mapping for species using Okabe-Ito
 species_names = ["setosa", "versicolor", "virginica"]
-color_map = {name: OKABE_ITO[i] for i, name in enumerate(species_names)}
+color_map = {name: IMPRINT[i] for i, name in enumerate(species_names)}
 df["color"] = df["species"].map(color_map)
 
 # Use 4 variables for the scatter matrix
@@ -87,7 +87,7 @@ for i, var_y in enumerate(variables):
                 bottom=0,
                 left=edges[:-1],
                 right=edges[1:],
-                fill_color=OKABE_ITO[0],
+                fill_color=IMPRINT[0],
                 line_color=PAGE_BG,
                 alpha=0.7,
             )

--- a/plots/scatter-matrix/implementations/python/bokeh.py
+++ b/plots/scatter-matrix/implementations/python/bokeh.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 species_list = ["setosa", "versicolor", "virginica"]
 
 # Data - Iris-like dataset with 4 variables and species groups
@@ -81,7 +81,7 @@ for i in range(n_vars):
                     left="left",
                     right="right",
                     source=source,
-                    fill_color=OKABE_ITO[k],
+                    fill_color=IMPRINT[k],
                     line_color=PAGE_BG,
                     line_width=1.5,
                     alpha=0.7,
@@ -110,7 +110,7 @@ for i in range(n_vars):
                 source=source,
                 size=14,
                 alpha=0.65,
-                fill_color=factor_cmap("species", OKABE_ITO, species_list),
+                fill_color=factor_cmap("species", IMPRINT, species_list),
                 line_color="white" if THEME == "light" else "#2A2A27",
                 line_width=0.8,
             )

--- a/plots/scatter-regression-linear/implementations/python/bokeh.py
+++ b/plots/scatter-regression-linear/implementations/python/bokeh.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Study hours vs exam scores
 np.random.seed(42)
@@ -83,20 +83,20 @@ band = Band(
     lower="lower",
     upper="upper",
     source=band_source,
-    fill_color=OKABE_ITO[0],
+    fill_color=IMPRINT[0],
     fill_alpha=0.15,
-    line_color=OKABE_ITO[0],
+    line_color=IMPRINT[0],
     line_alpha=0.2,
     line_width=1,
 )
 p.add_layout(band)
 
 # Add regression line
-p.line("x", "y", source=line_source, line_color=OKABE_ITO[1], line_width=5, legend_label="Linear Regression")
+p.line("x", "y", source=line_source, line_color=IMPRINT[1], line_width=5, legend_label="Linear Regression")
 
 # Add scatter points with hover tooltip
 scatter = p.scatter(
-    "x", "y", source=scatter_source, size=16, color=OKABE_ITO[0], alpha=0.65, legend_label="Data Points"
+    "x", "y", source=scatter_source, size=16, color=IMPRINT[0], alpha=0.65, legend_label="Data Points"
 )
 
 # Add hover tooltip

--- a/plots/scatter-regression-lowess/implementations/python/bokeh.py
+++ b/plots/scatter-regression-lowess/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2 for LOWESS curve
+ACCENT = "#C475FD"  # Okabe-Ito position 2 for LOWESS curve
 
 # Data: Simulate a complex non-linear relationship (e.g., temperature vs enzyme activity)
 np.random.seed(42)

--- a/plots/scatter-regression-polynomial/implementations/python/bokeh.py
+++ b/plots/scatter-regression-polynomial/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series - always green
-ACCENT = "#D55E00"  # Second series - vermillion for contrast
+ACCENT = "#C475FD"  # Second series - vermillion for contrast
 
 # Data - Manufacturing efficiency curve (diminishing returns pattern)
 np.random.seed(42)

--- a/plots/shap-waterfall/implementations/python/bokeh.py
+++ b/plots/shap-waterfall/implementations/python/bokeh.py
@@ -28,8 +28,8 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-POS_COLOR = "#D55E00"  # Okabe-Ito vermillion — positive SHAP (pushes prediction up)
-NEG_COLOR = "#0072B2"  # Okabe-Ito blue — negative SHAP (pushes prediction down)
+POS_COLOR = "#AE3030"  # imprint red — positive SHAP (pushes prediction up)
+NEG_COLOR = "#4467A3"  # Okabe-Ito blue — negative SHAP (pushes prediction down)
 LABEL_INK = "#F0EFE8"  # near-white for text on colored bar segments
 
 # Data — credit default risk model: explaining one loan applicant's prediction

--- a/plots/silhouette-basic/implementations/python/bokeh.py
+++ b/plots/silhouette-basic/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito colors for clusters
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - simulating silhouette analysis of customer segmentation (3 clusters)
 # Realistic scenario: clustering customers by purchase behavior
@@ -79,7 +79,7 @@ for i in range(n_clusters):
         bar_data["y"].append(y_lower + j + 0.5)  # Y position
         bar_data["width"].append(abs(val))  # Width = silhouette value
         bar_data["height"].append(0.85)  # Slightly less than 1 for gap
-        bar_data["color"].append(OKABE_ITO[i])
+        bar_data["color"].append(IMPRINT[i])
 
     y_lower = y_upper + 15  # Gap between clusters
 
@@ -148,7 +148,7 @@ for center_y, cluster_avg, size, cluster_idx in cluster_info:
         y=center_y,
         text=f"Cluster {cluster_idx}",
         text_font_size="18pt",
-        text_color=OKABE_ITO[cluster_idx],
+        text_color=IMPRINT[cluster_idx],
         text_font_style="bold",
         text_align="left",
         text_baseline="middle",
@@ -161,7 +161,7 @@ for center_y, cluster_avg, size, cluster_idx in cluster_info:
         y=center_y,
         text=f"n={size}, avg={cluster_avg:.2f}",
         text_font_size="16pt",
-        text_color=OKABE_ITO[cluster_idx],
+        text_color=IMPRINT[cluster_idx],
         text_font_style="normal",
         text_align="left",
         text_baseline="middle",

--- a/plots/skewt-logp-atmospheric/implementations/python/bokeh.py
+++ b/plots/skewt-logp-atmospheric/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data
 np.random.seed(42)
@@ -139,7 +139,7 @@ for theta in np.arange(250, 400, 20):
     mask = (t_adiabat > -80) & (t_adiabat < 60)
     if np.any(mask):
         src = ColumnDataSource(data={"x": x_adiabat[mask], "y": p_range[mask]})
-        fig.line(x="x", y="y", source=src, line_color=OKABE_ITO[4], line_width=1.5, line_alpha=0.50, line_dash="dashed")
+        fig.line(x="x", y="y", source=src, line_color=IMPRINT[4], line_width=1.5, line_alpha=0.50, line_dash="dashed")
 
 # Moist adiabats (pseudoadiabats — simplified iterative approximation)
 for t_start in np.arange(-10, 35, 10):
@@ -157,7 +157,7 @@ for t_start in np.arange(-10, 35, 10):
     if np.any(mask):
         src = ColumnDataSource(data={"x": x_moist[mask], "y": p_range[mask]})
         fig.line(
-            x="x", y="y", source=src, line_color=OKABE_ITO[5], line_width=1.5, line_alpha=0.50, line_dash="dotdash"
+            x="x", y="y", source=src, line_color=IMPRINT[5], line_width=1.5, line_alpha=0.50, line_dash="dotdash"
         )
 
 # Mixing ratio lines
@@ -166,27 +166,27 @@ for mr in [1, 2, 4, 8, 12, 16, 20]:
     log_p = np.log10(p_range / 1000.0)
     x_mr = np.full_like(p_range, td_mr) - SKEW_FACTOR * log_p
     src = ColumnDataSource(data={"x": x_mr, "y": p_range})
-    fig.line(x="x", y="y", source=src, line_color=OKABE_ITO[3], line_width=1.2, line_alpha=0.40, line_dash="dotted")
+    fig.line(x="x", y="y", source=src, line_color=IMPRINT[3], line_width=1.2, line_alpha=0.40, line_dash="dotted")
 
 # Highlighted 0°C isotherm
 log_p_ref = np.log10(p_range / 1000.0)
 x_freeze = -SKEW_FACTOR * log_p_ref
 src_freeze = ColumnDataSource(data={"x": x_freeze, "y": p_range})
 fig.line(
-    x="x", y="y", source=src_freeze, line_color=OKABE_ITO[2], line_width=3, line_alpha=0.85, legend_label="0°C Isotherm"
+    x="x", y="y", source=src_freeze, line_color=IMPRINT[2], line_width=3, line_alpha=0.85, legend_label="0°C Isotherm"
 )
 
 # Temperature profile
 src_temp = ColumnDataSource(data={"x": x_temp, "y": pressure, "temp_c": np.round(temperature, 1)})
-fig.line(x="x", y="y", source=src_temp, line_color=OKABE_ITO[0], line_width=5, legend_label="Temperature")
-temp_scatter = fig.scatter(x="x", y="y", source=src_temp, size=14, color=OKABE_ITO[0], alpha=0.85)
+fig.line(x="x", y="y", source=src_temp, line_color=IMPRINT[0], line_width=5, legend_label="Temperature")
+temp_scatter = fig.scatter(x="x", y="y", source=src_temp, size=14, color=IMPRINT[0], alpha=0.85)
 
 # Dewpoint profile
 src_dew = ColumnDataSource(data={"x": x_dewpoint, "y": pressure, "dewpt_c": np.round(dewpoint, 1)})
 fig.line(
-    x="x", y="y", source=src_dew, line_color=OKABE_ITO[1], line_width=5, line_dash="dashed", legend_label="Dewpoint"
+    x="x", y="y", source=src_dew, line_color=IMPRINT[1], line_width=5, line_dash="dashed", legend_label="Dewpoint"
 )
-dew_scatter = fig.scatter(x="x", y="y", source=src_dew, size=14, color=OKABE_ITO[1], alpha=0.85, marker="diamond")
+dew_scatter = fig.scatter(x="x", y="y", source=src_dew, size=14, color=IMPRINT[1], alpha=0.85, marker="diamond")
 
 # HoverTools for interactive temperature/pressure display
 fig.add_tools(HoverTool(renderers=[temp_scatter], tooltips=[("Pressure", "@y{0} hPa"), ("Temperature", "@temp_c °C")]))
@@ -195,13 +195,13 @@ fig.add_tools(CrosshairTool(), WheelZoomTool())
 
 # Reference line labels
 fig.add_layout(
-    Label(x=-34, y=340, text="Dry Adiabats", text_font_size="33pt", text_color=OKABE_ITO[4], text_alpha=0.90)
+    Label(x=-34, y=340, text="Dry Adiabats", text_font_size="33pt", text_color=IMPRINT[4], text_alpha=0.90)
 )
 fig.add_layout(
-    Label(x=24, y=195, text="Moist Adiabats", text_font_size="33pt", text_color=OKABE_ITO[5], text_alpha=0.90)
+    Label(x=24, y=195, text="Moist Adiabats", text_font_size="33pt", text_color=IMPRINT[5], text_alpha=0.90)
 )
 fig.add_layout(
-    Label(x=-48, y=590, text="Mixing Ratio", text_font_size="33pt", text_color=OKABE_ITO[3], text_alpha=0.90)
+    Label(x=-48, y=590, text="Mixing Ratio", text_font_size="33pt", text_color=IMPRINT[3], text_alpha=0.90)
 )
 
 # Legend

--- a/plots/slope-basic/implementations/python/bokeh.py
+++ b/plots/slope-basic/implementations/python/bokeh.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 INCREASE_COLOR = "#009E73"  # Okabe-Ito position 1 (brand green)
-DECREASE_COLOR = "#D55E00"  # Okabe-Ito position 2 (vermillion)
+DECREASE_COLOR = "#AE3030"  # imprint red — decrease
 
 products = [
     "Product A",

--- a/plots/smith-chart-basic/implementations/python/bokeh.py
+++ b/plots/smith-chart-basic/implementations/python/bokeh.py
@@ -31,8 +31,8 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito data colors (theme-independent)
 LOCUS_COLOR = "#009E73"  # position 1 — brand green, impedance locus
-BOUNDARY_COLOR = "#0072B2"  # position 3 — blue, unit circle boundary
-MARKER_COLOR = "#D55E00"  # position 2 — vermillion, matched condition
+BOUNDARY_COLOR = "#4467A3"  # position 3 — blue, unit circle boundary
+MARKER_COLOR = "#C475FD"  # position 2 — vermillion, matched condition
 
 # Reference impedance
 Z0 = 50  # ohms

--- a/plots/sn-curve-basic/implementations/python/bokeh.py
+++ b/plots/sn-curve-basic/implementations/python/bokeh.py
@@ -28,9 +28,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — data series
-ULT_COLOR = "#D55E00"  # Okabe-Ito position 2 — Ultimate Strength line
-ENDU_COLOR = "#0072B2"  # Okabe-Ito position 3 — Endurance Limit line
-YIELD_COLOR = "#CC79A7"  # Okabe-Ito position 4 — Yield Strength line
+ULT_COLOR = "#C475FD"  # Okabe-Ito position 2 — Ultimate Strength line
+ENDU_COLOR = "#4467A3"  # Okabe-Ito position 3 — Endurance Limit line
+YIELD_COLOR = "#BD8233"  # Okabe-Ito position 4 — Yield Strength line
 
 # Data — S-N fatigue test results for steel specimens (Basquin equation)
 np.random.seed(42)

--- a/plots/span-basic/implementations/python/bokeh.py
+++ b/plots/span-basic/implementations/python/bokeh.py
@@ -45,9 +45,9 @@ vertical_span = BoxAnnotation(
 )
 p.add_layout(vertical_span)
 
-# Add horizontal span - highlight target revenue range (120-140)
+# Add horizontal span - highlight target revenue range (120-140) using imprint amber
 horizontal_span = BoxAnnotation(
-    bottom=120, top=140, fill_alpha=0.2, fill_color="#AE3030", line_color="#AE3030", line_width=2, line_alpha=0.5
+    bottom=120, top=140, fill_alpha=0.2, fill_color="#DDCC77", line_color="#DDCC77", line_width=2, line_alpha=0.5
 )
 p.add_layout(horizontal_span)
 

--- a/plots/span-basic/implementations/python/bokeh.py
+++ b/plots/span-basic/implementations/python/bokeh.py
@@ -41,13 +41,13 @@ p = figure(
 
 # Add vertical span - highlight Q4 of Year 1 (months 10-12)
 vertical_span = BoxAnnotation(
-    left=10, right=12, fill_alpha=0.25, fill_color="#0072B2", line_color="#0072B2", line_width=2, line_alpha=0.5
+    left=10, right=12, fill_alpha=0.25, fill_color="#4467A3", line_color="#4467A3", line_width=2, line_alpha=0.5
 )
 p.add_layout(vertical_span)
 
 # Add horizontal span - highlight target revenue range (120-140)
 horizontal_span = BoxAnnotation(
-    bottom=120, top=140, fill_alpha=0.2, fill_color="#E69F00", line_color="#E69F00", line_width=2, line_alpha=0.5
+    bottom=120, top=140, fill_alpha=0.2, fill_color="#AE3030", line_color="#AE3030", line_width=2, line_alpha=0.5
 )
 p.add_layout(horizontal_span)
 
@@ -61,7 +61,7 @@ p.add_tools(hover)
 
 # Add labels for spans — positioned prominently at top of each span
 vertical_label = Label(
-    x=10.2, y=143, text="Q4 Peak Season", text_font_size="28pt", text_color="#0072B2", text_font_style="bold"
+    x=10.2, y=143, text="Q4 Peak Season", text_font_size="28pt", text_color="#4467A3", text_font_style="bold"
 )
 p.add_layout(vertical_label)
 
@@ -70,7 +70,7 @@ horizontal_label = Label(
     y=124,
     text="Target Range",
     text_font_size="28pt",
-    text_color="#B8720B" if THEME == "light" else "#E69F00",
+    text_color="#B8720B" if THEME == "light" else "#AE3030",
     text_font_style="bold",
 )
 p.add_layout(horizontal_label)

--- a/plots/sparkline-basic/implementations/python/bokeh.py
+++ b/plots/sparkline-basic/implementations/python/bokeh.py
@@ -19,7 +19,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette — identical across themes; only chrome flips.
 LINE_COLOR = "#009E73"
-MIN_COLOR = "#D55E00"
+MIN_COLOR = "#C475FD"
 MAX_COLOR = "#009E73"
 
 # Data — daily web-traffic sessions over 60 days, with a launch bump,

--- a/plots/spectrum-basic/implementations/python/bokeh.py
+++ b/plots/spectrum-basic/implementations/python/bokeh.py
@@ -84,7 +84,7 @@ p.add_tools(hover)
 
 # Mark peak frequencies with circles
 peak_freqs = [50, 150, 400]
-peak_colors = ["#D55E00", "#0072B2", "#CC79A7"]  # Okabe-Ito positions 2, 3, 4
+peak_colors = ["#C475FD", "#4467A3", "#BD8233"]  # Okabe-Ito positions 2, 3, 4
 for freq, color in zip(peak_freqs, peak_colors, strict=True):
     freq_idx = np.argmin(np.abs(frequencies - freq))
     peak_amp = amplitude_db[freq_idx]

--- a/plots/streamgraph-basic/implementations/python/bokeh.py
+++ b/plots/streamgraph-basic/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: monthly streaming hours by music genre over two years
 np.random.seed(42)

--- a/plots/strip-basic/implementations/python/bokeh.py
+++ b/plots/strip-basic/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Survey response scores by department
 np.random.seed(42)
@@ -42,7 +42,7 @@ data = {
 x_values = []
 y_values = []
 colors = []
-color_map = dict(zip(categories, OKABE_ITO, strict=True))
+color_map = dict(zip(categories, IMPRINT, strict=True))
 
 jitter_width = 0.25
 

--- a/plots/subplot-grid/implementations/python/bokeh.py
+++ b/plots/subplot-grid/implementations/python/bokeh.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Financial dashboard with multiple metrics
 np.random.seed(42)
@@ -64,8 +64,8 @@ p1 = figure(
     tools="",
     toolbar_location=None,
 )
-p1.line("x", "y", source=source_price, line_width=4, color=OKABE_ITO[0], alpha=0.9)
-p1.scatter("x", "y", source=source_price, size=12, color=OKABE_ITO[0], alpha=0.6)
+p1.line("x", "y", source=source_price, line_width=4, color=IMPRINT[0], alpha=0.9)
+p1.scatter("x", "y", source=source_price, size=12, color=IMPRINT[0], alpha=0.6)
 
 # Styling for p1
 p1.background_fill_color = PAGE_BG
@@ -101,7 +101,7 @@ p2 = figure(
     tools="",
     toolbar_location=None,
 )
-p2.vbar(x="x", top="y", source=source_volume, width=0.7, color=OKABE_ITO[1], alpha=0.8)
+p2.vbar(x="x", top="y", source=source_volume, width=0.7, color=IMPRINT[1], alpha=0.8)
 
 # Styling for p2
 p2.background_fill_color = PAGE_BG
@@ -127,7 +127,7 @@ p2.grid.grid_line_alpha = 0.10
 
 # ========== SUBPLOT 3: Risk vs Return Scatter (bottom-left) ==========
 # Color by performance using Okabe-Ito palette
-colors = [OKABE_ITO[0] if r > 8 else (OKABE_ITO[2] if r < 5 else OKABE_ITO[1]) for r in asset_returns]
+colors = [IMPRINT[0] if r > 8 else (IMPRINT[2] if r < 5 else IMPRINT[1]) for r in asset_returns]
 
 source_scatter = ColumnDataSource(data={"x": asset_risk, "y": asset_returns, "color": colors})
 
@@ -184,7 +184,7 @@ p4.quad(
     left="left",
     right="right",
     source=source_hist,
-    fill_color=OKABE_ITO[2],
+    fill_color=IMPRINT[2],
     line_color=PAGE_BG,
     alpha=0.8,
     line_width=2,

--- a/plots/subplot-mosaic/implementations/python/bokeh.py
+++ b/plots/subplot-mosaic/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 np.random.seed(42)
 
@@ -94,8 +94,8 @@ def style_figure(fig):
 p_a = figure(
     width=3200, height=1100, title="Quarterly Revenue Overview", x_axis_label="Day", y_axis_label="Revenue ($)"
 )
-p_a.line("day", "revenue", source=source_a, line_width=4, color=OKABE_ITO[0], legend_label="Daily Revenue")
-p_a.scatter("day", "revenue", source=source_a, size=15, color=OKABE_ITO[0], alpha=0.7)
+p_a.line("day", "revenue", source=source_a, line_width=4, color=IMPRINT[0], legend_label="Daily Revenue")
+p_a.scatter("day", "revenue", source=source_a, size=15, color=IMPRINT[0], alpha=0.7)
 p_a.legend.label_text_font_size = "16pt"
 p_a.legend.background_fill_color = ELEVATED_BG
 p_a.legend.border_line_color = INK_SOFT
@@ -107,10 +107,10 @@ p_b = figure(
     width=1600, height=1100, title="Product Profitability", x_axis_label="Units Sold", y_axis_label="Profit Margin (%)"
 )
 p_b.scatter(
-    "products", "profit_margin", source=source_b1, size=18, color=OKABE_ITO[0], alpha=0.7, legend_label="Premium Line"
+    "products", "profit_margin", source=source_b1, size=18, color=IMPRINT[0], alpha=0.7, legend_label="Premium Line"
 )
 p_b.scatter(
-    "products", "profit_margin", source=source_b2, size=18, color=OKABE_ITO[1], alpha=0.7, legend_label="Standard Line"
+    "products", "profit_margin", source=source_b2, size=18, color=IMPRINT[1], alpha=0.7, legend_label="Standard Line"
 )
 p_b.legend.label_text_font_size = "14pt"
 p_b.legend.background_fill_color = ELEVATED_BG
@@ -137,7 +137,7 @@ p_c.vbar(
     top="sales",
     source=source_c,
     width=0.7,
-    color=OKABE_ITO[0],
+    color=IMPRINT[0],
     alpha=0.85,
     line_color=PAGE_BG,
     line_width=2,
@@ -172,7 +172,7 @@ p_f.vbar(
     top="satisfaction",
     source=source_f,
     width=0.6,
-    color=OKABE_ITO[1],
+    color=IMPRINT[1],
     alpha=0.9,
     line_color=PAGE_BG,
     line_width=2,
@@ -193,10 +193,10 @@ style_figure(p_f)
 p_d = figure(
     width=4800, height=700, title="subplot-mosaic · bokeh · anyplot.ai", x_axis_label="Month", y_axis_label="Orders"
 )
-p_d.line("month", "orders", source=source_d1, line_width=5, color=OKABE_ITO[0], legend_label="2023")
-p_d.scatter("month", "orders", source=source_d1, size=18, color=OKABE_ITO[0])
-p_d.line("month", "orders", source=source_d2, line_width=5, color=OKABE_ITO[1], legend_label="2024")
-p_d.scatter("month", "orders", source=source_d2, size=18, color=OKABE_ITO[1])
+p_d.line("month", "orders", source=source_d1, line_width=5, color=IMPRINT[0], legend_label="2023")
+p_d.scatter("month", "orders", source=source_d1, size=18, color=IMPRINT[0])
+p_d.line("month", "orders", source=source_d2, line_width=5, color=IMPRINT[1], legend_label="2024")
+p_d.scatter("month", "orders", source=source_d2, size=18, color=IMPRINT[1])
 p_d.legend.label_text_font_size = "18pt"
 p_d.legend.background_fill_color = ELEVATED_BG
 p_d.legend.border_line_color = INK_SOFT

--- a/plots/sunburst-basic/implementations/python/bokeh.py
+++ b/plots/sunburst-basic/implementations/python/bokeh.py
@@ -55,10 +55,10 @@ hierarchy = [
 
 # Department color families using Okabe-Ito bases with tints for child levels
 dept_colors = {
-    "Engineering": {"base": "#009E73", "mid": "#55C4A4", "light": "#AAE0D5"},
-    "Marketing": {"base": "#AE3030", "mid": "#F0BC4D", "light": "#F7D899"},
-    "Sales": {"base": "#4467A3", "mid": "#4DA6D5", "light": "#99CDE8"},
-    "Operations": {"base": "#BD8233", "mid": "#DDA5C5", "light": "#EED2E3"},
+    "Engineering": {"base": "#009E73", "mid": "#55C4A4", "light": "#AAE0D5"},  # imprint green family
+    "Marketing": {"base": "#AE3030", "mid": "#C56666", "light": "#DEAAAA"},  # imprint red family
+    "Sales": {"base": "#4467A3", "mid": "#7A93BD", "light": "#B0BFD8"},  # imprint blue family
+    "Operations": {"base": "#BD8233", "mid": "#D1A668", "light": "#E5C9A3"},  # imprint ochre family
 }
 
 # Clearer abbreviations than 3-char truncation

--- a/plots/sunburst-basic/implementations/python/bokeh.py
+++ b/plots/sunburst-basic/implementations/python/bokeh.py
@@ -38,16 +38,16 @@ hierarchy = [
     {"level_1": "Engineering", "level_2": "Frontend", "level_3": "Web App", "value": 100},
     {"level_1": "Engineering", "level_2": "Frontend", "level_3": "Mobile", "value": 60},
     {"level_1": "Engineering", "level_2": "DevOps", "level_3": "Infrastructure", "value": 50},
-    # Marketing (Okabe-Ito position 5: #E69F00)
+    # Marketing (Okabe-Ito position 5: #AE3030)
     {"level_1": "Marketing", "level_2": "Digital", "level_3": "Social Media", "value": 45},
     {"level_1": "Marketing", "level_2": "Digital", "level_3": "SEO", "value": 35},
     {"level_1": "Marketing", "level_2": "Content", "level_3": "Blog", "value": 30},
     {"level_1": "Marketing", "level_2": "Content", "level_3": "Video", "value": 40},
-    # Sales (Okabe-Ito position 3: #0072B2)
+    # Sales (Okabe-Ito position 3: #4467A3)
     {"level_1": "Sales", "level_2": "Enterprise", "level_3": "EMEA", "value": 70},
     {"level_1": "Sales", "level_2": "Enterprise", "level_3": "APAC", "value": 55},
     {"level_1": "Sales", "level_2": "SMB", "level_3": "Direct Sales", "value": 45},
-    # Operations (Okabe-Ito position 4: #CC79A7)
+    # Operations (Okabe-Ito position 4: #BD8233)
     {"level_1": "Operations", "level_2": "Support", "level_3": "Tier 1", "value": 40},
     {"level_1": "Operations", "level_2": "Support", "level_3": "Tier 2", "value": 25},
     {"level_1": "Operations", "level_2": "HR", "level_3": "Recruiting", "value": 30},
@@ -56,9 +56,9 @@ hierarchy = [
 # Department color families using Okabe-Ito bases with tints for child levels
 dept_colors = {
     "Engineering": {"base": "#009E73", "mid": "#55C4A4", "light": "#AAE0D5"},
-    "Marketing": {"base": "#E69F00", "mid": "#F0BC4D", "light": "#F7D899"},
-    "Sales": {"base": "#0072B2", "mid": "#4DA6D5", "light": "#99CDE8"},
-    "Operations": {"base": "#CC79A7", "mid": "#DDA5C5", "light": "#EED2E3"},
+    "Marketing": {"base": "#AE3030", "mid": "#F0BC4D", "light": "#F7D899"},
+    "Sales": {"base": "#4467A3", "mid": "#4DA6D5", "light": "#99CDE8"},
+    "Operations": {"base": "#BD8233", "mid": "#DDA5C5", "light": "#EED2E3"},
 }
 
 # Clearer abbreviations than 3-char truncation

--- a/plots/survival-kaplan-meier/implementations/python/bokeh.py
+++ b/plots/survival-kaplan-meier/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 TREATMENT_COLOR = "#009E73"  # Okabe-Ito position 1 (brand green)
-CONTROL_COLOR = "#D55E00"  # Okabe-Ito position 2 (vermillion)
+CONTROL_COLOR = "#C475FD"  # Okabe-Ito position 2 (vermillion)
 
 # Data - Simulated clinical trial with two treatment groups
 np.random.seed(42)

--- a/plots/swarm-basic/implementations/python/bokeh.py
+++ b/plots/swarm-basic/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — employee performance scores by department
 np.random.seed(42)
@@ -79,7 +79,7 @@ for dept in departments:
 
 x_positions = np.array([departments.index(cat) + x_jitter[i] for i, cat in enumerate(categories)])
 
-color_map = {dept: OKABE_ITO[i] for i, dept in enumerate(departments)}
+color_map = {dept: IMPRINT[i] for i, dept in enumerate(departments)}
 colors = [color_map[cat] for cat in categories]
 
 # Plot

--- a/plots/timeline-basic/implementations/python/bokeh.py
+++ b/plots/timeline-basic/implementations/python/bokeh.py
@@ -28,12 +28,12 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # brand green
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
-    "#E69F00",  # orange
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
+    "#AE3030",  # orange
 ]
 
 # Data - Software project milestones
@@ -58,7 +58,7 @@ df["y_pos"] = [0.6 if i % 2 == 0 else -0.6 for i in range(len(df))]
 
 # Map categories to Okabe-Ito colors
 categories = df["category"].unique().tolist()
-color_map = {cat: OKABE_ITO[i % len(OKABE_ITO)] for i, cat in enumerate(categories)}
+color_map = {cat: IMPRINT[i % len(IMPRINT)] for i, cat in enumerate(categories)}
 df["color"] = df["category"].map(color_map)
 
 # Create figure

--- a/plots/timeseries-decomposition/implementations/python/bokeh.py
+++ b/plots/timeseries-decomposition/implementations/python/bokeh.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for visual distinction of components
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]  # Positions 1-4
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]  # Positions 1-4
 
 # Data - Monthly airline passengers (classic time series dataset)
 np.random.seed(42)
@@ -116,21 +116,21 @@ def create_themed_figure(width, height, title_text, y_label, show_x_axis=False, 
 # Create subplots with theme-aware styling and distinct colors
 p1 = create_themed_figure(total_width, panel_height, "Original Series", "Passengers (thousands)")
 source1 = ColumnDataSource(data={"date": dates, "value": original})
-p1.line("date", "value", source=source1, line_width=3, color=OKABE_ITO[0])
+p1.line("date", "value", source=source1, line_width=3, color=IMPRINT[0])
 
 p2 = create_themed_figure(total_width, panel_height, "Trend Component", "Trend", x_range=p1.x_range)
 source2 = ColumnDataSource(data={"date": dates, "value": trend_component})
-p2.line("date", "value", source=source2, line_width=3, color=OKABE_ITO[1])
+p2.line("date", "value", source=source2, line_width=3, color=IMPRINT[1])
 
 p3 = create_themed_figure(total_width, panel_height, "Seasonal Component", "Seasonal", x_range=p1.x_range)
 source3 = ColumnDataSource(data={"date": dates, "value": seasonal_component})
-p3.line("date", "value", source=source3, line_width=3, color=OKABE_ITO[2])
+p3.line("date", "value", source=source3, line_width=3, color=IMPRINT[2])
 
 p4 = create_themed_figure(
     total_width, panel_height, "Residual Component", "Residual", show_x_axis=True, x_range=p1.x_range
 )
 source4 = ColumnDataSource(data={"date": dates, "value": residual_component})
-p4.line("date", "value", source=source4, line_width=3, color=OKABE_ITO[3])
+p4.line("date", "value", source=source4, line_width=3, color=IMPRINT[3])
 
 # Combine all panels into vertical layout
 layout = column(p1, p2, p3, p4)

--- a/plots/timeseries-forecast-uncertainty/implementations/python/bokeh.py
+++ b/plots/timeseries-forecast-uncertainty/implementations/python/bokeh.py
@@ -25,8 +25,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 OKABE_ITO_1 = "#009E73"  # Bluish green (brand)
-OKABE_ITO_2 = "#D55E00"  # Vermillion
-OKABE_ITO_4 = "#CC79A7"  # Reddish purple
+OKABE_ITO_2 = "#C475FD"  # Vermillion
+OKABE_ITO_4 = "#BD8233"  # Reddish purple
 
 # Data - Monthly product sales with forecast
 np.random.seed(42)

--- a/plots/treemap-basic/implementations/python/bokeh.py
+++ b/plots/treemap-basic/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - budget allocation by department and project
 data = [
@@ -49,7 +49,7 @@ df = df.sort_values("value", ascending=False).reset_index(drop=True)
 
 # Map categories to colors using Okabe-Ito palette
 unique_categories = df["category"].unique()
-category_color_map = {cat: OKABE_ITO[i % len(OKABE_ITO)] for i, cat in enumerate(unique_categories)}
+category_color_map = {cat: IMPRINT[i % len(IMPRINT)] for i, cat in enumerate(unique_categories)}
 
 # Extract values and labels
 values = df["value"].values

--- a/plots/venn-basic/implementations/python/bokeh.py
+++ b/plots/venn-basic/implementations/python/bokeh.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for three sets
-OI_COLORS = ["#009E73", "#D55E00", "#0072B2"]
+OI_COLORS = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Three sets representing product feature categories
 set_labels = ["Product A", "Product B", "Product C"]

--- a/plots/venn-labeled-items/implementations/python/bokeh.py
+++ b/plots/venn-labeled-items/implementations/python/bokeh.py
@@ -20,8 +20,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first circle is brand green, then vermillion, then blue
 COLOR_A = "#009E73"  # Overhyped
-COLOR_B = "#D55E00"  # Actually Useful
-COLOR_C = "#0072B2"  # Secretly Loved
+COLOR_B = "#C475FD"  # Actually Useful
+COLOR_C = "#4467A3"  # Secretly Loved
 
 # Geometry — equilateral triangle of centers (apex pointing down)
 r = 1.0

--- a/plots/violin-box/implementations/python/bokeh.py
+++ b/plots/violin-box/implementations/python/bokeh.py
@@ -24,11 +24,11 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green - first series
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
 ]
 
 # Data - Test scores by study method (educational context)
@@ -136,7 +136,7 @@ for i, cat in enumerate(categories):
     xs_right = [(cat, float(xr)) for xr in x_right[::-1]]
 
     # Draw violin patch with Okabe-Ito color
-    violin_color = OKABE_ITO[i % len(OKABE_ITO)]
+    violin_color = IMPRINT[i % len(IMPRINT)]
     vr = p.patch(
         xs_left + xs_right,
         list(y_grid) + list(y_grid[::-1]),

--- a/plots/violin-grouped-swarm/implementations/python/bokeh.py
+++ b/plots/violin-grouped-swarm/implementations/python/bokeh.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Response times (ms) across 3 task types and 2 expertise levels
 np.random.seed(42)
@@ -56,7 +56,7 @@ for cat_idx, category in enumerate(categories):
             data.append({"category": category, "group": group, "value": val})
 
 # Color mapping
-colors = {group: OKABE_ITO[i] for i, group in enumerate(groups)}
+colors = {group: IMPRINT[i] for i, group in enumerate(groups)}
 
 # Create figure
 p = figure(

--- a/plots/violin-split/implementations/python/bokeh.py
+++ b/plots/violin-split/implementations/python/bokeh.py
@@ -40,7 +40,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors for split groups
 COLOR_PLACEBO = "#009E73"  # First series - brand green
-COLOR_TREATMENT = "#D55E00"  # Second series - vermillion
+COLOR_TREATMENT = "#C475FD"  # Second series - vermillion
 
 # Data - Clinical trial recovery scores (placebo vs active treatment)
 np.random.seed(42)

--- a/plots/volcano-basic/implementations/python/bokeh.py
+++ b/plots/volcano-basic/implementations/python/bokeh.py
@@ -24,8 +24,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-COLOR_UP = "#D55E00"  # vermillion
-COLOR_DOWN = "#0072B2"  # blue
+COLOR_UP = "#C475FD"  # vermillion
+COLOR_DOWN = "#4467A3"  # blue
 COLOR_NS = "#AAAAAA"  # neutral gray
 
 # Data - Simulated differential expression results

--- a/plots/voronoi-basic/implementations/python/bokeh.py
+++ b/plots/voronoi-basic/implementations/python/bokeh.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
 
 # Okabe-Ito palette for Voronoi cells
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - seed points for Voronoi diagram
 np.random.seed(42)
@@ -132,7 +132,7 @@ for idx in range(n_points):
     if len(polygon) >= 3:
         xs = [v[0] for v in polygon]
         ys = [v[1] for v in polygon]
-        cell_color = OKABE_ITO[idx % len(OKABE_ITO)]
+        cell_color = IMPRINT[idx % len(IMPRINT)]
         p.patch(xs, ys, fill_color=cell_color, fill_alpha=0.5, line_color=INK_SOFT, line_width=2.5)
 
 # Draw seed points prominently

--- a/plots/waffle-basic/implementations/python/bokeh.py
+++ b/plots/waffle-basic/implementations/python/bokeh.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always brand green)
-PALETTE = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+PALETTE = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Survey results on renewable energy adoption
 categories = ["Solar", "Wind", "Hydro", "Geothermal"]

--- a/plots/waterfall-basic/implementations/python/bokeh.py
+++ b/plots/waterfall-basic/implementations/python/bokeh.py
@@ -23,8 +23,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 POSITIVE = "#009E73"  # brand green for positive changes
-NEGATIVE = "#D55E00"  # vermillion for negative changes
-TOTAL = "#0072B2"  # blue for totals
+NEGATIVE = "#AE3030"  # imprint red — negative changes
+TOTAL = "#4467A3"  # blue for totals
 
 # Data - quarterly financial breakdown
 categories = ["Starting Revenue", "Product Sales", "Services", "Refunds", "Operating Costs", "Marketing", "Net Income"]

--- a/plots/windrose-basic/implementations/python/bokeh.py
+++ b/plots/windrose-basic/implementations/python/bokeh.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette for speed bins (cool to warm progression)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Generate realistic wind data for a coastal weather station
 np.random.seed(42)
@@ -166,7 +166,7 @@ for dir_idx in range(8):
                 xs="x",
                 ys="y",
                 source=source,
-                fill_color=OKABE_ITO[speed_idx],
+                fill_color=IMPRINT[speed_idx],
                 fill_alpha=0.85,
                 line_color=PAGE_BG,
                 line_width=1.5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,10 +90,11 @@ plotting = [
     "scikit-learn>=1.6.0",
     "statsmodels>=0.14.0",
     # matplotlib add-ons required by individual specs (cartopy: map-projections,
-    # wordcloud: wordcloud-basic, matplotlib-venn: venn-basic)
+    # wordcloud: wordcloud-basic, matplotlib-venn: venn-basic, squarify: treemap-basic seaborn)
     "cartopy>=0.24.0",
     "wordcloud>=1.9.0",
     "matplotlib-venn>=1.1.0",
+    "squarify>=0.4.0",
 ]
 # Per-library dependencies for CI (minimal installs)
 lib-matplotlib = ["matplotlib>=3.10.9", "numpy>=2.4.6", "pandas>=3.0.3", "scipy>=1.14.0", "scikit-learn>=1.6.0", "statsmodels>=0.14.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,9 @@ plotting = [
     "scipy>=1.14.0",
     "scikit-learn>=1.6.0",
     "statsmodels>=0.14.0",
-    # matplotlib add-ons required by individual specs (cartopy: map-projections,
-    # wordcloud: wordcloud-basic, matplotlib-venn: venn-basic, squarify: treemap-basic seaborn)
+    # matplotlib add-ons required by individual specs:
+    #   cartopy → map-projections, wordcloud → wordcloud-basic,
+    #   matplotlib-venn → venn-basic, squarify → treemap-basic (seaborn variant)
     "cartopy>=0.24.0",
     "wordcloud>=1.9.0",
     "matplotlib-venn>=1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -271,6 +271,7 @@ all = [
     { name = "scipy" },
     { name = "seaborn" },
     { name = "selenium" },
+    { name = "squarify" },
     { name = "statsmodels", version = "0.14.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
     { name = "statsmodels", version = "0.14.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "vl-convert-python" },
@@ -384,6 +385,7 @@ plotting = [
     { name = "scipy" },
     { name = "seaborn" },
     { name = "selenium" },
+    { name = "squarify" },
     { name = "statsmodels", version = "0.14.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
     { name = "statsmodels", version = "0.14.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "vl-convert-python" },
@@ -499,6 +501,7 @@ requires-dist = [
     { name = "selenium", marker = "extra == 'lib-highcharts'", specifier = ">=4.44.0" },
     { name = "selenium", marker = "extra == 'plotting'", specifier = ">=4.44.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.50" },
+    { name = "squarify", marker = "extra == 'plotting'", specifier = ">=0.4.0" },
     { name = "statsmodels", specifier = ">=0.14.0" },
     { name = "statsmodels", marker = "extra == 'lib-altair'", specifier = ">=0.14.0" },
     { name = "statsmodels", marker = "extra == 'lib-bokeh'", specifier = ">=0.14.0" },
@@ -3593,6 +3596,15 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "greenlet" },
+]
+
+[[package]]
+name = "squarify"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/01/1753243870dff9fa786c9712fdc8dffb56f356c46c77d7468cb12f6d8398/squarify-0.4.4.tar.gz", hash = "sha256:b8a110c8dc5f1cd1402ca12d79764a081e90bfc445346cfa166df929753ecb46", size = 5514, upload-time = "2024-07-19T18:57:41.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/3c/eedbe9fb07cc20fd9a8423da14b03bc270d0570b3ba9174a4497156a2152/squarify-0.4.4-py3-none-any.whl", hash = "sha256:d7597724e29d48aa14fd2f551060d6b09e1f0a67e4cd3ea329fe03b4c9a56f11", size = 4082, upload-time = "2024-07-19T18:57:40.338Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Positional hex + rgba replacement across **135 bokeh impls** with light+dark renders → imprint.
- Stage A's rgba pass (added in #7781) catches the same outline/fill mismatch class that bit plotly, so this PR ships with that already clean.
- Proactive **semantic-anchor fixes for 13 bokeh impls** (red/amber/green where slot-1 lavender broke meaning).
- Drive-by: `squarify` added to `[plotting]` extra (was the last spec to fail Stage B during the seaborn pass — needed by `treemap-basic/seaborn.py`).

## Semantic fixes (proactive)

bar-diverging, candlestick-volume, dashboard-metrics-tiles (traffic-light + UNFAVORABLE), gain-curve (perfect-line not red), gauge-basic, horizon-basic (red ramp restored), indicator-macd, kagi-basic, point-and-figure-basic, renko-basic, shap-waterfall, slope-basic, waterfall-basic.

## Test plan

- [x] `ruff check .` + format green
- [ ] CI green
- [ ] Copilot triage
- [ ] After merge: Stage B for 135 bokeh impls → GCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)