### PR TITLE
chore(palette): migrate altair impls from Okabe-Ito to imprint

### DIFF
--- a/plots/alluvial-basic/implementations/python/altair.py
+++ b/plots/alluvial-basic/implementations/python/altair.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series must be #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Voter migration between political parties across 4 election cycles
 # Time points: 2012, 2016, 2020, 2024
@@ -71,10 +71,10 @@ node_padding = 20
 
 # Colors for each category (using Okabe-Ito palette)
 category_colors = {
-    "Conservative": OKABE_ITO[0],  # #009E73 (brand green)
-    "Liberal": OKABE_ITO[1],  # #D55E00 (vermillion)
-    "Progressive": OKABE_ITO[2],  # #0072B2 (blue)
-    "Independent": OKABE_ITO[3],  # #CC79A7 (reddish purple)
+    "Conservative": IMPRINT[0],  # #009E73 (brand green)
+    "Liberal": IMPRINT[1],  # #C475FD (vermillion)
+    "Progressive": IMPRINT[2],  # #4467A3 (blue)
+    "Independent": IMPRINT[3],  # #BD8233 (reddish purple)
 }
 
 # Calculate totals at each time point for each category

--- a/plots/andrews-curves/implementations/python/altair.py
+++ b/plots/andrews-curves/implementations/python/altair.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Load and prepare data
 np.random.seed(42)
@@ -85,7 +85,7 @@ chart = (
         color=alt.Color(
             "species:N",
             title="Species",
-            scale=alt.Scale(domain=species_names, range=OKABE_ITO),
+            scale=alt.Scale(domain=species_names, range=IMPRINT),
             legend=alt.Legend(
                 titleFontSize=18,
                 labelFontSize=16,

--- a/plots/area-cumulative-flow/implementations/python/altair.py
+++ b/plots/area-cumulative-flow/implementations/python/altair.py
@@ -22,7 +22,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — 90-day software delivery Kanban board
 np.random.seed(42)
@@ -71,7 +71,7 @@ base = (
         y=alt.Y("wip:Q", stack="zero", title="Cumulative Items"),
         color=alt.Color(
             "stage:N",
-            scale=alt.Scale(domain=stages, range=OKABE_ITO),
+            scale=alt.Scale(domain=stages, range=IMPRINT),
             legend=alt.Legend(title="Workflow Stage", orient="top-left"),
         ),
         order=alt.Order("stack_order:Q"),

--- a/plots/area-stacked-percent/implementations/python/altair.py
+++ b/plots/area-stacked-percent/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Energy source mix evolution
 np.random.seed(42)
@@ -60,7 +60,7 @@ chart = (
         ),
         color=alt.Color(
             "Source:N",
-            scale=alt.Scale(domain=source_order, range=OKABE_ITO),
+            scale=alt.Scale(domain=source_order, range=IMPRINT),
             legend=alt.Legend(
                 title="Energy Source",
                 titleFontSize=20,

--- a/plots/area-stacked/implementations/python/altair.py
+++ b/plots/area-stacked/implementations/python/altair.py
@@ -50,7 +50,7 @@ stack_order = {"Software": 1, "Hardware": 2, "Services": 3, "Support": 4}
 df["StackOrder"] = df["Category"].map(stack_order)
 
 # Okabe-Ito palette: first series ALWAYS #009E73
-colors = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+colors = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Create stacked area chart
 chart = (

--- a/plots/bar-3d-categorical/implementations/python/altair.py
+++ b/plots/bar-3d-categorical/implementations/python/altair.py
@@ -22,7 +22,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — survey satisfaction scores across age groups and education levels
 np.random.seed(42)
@@ -64,7 +64,7 @@ chart = (
         color=alt.Color(
             "Education:N",
             sort=education_levels,
-            scale=alt.Scale(domain=education_levels, range=OKABE_ITO),
+            scale=alt.Scale(domain=education_levels, range=IMPRINT),
             legend=alt.Legend(title="Education Level", titleFontSize=18, labelFontSize=16, orient="top-right"),
         ),
         xOffset=alt.XOffset("Education:N", sort=education_levels),

--- a/plots/bar-diverging/implementations/python/altair.py
+++ b/plots/bar-diverging/implementations/python/altair.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 POSITIVE_COLOR = "#009E73"  # Okabe-Ito position 1 (brand green)
-NEGATIVE_COLOR = "#D55E00"  # Okabe-Ito position 2 (vermillion)
+NEGATIVE_COLOR = "#AE3030"  # imprint red — negative
 
 # Data - Customer satisfaction survey results by department
 data = pd.DataFrame(

--- a/plots/bar-drilldown/implementations/python/altair.py
+++ b/plots/bar-drilldown/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Hierarchical data: Sales by Region -> Country -> City
 # Children always sum exactly to their parent value
@@ -63,7 +63,7 @@ df = pd.DataFrame(data)
 # Root-level data sorted by value descending for consistent color mapping
 root_df = df[df["parent"].isna()].copy()
 root_order = root_df.sort_values("value", ascending=False)["name"].tolist()
-region_colors = OKABE_ITO[: len(root_order)]
+region_colors = IMPRINT[: len(root_order)]
 
 TITLE = "bar-drilldown · python · altair · anyplot.ai"
 
@@ -127,7 +127,7 @@ chart.save(f"plot-{THEME}.png", scale_factor=4.0)
 # Interactive HTML with full drilldown functionality
 data_json = df.to_json(orient="records")
 id_to_name_json = json.dumps(df.set_index("id")["name"].to_dict())
-okabe_ito_json = json.dumps(OKABE_ITO)
+okabe_ito_json = json.dumps(IMPRINT)
 
 html_content = f"""<!DOCTYPE html>
 <html>
@@ -172,7 +172,7 @@ html_content = f"""<!DOCTYPE html>
     <script>
         const fullData = {data_json};
         const idToName = {id_to_name_json};
-        const OKABE_ITO = {okabe_ito_json};
+        const IMPRINT = {okabe_ito_json};
         const PAGE_BG = "{PAGE_BG}";
         const ELEVATED_BG = "{ELEVATED_BG}";
         const INK = "{INK}";
@@ -216,7 +216,7 @@ html_content = f"""<!DOCTYPE html>
             const items = getChildren(currentParent);
             const sorted = [...items].sort((a, b) => b.value - a.value);
             const names = sorted.map(d => d.name);
-            const colors = names.map((_, i) => OKABE_ITO[i % OKABE_ITO.length]);
+            const colors = names.map((_, i) => IMPRINT[i % IMPRINT.length]);
             const hasChildren = items.some(d => getChildren(d.id).length > 0);
 
             const spec = {{

--- a/plots/bar-grouped/implementations/python/altair.py
+++ b/plots/bar-grouped/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1→3)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Quarterly revenue by product line
 data = pd.DataFrame(
@@ -67,7 +67,7 @@ chart = (
         ),
         color=alt.Color(
             "Product:N",
-            scale=alt.Scale(domain=["Software", "Hardware", "Services"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Software", "Hardware", "Services"], range=IMPRINT),
             legend=alt.Legend(
                 title="Product Line", titleFontSize=20, labelFontSize=18, orient="bottom", direction="horizontal"
             ),

--- a/plots/bar-race-animated/implementations/python/altair.py
+++ b/plots/bar-race-animated/implementations/python/altair.py
@@ -21,12 +21,12 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 # Okabe-Ito palette (first series always #009E73) + accessible extensions for 10 entities
 COLORS = [
     "#009E73",  # Okabe-Ito pos 1 — brand green, always first
-    "#D55E00",  # Okabe-Ito pos 2 — vermillion
-    "#0072B2",  # Okabe-Ito pos 3 — blue
-    "#CC79A7",  # Okabe-Ito pos 4 — reddish purple
-    "#E69F00",  # Okabe-Ito pos 5 — orange
-    "#56B4E9",  # Okabe-Ito pos 6 — sky blue
-    "#F0E442",  # Okabe-Ito pos 7 — yellow
+    "#C475FD",  # Okabe-Ito pos 2 — vermillion
+    "#4467A3",  # Okabe-Ito pos 3 — blue
+    "#BD8233",  # Okabe-Ito pos 4 — reddish purple
+    "#AE3030",  # Okabe-Ito pos 5 — orange
+    "#2ABCCD",  # Okabe-Ito pos 6 — sky blue
+    "#954477",  # Okabe-Ito pos 7 — yellow
     "#332288",  # accessible extension — deep indigo
     "#117733",  # accessible extension — deep green
     "#882255",  # accessible extension — deep crimson

--- a/plots/bar-spine/implementations/python/altair.py
+++ b/plots/bar-spine/implementations/python/altair.py
@@ -24,7 +24,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — technology comfort survey by age group
 age_groups = ["18-24", "25-34", "35-44", "45-54", "55-64", "65+"]
@@ -134,7 +134,7 @@ bars = (
         y2="y_end:Q",
         color=alt.Color(
             "comfort:N",
-            scale=alt.Scale(domain=comfort_cats, range=OKABE_ITO),
+            scale=alt.Scale(domain=comfort_cats, range=IMPRINT),
             legend=alt.Legend(
                 title="Technology Comfort",
                 titleFontSize=18,

--- a/plots/bar-stacked-labeled/implementations/python/altair.py
+++ b/plots/bar-stacked-labeled/implementations/python/altair.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product category
 data = pd.DataFrame(
@@ -49,7 +49,7 @@ bars = (
         color=alt.Color(
             "product:N",
             title="Product",
-            scale=alt.Scale(domain=["Software", "Hardware", "Services"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Software", "Hardware", "Services"], range=IMPRINT),
             legend=alt.Legend(titleFontSize=20, labelFontSize=18, symbolSize=300),
         ),
         order=alt.Order("product:N", sort="ascending"),

--- a/plots/bar-stacked-percent/implementations/python/altair.py
+++ b/plots/bar-stacked-percent/implementations/python/altair.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Energy mix by country
 data = pd.DataFrame(
@@ -85,7 +85,7 @@ chart = (
         ),
         color=alt.Color(
             "Source:N",
-            scale=alt.Scale(domain=["Fossil Fuels", "Nuclear", "Renewables", "Hydro"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Fossil Fuels", "Nuclear", "Renewables", "Hydro"], range=IMPRINT),
             legend=alt.Legend(
                 title="Energy Source",
                 titleFontSize=18,

--- a/plots/bar-stacked/implementations/python/altair.py
+++ b/plots/bar-stacked/implementations/python/altair.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette: first series is ALWAYS #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Quarterly sales by product category
 data = pd.DataFrame(
@@ -65,7 +65,7 @@ bars = (
         color=alt.Color(
             "Product:N",
             title="Product Category",
-            scale=alt.Scale(domain=category_order, range=OKABE_ITO),
+            scale=alt.Scale(domain=category_order, range=IMPRINT),
             legend=alt.Legend(
                 titleFontSize=18, labelFontSize=16, symbolSize=300, orient="right", titlePadding=10, labelLimit=150
             ),

--- a/plots/biplot-pca/implementations/python/altair.py
+++ b/plots/biplot-pca/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - using Iris dataset for multivariate analysis
 iris = load_iris()
@@ -73,7 +73,7 @@ scatter = (
         y=alt.Y("PC2:Q", title=f"PC2 ({var_explained[1]:.1f}%)", scale=alt.Scale(domain=[-3, 3])),
         color=alt.Color(
             "Species:N",
-            scale=alt.Scale(range=OKABE_ITO),
+            scale=alt.Scale(range=IMPRINT),
             legend=alt.Legend(title="Species", titleFontSize=18, labelFontSize=16, symbolSize=200, orient="right"),
         ),
         tooltip=["Species:N", alt.Tooltip("PC1:Q", format=".2f"), alt.Tooltip("PC2:Q", format=".2f")],

--- a/plots/bland-altman-basic/implementations/python/altair.py
+++ b/plots/bland-altman-basic/implementations/python/altair.py
@@ -25,7 +25,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 
 # Data: Simulated blood pressure measurements from two sphygmomanometers
 np.random.seed(42)

--- a/plots/box-grouped/implementations/python/altair.py
+++ b/plots/box-grouped/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1, 2, 3 for Junior, Mid, Senior)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Employee performance scores across departments and experience levels
 np.random.seed(42)
@@ -74,7 +74,7 @@ chart = (
         color=altair.Color(
             "Experience:N",
             title="Experience Level",
-            scale=altair.Scale(domain=["Junior", "Mid", "Senior"], range=OKABE_ITO),
+            scale=altair.Scale(domain=["Junior", "Mid", "Senior"], range=IMPRINT),
             legend=altair.Legend(titleFontSize=20, labelFontSize=18, symbolSize=300, orient="top-left"),
         ),
         xOffset="Experience:N",

--- a/plots/bubble-map-geographic/implementations/python/altair.py
+++ b/plots/bubble-map-geographic/implementations/python/altair.py
@@ -25,7 +25,7 @@ LAND_FILL = "#E8E4DC" if THEME == "light" else "#2C2C28"
 LAND_STROKE = "#B0AFA8" if THEME == "light" else "#4A4A44"
 
 # Okabe-Ito positions 1-4 for tectonic regions
-REGION_COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+REGION_COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Major earthquakes (M ≥ 6.0), 20th–21st century
 # Source: USGS Significant Earthquake Catalog

--- a/plots/calibration-curve/implementations/python/altair.py
+++ b/plots/calibration-curve/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Generate synthetic classification predictions
 np.random.seed(42)

--- a/plots/candlestick-volume/implementations/python/altair.py
+++ b/plots/candlestick-volume/implementations/python/altair.py
@@ -21,7 +21,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette
 BULLISH = "#009E73"  # Okabe-Ito position 1 (bluish green)
-BEARISH = "#D55E00"  # Okabe-Ito position 2 (vermillion)
+BEARISH = "#AE3030"  # imprint red — bearish
 
 # Data: Generate 60 days of realistic stock OHLC data with volume
 np.random.seed(42)

--- a/plots/cat-box-strip/implementations/python/altair.py
+++ b/plots/cat-box-strip/implementations/python/altair.py
@@ -52,7 +52,7 @@ df = pd.DataFrame(data)
 # Box plot layer
 boxplot = (
     alt.Chart(df)
-    .mark_boxplot(size=60, color=BRAND, median={"color": "#F0E442", "strokeWidth": 3}, opacity=0.8)
+    .mark_boxplot(size=60, color=BRAND, median={"color": "#954477", "strokeWidth": 3}, opacity=0.8)
     .encode(
         x=alt.X("Department:N", title="Department", axis=alt.Axis(labelFontSize=18, titleFontSize=22, labelAngle=0)),
         y=alt.Y(

--- a/plots/chernoff-basic/implementations/python/altair.py
+++ b/plots/chernoff-basic/implementations/python/altair.py
@@ -20,7 +20,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette for species
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Iris dataset features for 12 representative flowers
 np.random.seed(42)
@@ -50,7 +50,7 @@ data = pd.DataFrame(
 )
 
 # Map species to Okabe-Ito colors
-species_colors = {"setosa": OKABE_ITO[0], "versicolor": OKABE_ITO[1], "virginica": OKABE_ITO[2]}
+species_colors = {"setosa": IMPRINT[0], "versicolor": IMPRINT[1], "virginica": IMPRINT[2]}
 data["color"] = data["species"].map(species_colors)
 
 # Create descriptive labels including species name
@@ -251,7 +251,7 @@ for _, r in data.iterrows():
         }
     )
     # Mouth - using horizontal ellipse shape for better representation
-    mouth_color = OKABE_ITO[1] if THEME == "light" else OKABE_ITO[4]
+    mouth_color = IMPRINT[1] if THEME == "light" else IMPRINT[4]
     mouth_y = yc - fh * 0.30
     for dx in np.linspace(-mw * 0.4, mw * 0.4, 7):
         # Parabolic curve for mouth (smiling effect based on width)
@@ -307,7 +307,7 @@ legend_data = pd.DataFrame(
         "species": ["setosa", "versicolor", "virginica"],
         "x": [850, 850, 850],
         "y": [780, 730, 680],
-        "color": [OKABE_ITO[0], OKABE_ITO[1], OKABE_ITO[2]],
+        "color": [IMPRINT[0], IMPRINT[1], IMPRINT[2]],
     }
 )
 

--- a/plots/circlepacking-basic/implementations/python/altair.py
+++ b/plots/circlepacking-basic/implementations/python/altair.py
@@ -59,7 +59,7 @@ for t in teams:
     dept_totals[t["parent"]] = dept_totals.get(t["parent"], 0) + t["value"]
 
 # Okabe-Ito palette for departments (theme-independent data colors)
-okabe_ito = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+okabe_ito = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 dept_colors = {
     "Engineering": okabe_ito[0],  # bluish green
     "Sales": okabe_ito[1],  # vermillion

--- a/plots/circos-basic/implementations/python/altair.py
+++ b/plots/circos-basic/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Software module dependencies
 np.random.seed(42)
@@ -54,12 +54,12 @@ connections = [
 track_data = np.random.uniform(0.3, 1.0, n_segments)
 
 # Map segments to Okabe-Ito colors
-segment_colors = {segments[i]: OKABE_ITO[i % len(OKABE_ITO)] for i in range(n_segments)}
+segment_colors = {segments[i]: IMPRINT[i % len(IMPRINT)] for i in range(n_segments)}
 
 # Darker shades for inner track (reduce lightness while maintaining hue)
 inner_colors = {}
 for i, seg in enumerate(segments):
-    color = OKABE_ITO[i % len(OKABE_ITO)]
+    color = IMPRINT[i % len(IMPRINT)]
     # Create darker shade by reducing brightness
     import colorsys
 

--- a/plots/contour-decision-boundary/implementations/python/altair.py
+++ b/plots/contour-decision-boundary/implementations/python/altair.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - generate two-moon classification dataset
 np.random.seed(42)
@@ -63,7 +63,7 @@ background = (
         y=alt.Y("X2:Q", bin=alt.Bin(maxbins=150), title="Feature X2"),
         color=alt.Color(
             "Class:N",
-            scale=alt.Scale(domain=["Class A", "Class B"], range=[OKABE_ITO[0], OKABE_ITO[1]]),
+            scale=alt.Scale(domain=["Class A", "Class B"], range=[IMPRINT[0], IMPRINT[1]]),
             legend=alt.Legend(title="Decision Region", titleFontSize=18, labelFontSize=16, orient="right"),
         ),
     )
@@ -77,7 +77,7 @@ correct_points = (
         x=alt.X("X1:Q"),
         y=alt.Y("X2:Q"),
         fill=alt.Color(
-            "Class:N", scale=alt.Scale(domain=["Class A", "Class B"], range=[OKABE_ITO[0], OKABE_ITO[1]]), legend=None
+            "Class:N", scale=alt.Scale(domain=["Class A", "Class B"], range=[IMPRINT[0], IMPRINT[1]]), legend=None
         ),
         stroke=alt.value(INK_SOFT),
         tooltip=["X1:Q", "X2:Q", "Class:N", "Classification:N"],
@@ -92,9 +92,9 @@ incorrect_points = (
         x=alt.X("X1:Q"),
         y=alt.Y("X2:Q"),
         fill=alt.Color(
-            "Class:N", scale=alt.Scale(domain=["Class A", "Class B"], range=[OKABE_ITO[0], OKABE_ITO[1]]), legend=None
+            "Class:N", scale=alt.Scale(domain=["Class A", "Class B"], range=[IMPRINT[0], IMPRINT[1]]), legend=None
         ),
-        stroke=alt.value(OKABE_ITO[1]),
+        stroke=alt.value(IMPRINT[1]),
         tooltip=["X1:Q", "X2:Q", "Class:N", "Classification:N"],
     )
 )

--- a/plots/dashboard-metrics-tiles/implementations/python/altair.py
+++ b/plots/dashboard-metrics-tiles/implementations/python/altair.py
@@ -20,8 +20,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colours mapped to status roles
 GOOD_COLOR = "#009E73"
-WARN_COLOR = "#E69F00"
-CRIT_COLOR = "#D55E00"
+WARN_COLOR = "#DDCC77"  # imprint amber — semantic warning
+CRIT_COLOR = "#AE3030"  # imprint red — semantic critical
 STATUS_COLORS = {"good": GOOD_COLOR, "warning": WARN_COLOR, "critical": CRIT_COLOR}
 
 # Data - KPI metrics with sparkline history

--- a/plots/dashboard-synchronized-crosshair/implementations/python/altair.py
+++ b/plots/dashboard-synchronized-crosshair/implementations/python/altair.py
@@ -21,8 +21,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # anyplot palette positions 1–3
 COLOR_PRICE = "#009E73"
-COLOR_VOLUME = "#9418DB"
-COLOR_INDICATOR = "#B71D27"
+COLOR_VOLUME = "#C475FD"
+COLOR_INDICATOR = "#AE3030"
 
 # Data — stock market: price, volume, momentum indicator
 np.random.seed(42)

--- a/plots/dendrogram-radial/implementations/python/altair.py
+++ b/plots/dendrogram-radial/implementations/python/altair.py
@@ -28,7 +28,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: gene expression profiles, 5 well-separated clusters
 np.random.seed(42)
@@ -83,7 +83,7 @@ for i, (left, right, dist, _) in enumerate(Z):
 def branch_color(node_id):
     clusters = subtree_clusters[node_id]
     if len(clusters) == 1:
-        return OKABE_ITO[list(clusters)[0]]
+        return IMPRINT[list(clusters)[0]]
     return INK_SOFT
 
 
@@ -146,7 +146,7 @@ for leaf_idx in range(n_leaves):
             "y": np.sin(a),
             "label": gene_names[leaf_idx],
             "cluster": f"Cluster {c + 1}",
-            "clr": OKABE_ITO[c],
+            "clr": IMPRINT[c],
         }
     )
 df_leaves = pd.DataFrame(leaf_rows)
@@ -157,11 +157,11 @@ legend_data = pd.DataFrame(
         "x": np.linspace(-0.72, 0.72, n_clusters),
         "y": [-1.22] * n_clusters,
         "label": [f"Cluster {k + 1}" for k in range(n_clusters)],
-        "clr": OKABE_ITO[:n_clusters],
+        "clr": IMPRINT[:n_clusters],
     }
 )
 
-all_colors = sorted(set(df_lines["clr"].unique()) | set(OKABE_ITO[:n_clusters]))
+all_colors = sorted(set(df_lines["clr"].unique()) | set(IMPRINT[:n_clusters]))
 cscale = alt.Scale(domain=all_colors, range=all_colors)
 XY_DOM = [-1.40, 1.40]
 

--- a/plots/diagnostic-regression-panel/implementations/python/altair.py
+++ b/plots/diagnostic-regression-panel/implementations/python/altair.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Data — housing price prediction scenario
 np.random.seed(42)

--- a/plots/donut-basic/implementations/python/altair.py
+++ b/plots/donut-basic/implementations/python/altair.py
@@ -20,7 +20,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 data = pd.DataFrame(
     {"category": ["Engineering", "Marketing", "Operations", "Sales", "Support"], "value": [480, 210, 155, 125, 55]}
@@ -38,7 +38,7 @@ arc = (
         color=alt.Color(
             field="category",
             type="nominal",
-            scale=alt.Scale(domain=list(data["category"]), range=OKABE_ITO),
+            scale=alt.Scale(domain=list(data["category"]), range=IMPRINT),
             legend=alt.Legend(
                 title="Department", titleFontSize=22, labelFontSize=18, orient="right", symbolSize=400, padding=16
             ),

--- a/plots/donut-nested/implementations/python/altair.py
+++ b/plots/donut-nested/implementations/python/altair.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Market share by region (inner) and product lines within each region (outer)
 data = {
@@ -49,7 +49,7 @@ inner_df["level_2"] = inner_df["level_1"]
 # Use Okabe-Ito palette positions with variations for subcategories
 color_map = {}
 for i, parent in enumerate(inner_df["level_1"]):
-    parent_color = OKABE_ITO[i % len(OKABE_ITO)]
+    parent_color = IMPRINT[i % len(IMPRINT)]
     parent_children = df[df["level_1"] == parent]["level_2"].tolist()
     color_map[parent] = {}
     for j, child in enumerate(parent_children):
@@ -73,7 +73,7 @@ df["color"] = outer_colors
 # Inner ring colors (use Okabe-Ito positions)
 inner_color_map = {}
 for i, parent in enumerate(inner_df["level_1"]):
-    inner_color_map[parent] = OKABE_ITO[i % len(OKABE_ITO)]
+    inner_color_map[parent] = IMPRINT[i % len(IMPRINT)]
 inner_df["color"] = inner_df["level_1"].map(inner_color_map)
 
 # Format values for tooltip

--- a/plots/dot-matrix-proportional/implementations/python/altair.py
+++ b/plots/dot-matrix-proportional/implementations/python/altair.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-COLORS = ["#009E73", "#D55E00", "#0072B2"]
+COLORS = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: conference session survey — 100 attendees, 10×10 grid
 # Categories ordered alphabetically to match Altair's nominal-sort color assignment.

--- a/plots/drawdown-basic/implementations/python/altair.py
+++ b/plots/drawdown-basic/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-DD_COLOR = "#B71D27"  # anyplot palette pos 3 — semantic: loss/drawdown
+DD_COLOR = "#AE3030"  # anyplot palette pos 3 — semantic: loss/drawdown
 REC_COLOR = "#009E73"  # anyplot palette pos 1 — semantic: recovery/new high
 
 # Data — simulated asset price over ~2 years with drawdowns and recoveries
@@ -101,7 +101,7 @@ zero_rule = (
 
 max_dd_point = (
     alt.Chart(max_dd_df)
-    .mark_point(size=250, color="#9418DB", filled=True, stroke=INK, strokeWidth=1.5)
+    .mark_point(size=250, color="#C475FD", filled=True, stroke=INK, strokeWidth=1.5)
     .encode(x="date:T", y="drawdown:Q")
 )
 

--- a/plots/dumbbell-basic/implementations/python/altair.py
+++ b/plots/dumbbell-basic/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette positions 1 and 2
 COLOR_BEFORE = "#009E73"
-COLOR_AFTER = "#D55E00"
+COLOR_AFTER = "#C475FD"
 
 # Data — Employee satisfaction scores before and after policy changes
 data = pd.DataFrame(

--- a/plots/facet-grid/implementations/python/altair.py
+++ b/plots/facet-grid/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Crop yield across different soil types and seasons
 np.random.seed(42)
@@ -59,7 +59,7 @@ chart = (
     .encode(
         x=alt.X("Water Usage (mm):Q", scale=alt.Scale(zero=False)),
         y=alt.Y("Yield (tons/ha):Q", scale=alt.Scale(zero=False)),
-        color=alt.Color("Crop:N", scale=alt.Scale(domain=crop_types, range=OKABE_ITO[:3])),
+        color=alt.Color("Crop:N", scale=alt.Scale(domain=crop_types, range=IMPRINT[:3])),
         tooltip=["Yield (tons/ha)", "Water Usage (mm)", "Soil Type", "Season", "Crop"],
     )
     .properties(width=320, height=260)

--- a/plots/forest-basic/implementations/python/altair.py
+++ b/plots/forest-basic/implementations/python/altair.py
@@ -110,7 +110,7 @@ pooled_ci = (
 # Diamond marker for pooled estimate
 pooled_diamond = (
     alt.Chart(df_pooled)
-    .mark_point(shape="diamond", filled=True, size=1500, color="#E69F00", stroke="#009E73", strokeWidth=3)
+    .mark_point(shape="diamond", filled=True, size=1500, color="#AE3030", stroke="#009E73", strokeWidth=3)
     .encode(
         x=alt.X("effect_size:Q", scale=alt.Scale(domain=[-1.15, 0.60])),
         y=alt.Y("study:N", sort=y_labels),

--- a/plots/frequency-polygon-basic/implementations/python/altair.py
+++ b/plots/frequency-polygon-basic/implementations/python/altair.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (colorblind-safe)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Response times (ms) by experimental condition
 np.random.seed(42)
@@ -65,7 +65,7 @@ chart = (
         y=alt.Y("Frequency:Q", title="Frequency"),
         color=alt.Color(
             "Condition:N",
-            scale=alt.Scale(domain=["Control", "Treatment A", "Treatment B"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Control", "Treatment A", "Treatment B"], range=IMPRINT),
             legend=alt.Legend(title="Condition", titleFontSize=20, labelFontSize=18),
         ),
         strokeDash=alt.StrokeDash(

--- a/plots/frontier-efficient/implementations/python/altair.py
+++ b/plots/frontier-efficient/implementations/python/altair.py
@@ -21,7 +21,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Portfolio simulation with efficient frontier
 np.random.seed(42)
@@ -149,7 +149,7 @@ frontier_line = (
 # Capital market line
 cml_line = (
     alt.Chart(cml_df)
-    .mark_line(strokeWidth=3, strokeDash=[8, 4], color=OKABE_ITO[1])
+    .mark_line(strokeWidth=3, strokeDash=[8, 4], color=IMPRINT[1])
     .encode(x="Risk (Std Dev):Q", y="Expected Return:Q")
 )
 
@@ -162,7 +162,7 @@ special_points = (
         y="Expected Return:Q",
         color=alt.Color(
             "Portfolio:N",
-            scale=alt.Scale(domain=["Minimum Variance", "Maximum Sharpe Ratio"], range=[OKABE_ITO[1], OKABE_ITO[2]]),
+            scale=alt.Scale(domain=["Minimum Variance", "Maximum Sharpe Ratio"], range=[IMPRINT[1], IMPRINT[2]]),
             legend=alt.Legend(title="Key Portfolios", titleFontSize=16, labelFontSize=14),
         ),
         tooltip=["Portfolio", "Risk (Std Dev)", "Expected Return"],

--- a/plots/funnel-basic/implementations/python/altair.py
+++ b/plots/funnel-basic/implementations/python/altair.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette — first stage is brand green (#009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — sales funnel example from the specification
 stages = ["Awareness", "Interest", "Consideration", "Intent", "Purchase"]
@@ -43,7 +43,7 @@ bars = (
         x=alt.X("x_start:Q", axis=None, scale=x_scale),
         x2="x_end:Q",
         y=alt.Y("stage:N", sort=stages, axis=alt.Axis(title=None, labelPadding=18, ticks=False, domain=False)),
-        color=alt.Color("stage:N", scale=alt.Scale(domain=stages, range=OKABE_ITO), legend=None),
+        color=alt.Color("stage:N", scale=alt.Scale(domain=stages, range=IMPRINT), legend=None),
         tooltip=[
             alt.Tooltip("stage:N", title="Stage"),
             alt.Tooltip("value:Q", title="Count", format=","),

--- a/plots/gain-curve/implementations/python/altair.py
+++ b/plots/gain-curve/implementations/python/altair.py
@@ -20,7 +20,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Model curve
-SECONDARY = "#D55E00"  # Baseline reference
+SECONDARY = "#C475FD"  # Baseline reference
 
 # Data - Simulated model predictions for fraud detection
 np.random.seed(42)

--- a/plots/gantt-basic/implementations/python/altair.py
+++ b/plots/gantt-basic/implementations/python/altair.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 tasks = [
     {"task": "Project Planning", "category": "Planning", "start": "2024-01-02", "end": "2024-01-18"},
@@ -47,11 +47,11 @@ df = df.sort_values("start", ascending=True).reset_index(drop=True)
 task_order = df["task"].tolist()
 
 category_map = {
-    "Planning": OKABE_ITO[0],
-    "Design": OKABE_ITO[1],
-    "Development": OKABE_ITO[2],
-    "Testing": OKABE_ITO[3],
-    "Deployment": OKABE_ITO[4],
+    "Planning": IMPRINT[0],
+    "Design": IMPRINT[1],
+    "Development": IMPRINT[2],
+    "Testing": IMPRINT[3],
+    "Deployment": IMPRINT[4],
 }
 
 chart = (

--- a/plots/gauge-basic/implementations/python/altair.py
+++ b/plots/gauge-basic/implementations/python/altair.py
@@ -20,9 +20,9 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito zone colors (colorblind-safe red/yellow/green)
-ZONE_BAD = "#D55E00"  # vermillion
-ZONE_WARN = "#E69F00"  # orange
-ZONE_GOOD = "#009E73"  # bluish green (brand)
+ZONE_BAD = "#AE3030"  # imprint red — bad
+ZONE_WARN = "#DDCC77"  # imprint amber — warning
+ZONE_GOOD = "#009E73"  # imprint green — good
 
 # Data — Sales performance gauge
 value = 72

--- a/plots/hierarchy-toggle-view/implementations/python/altair.py
+++ b/plots/hierarchy-toggle-view/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 DEPT_DOMAIN = ["Engineering", "Sales", "Marketing", "Operations"]
-DEPT_COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+DEPT_COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data
 np.random.seed(42)

--- a/plots/histogram-kde/implementations/python/altair.py
+++ b/plots/histogram-kde/implementations/python/altair.py
@@ -21,7 +21,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - first series
-ACCENT = "#F0E442"  # Position 7 - for KDE line
+ACCENT = "#954477"  # Position 7 - for KDE line
 
 # Data - bimodal distribution for interesting KDE demonstration
 np.random.seed(42)

--- a/plots/histogram-overlapping/implementations/python/altair.py
+++ b/plots/histogram-overlapping/implementations/python/altair.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Employee response times (ms) by department
 np.random.seed(42)
@@ -53,7 +53,7 @@ chart = (
         y=alt.Y("count():Q", title="Frequency", stack=None, axis=alt.Axis(labelFontSize=18, titleFontSize=22)),
         color=alt.Color(
             "Department:N",
-            scale=alt.Scale(domain=["Engineering", "Sales", "Support"], range=OKABE_ITO[:3]),
+            scale=alt.Scale(domain=["Engineering", "Sales", "Support"], range=IMPRINT[:3]),
             legend=alt.Legend(
                 title="Department",
                 titleFontSize=20,

--- a/plots/histogram-returns-distribution/implementations/python/altair.py
+++ b/plots/histogram-returns-distribution/implementations/python/altair.py
@@ -27,8 +27,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito 1 — main distribution bars
-TAIL_COLOR = "#D55E00"  # Okabe-Ito 2 — tail bars beyond ±2σ
-CURVE_COLOR = "#0072B2"  # Okabe-Ito 3 — fitted normal distribution overlay
+TAIL_COLOR = "#C475FD"  # Okabe-Ito 2 — tail bars beyond ±2σ
+CURVE_COLOR = "#4467A3"  # Okabe-Ito 3 — fitted normal distribution overlay
 
 # Data
 np.random.seed(42)

--- a/plots/histogram-stacked/implementations/python/altair.py
+++ b/plots/histogram-stacked/implementations/python/altair.py
@@ -17,7 +17,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Test scores from three different study methods
 np.random.seed(42)
@@ -57,7 +57,7 @@ chart = (
         ),
         color=alt.Color(
             "Study Method:N",
-            scale=alt.Scale(domain=["Traditional Study", "Active Recall", "Passive Reading"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Traditional Study", "Active Recall", "Passive Reading"], range=IMPRINT),
             legend=alt.Legend(title="Study Method", titleFontSize=18, labelFontSize=16, orient="right"),
         ),
         order=alt.Order("Study Method:N", sort="ascending"),

--- a/plots/hive-basic/implementations/python/altair.py
+++ b/plots/hive-basic/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1 — first categorical series
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Software module dependency network
 nodes_data = [
@@ -65,9 +65,9 @@ edges_data = [
 
 # Axis configuration: three axes at 120-degree separation using Okabe-Ito
 axis_config = {
-    "Core": {"angle": 30, "color": OKABE_ITO[0]},  # Bluish green
-    "Utility": {"angle": 150, "color": OKABE_ITO[1]},  # Vermillion
-    "Interface": {"angle": 270, "color": OKABE_ITO[2]},  # Blue
+    "Core": {"angle": 30, "color": IMPRINT[0]},  # Bluish green
+    "Utility": {"angle": 150, "color": IMPRINT[1]},  # Vermillion
+    "Interface": {"angle": 270, "color": IMPRINT[2]},  # Blue
 }
 
 # Build node DataFrame with positions
@@ -153,7 +153,7 @@ axis_chart = (
         x2="x2:Q",
         y2="y2:Q",
         color=alt.Color(
-            "axis:N", scale=alt.Scale(domain=["Core", "Utility", "Interface"], range=OKABE_ITO), legend=None
+            "axis:N", scale=alt.Scale(domain=["Core", "Utility", "Interface"], range=IMPRINT), legend=None
         ),
     )
 )
@@ -166,7 +166,7 @@ nodes_chart = (
         x="x:Q",
         y="y:Q",
         color=alt.Color(
-            "axis:N", scale=alt.Scale(domain=["Core", "Utility", "Interface"], range=OKABE_ITO), legend=None
+            "axis:N", scale=alt.Scale(domain=["Core", "Utility", "Interface"], range=IMPRINT), legend=None
         ),
         tooltip=["name:N", "axis:N", "importance:Q"],
     )
@@ -206,7 +206,7 @@ axis_label_chart = (
         y="y:Q",
         text="label:N",
         color=alt.Color(
-            "label:N", scale=alt.Scale(domain=["Core", "Utility", "Interface"], range=OKABE_ITO), legend=None
+            "label:N", scale=alt.Scale(domain=["Core", "Utility", "Interface"], range=IMPRINT), legend=None
         ),
     )
 )

--- a/plots/ice-basic/implementations/python/altair.py
+++ b/plots/ice-basic/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"
-PDP_COLOR = "#D55E00"
+PDP_COLOR = "#C475FD"
 
 # Data
 np.random.seed(42)

--- a/plots/icicle-basic/implementations/python/altair.py
+++ b/plots/icicle-basic/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for levels
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: File system hierarchy with sizes (in MB)
 data = [
@@ -155,7 +155,7 @@ chart = (
         y2=alt.Y2("y_end:Q"),
         color=alt.Color(
             "level:O",
-            scale=alt.Scale(domain=list(range(max_level + 1)), range=OKABE_ITO),
+            scale=alt.Scale(domain=list(range(max_level + 1)), range=IMPRINT),
             legend=alt.Legend(title="Level", labelFontSize=16, titleFontSize=18, orient="right"),
         ),
         tooltip=["name:N", "value:Q", "parent:N", "level:O"],

--- a/plots/indicator-bollinger/implementations/python/altair.py
+++ b/plots/indicator-bollinger/implementations/python/altair.py
@@ -26,8 +26,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Data colors (Okabe-Ito palette - theme-independent)
 PRICE_COLOR = "#009E73"  # Position 1: brand green
-SMA_COLOR = "#D55E00"  # Position 2: vermillion
-BAND_COLOR = "#0072B2"  # Position 3: blue
+SMA_COLOR = "#C475FD"  # Position 2: vermillion
+BAND_COLOR = "#4467A3"  # Position 3: blue
 
 # Data - Simulated stock price with realistic Bollinger Bands
 np.random.seed(42)

--- a/plots/indicator-ema/implementations/python/altair.py
+++ b/plots/indicator-ema/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -46,7 +46,7 @@ df_ema26["series"] = "EMA 26"
 df_long = pd.concat([df_price, df_ema12, df_ema26], ignore_index=True)
 
 # Scales
-color_scale = alt.Scale(domain=["Close Price", "EMA 12", "EMA 26"], range=OKABE_ITO)
+color_scale = alt.Scale(domain=["Close Price", "EMA 12", "EMA 26"], range=IMPRINT)
 stroke_scale = alt.Scale(domain=["Close Price", "EMA 12", "EMA 26"], range=[3.5, 2.5, 2.5])
 
 # Line chart layer
@@ -69,7 +69,7 @@ lines = (
 # Crossover markers (diamond points where EMA 12 crosses EMA 26)
 crossover_markers = (
     alt.Chart(crossover_df)
-    .mark_point(size=300, shape="diamond", filled=True, color="#CC79A7", opacity=0.85)
+    .mark_point(size=300, shape="diamond", filled=True, color="#BD8233", opacity=0.85)
     .encode(
         x=alt.X("date:T"), y=alt.Y("value:Q"), tooltip=[alt.Tooltip("date:T", title="EMA Crossover", format="%Y-%m-%d")]
     )

--- a/plots/indicator-macd/implementations/python/altair.py
+++ b/plots/indicator-macd/implementations/python/altair.py
@@ -97,7 +97,7 @@ line_chart = (
         y=alt.Y("value:Q", title="Value"),
         color=alt.Color(
             "line_label:N",
-            scale=alt.Scale(domain=["MACD (12, 26)", "Signal (9)"], range=["#0072B2", "#E69F00"]),
+            scale=alt.Scale(domain=["MACD (12, 26)", "Signal (9)"], range=["#4467A3", "#AE3030"]),
             legend=alt.Legend(title="Lines", labelFontSize=14, titleFontSize=16),
         ),
         strokeDash=alt.StrokeDash(

--- a/plots/indicator-rsi/implementations/python/altair.py
+++ b/plots/indicator-rsi/implementations/python/altair.py
@@ -100,7 +100,7 @@ threshold_lines = (
 
 rsi_line = (
     alt.Chart(df)
-    .mark_line(strokeWidth=3, color="#0072B2")
+    .mark_line(strokeWidth=3, color="#4467A3")
     .encode(
         x=alt.X("date:T", title="Date", axis=alt.Axis(format="%b %Y")),
         y=alt.Y("rsi:Q", title="RSI Value", scale=alt.Scale(domain=[0, 100])),

--- a/plots/indicator-sma/implementations/python/altair.py
+++ b/plots/indicator-sma/implementations/python/altair.py
@@ -17,7 +17,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 np.random.seed(42)
 n_days = 300
@@ -53,7 +53,7 @@ combined_df = pd.concat([price_df, sma20_df, sma50_df, sma200_df], ignore_index=
 
 SERIES = ["Close Price", "SMA 20", "SMA 50", "SMA 200"]
 
-color_scale = alt.Scale(domain=SERIES, range=OKABE_ITO)
+color_scale = alt.Scale(domain=SERIES, range=IMPRINT)
 stroke_dash_scale = alt.Scale(domain=SERIES, range=[[0], [8, 4], [4, 4], [2, 2]])
 stroke_width_scale = alt.Scale(domain=SERIES, range=[3.5, 1.5, 1.5, 1.5])
 

--- a/plots/kagi-basic/implementations/python/altair.py
+++ b/plots/kagi-basic/implementations/python/altair.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 YANG_COLOR = "#009E73"  # Bluish green (brand)
-YIN_COLOR = "#D55E00"  # Vermillion
+YIN_COLOR = "#AE3030"  # imprint red — bearish
 
 # Generate realistic stock price data (simulated random walk)
 np.random.seed(42)

--- a/plots/learning-curve-basic/implementations/python/altair.py
+++ b/plots/learning-curve-basic/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Training (first series)
-ACCENT = "#D55E00"  # Validation (second series)
+ACCENT = "#C475FD"  # Validation (second series)
 
 # Data - simulate learning curve for a classification model
 np.random.seed(42)

--- a/plots/line-annotated-events/implementations/python/altair.py
+++ b/plots/line-annotated-events/implementations/python/altair.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 (bluish green)
-EVENT_COLOR = "#D55E00"  # Okabe-Ito position 2 (vermillion)
+EVENT_COLOR = "#C475FD"  # Okabe-Ito position 2 (vermillion)
 
 # Data
 np.random.seed(42)

--- a/plots/line-markers/implementations/python/altair.py
+++ b/plots/line-markers/implementations/python/altair.py
@@ -25,7 +25,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Quality control measurements over time (sparse dataset where each point matters)
 np.random.seed(42)
@@ -46,7 +46,7 @@ df = pd.DataFrame(
 base_chart = alt.Chart(df).encode(
     x=alt.X("Time (hours):Q", title="Time (hours)"),
     y=alt.Y("Quality (%):Q", title="Quality (%)"),
-    color=alt.Color("Batch:N", scale=alt.Scale(range=OKABE_ITO[:3])),
+    color=alt.Color("Batch:N", scale=alt.Scale(range=IMPRINT[:3])),
     strokeDash=alt.StrokeDash(
         "Batch:N", scale=alt.Scale(domain=["Batch A", "Batch B", "Batch C"], range=[[], [5, 5], [2, 2]])
     ),

--- a/plots/line-multi/implementations/python/altair.py
+++ b/plots/line-multi/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for categorical data
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Monthly sales for 4 product lines over 24 months
 np.random.seed(42)
@@ -76,7 +76,7 @@ chart = (
         ),
         color=alt.Color(
             "Product:N",
-            scale=alt.Scale(range=OKABE_ITO),
+            scale=alt.Scale(range=IMPRINT),
             legend=alt.Legend(
                 title="Product Line",
                 titleFontSize=20,

--- a/plots/line-stock-comparison/implementations/python/altair.py
+++ b/plots/line-stock-comparison/implementations/python/altair.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -49,7 +49,7 @@ base = alt.Chart(df).encode(
     color=alt.Color(
         "symbol:N",
         title="Symbol",
-        scale=alt.Scale(domain=symbols, range=ANYPLOT_PALETTE),
+        scale=alt.Scale(domain=symbols, range=IMPRINT),
         legend=alt.Legend(titleFontSize=10, labelFontSize=10, symbolSize=120),
     ),
     tooltip=[

--- a/plots/linked-views-selection/implementations/python/altair.py
+++ b/plots/linked-views-selection/implementations/python/altair.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first three positions)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris-like flower measurements with categories
 np.random.seed(42)
@@ -57,7 +57,7 @@ for i, cat in enumerate(categories):
 df = pd.DataFrame(data)
 
 # Color scale using Okabe-Ito
-color_scale = alt.Scale(domain=categories, range=OKABE_ITO)
+color_scale = alt.Scale(domain=categories, range=IMPRINT)
 
 # Selection mechanism
 brush = alt.selection_interval()

--- a/plots/logistic-regression/implementations/python/altair.py
+++ b/plots/logistic-regression/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series (Fail)
-SECONDARY = "#D55E00"  # Second series (Pass)
+SECONDARY = "#C475FD"  # Second series (Pass)
 
 # Data - Study hours vs exam pass/fail
 np.random.seed(42)

--- a/plots/lollipop-grouped/implementations/python/altair.py
+++ b/plots/lollipop-grouped/implementations/python/altair.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Quarterly performance metrics across regions
 np.random.seed(42)
@@ -48,7 +48,7 @@ df["series_order"] = df["series"].map({s: i for i, s in enumerate(series)})
 df["x_offset"] = (df["series_order"] - (len(series) - 1) / 2) * 0.25
 
 # Color scale using Okabe-Ito palette
-color_scale = alt.Scale(domain=series, range=OKABE_ITO[: len(series)])
+color_scale = alt.Scale(domain=series, range=IMPRINT[: len(series)])
 
 # Base chart
 base = alt.Chart(df).encode(

--- a/plots/manhattan-gwas/implementations/python/altair.py
+++ b/plots/manhattan-gwas/implementations/python/altair.py
@@ -22,7 +22,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for alternating chromosomes
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data generation
 np.random.seed(42)
@@ -108,7 +108,7 @@ chrom_label_df = pd.DataFrame([{"chrom_label": chrom, "center": center} for chro
 chrom_list = list(chrom_lengths.keys())
 color_mapping = {}
 for i, chrom in enumerate(chrom_list):
-    color_mapping[chrom] = OKABE_ITO[i % len(OKABE_ITO)]
+    color_mapping[chrom] = IMPRINT[i % len(IMPRINT)]
 
 color_scale = alt.Scale(domain=chrom_list, range=[color_mapping[chrom] for chrom in chrom_list])
 

--- a/plots/map-drilldown-geographic/implementations/python/altair.py
+++ b/plots/map-drilldown-geographic/implementations/python/altair.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
 REGIONS = ["West", "South", "Midwest", "Northeast"]
 
 # Data — US state-level sales ($K), Region → State → City hierarchy
@@ -336,7 +336,7 @@ region_bars = (
         x=alt.X("total_value:Q", title="Sales ($K)", axis=alt.Axis(grid=True, gridOpacity=0.10)),
         color=alt.Color(
             "region:N",
-            scale=alt.Scale(domain=REGIONS, range=ANYPLOT_PALETTE),
+            scale=alt.Scale(domain=REGIONS, range=IMPRINT),
             legend=alt.Legend(title="Region", titleFontSize=10, labelFontSize=11, orient="right", direction="vertical"),
         ),
         opacity=alt.condition(region_select, alt.value(1.0), alt.value(0.55)),
@@ -357,7 +357,7 @@ state_bars = (
     .encode(
         y=alt.Y("state:N", sort="-x", title=None),
         x=alt.X("value:Q", title="Sales ($K)", axis=alt.Axis(grid=True, gridOpacity=0.10)),
-        color=alt.Color("region:N", scale=alt.Scale(domain=REGIONS, range=ANYPLOT_PALETTE), legend=None),
+        color=alt.Color("region:N", scale=alt.Scale(domain=REGIONS, range=IMPRINT), legend=None),
         opacity=alt.condition(state_select, alt.value(1.0), alt.value(0.55)),
         tooltip=[
             alt.Tooltip("state:N", title="State"),
@@ -373,7 +373,7 @@ state_bars = (
 # City bars — ③ State → Cities (filtered by selected state; CA, TX, NY, FL have data)
 city_bars = (
     alt.Chart(cities_data)
-    .mark_bar(cornerRadiusTopRight=4, cornerRadiusBottomRight=4, color=ANYPLOT_PALETTE[0])
+    .mark_bar(cornerRadiusTopRight=4, cornerRadiusBottomRight=4, color=IMPRINT[0])
     .encode(
         y=alt.Y("city:N", sort="-x", title=None),
         x=alt.X("value:Q", title="Sales ($K)", axis=alt.Axis(grid=True, gridOpacity=0.10)),

--- a/plots/map-marker-clustered/implementations/python/altair.py
+++ b/plots/map-marker-clustered/implementations/python/altair.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 MAP_FILL = "#E8E6DF" if THEME == "light" else "#2A2A27"
 MAP_STROKE = "#B8B7B0" if THEME == "light" else "#4A4A44"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3", "#99B314", "#D359A7", "#BA843E"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]  # imprint canonical slot order
 
 # Data — store locations across the United States
 np.random.seed(42)
@@ -108,7 +108,7 @@ background = (
 )
 
 category_colors = alt.Scale(
-    domain=["retail", "food", "services"], range=[ANYPLOT_PALETTE[0], ANYPLOT_PALETTE[1], ANYPLOT_PALETTE[2]]
+    domain=["retail", "food", "services"], range=[IMPRINT[0], IMPRINT[1], IMPRINT[2]]
 )
 
 # Hover selection on cluster circles — gates spider lines and member-point reveal

--- a/plots/map-route-path/implementations/python/altair.py
+++ b/plots/map-route-path/implementations/python/altair.py
@@ -134,7 +134,7 @@ start_marker = (
 
 end_marker = (
     alt.Chart(end_df)
-    .mark_point(shape="square", size=320, filled=True, color="#D55E00", stroke="white", strokeWidth=2.5)
+    .mark_point(shape="square", size=320, filled=True, color="#C475FD", stroke="white", strokeWidth=2.5)
     .encode(longitude="lon:Q", latitude="lat:Q", tooltip="label:N")
     .project(type="albersUsa")
 )

--- a/plots/maze-circular/implementations/python/altair.py
+++ b/plots/maze-circular/implementations/python/altair.py
@@ -22,8 +22,8 @@ THEME = os.getenv("ANYPLOT_THEME", "light")
 PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 WALL_COLOR = "#1A1A17" if THEME == "light" else "#E0DFD8"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
-ENTRY_COLOR = "#0072B2"  # Okabe-Ito position 3, theme-independent (same in light and dark)
-GOAL_COLOR = "#E69F00"  # Okabe-Ito position 5, theme-independent
+ENTRY_COLOR = "#4467A3"  # Okabe-Ito position 3, theme-independent (same in light and dark)
+GOAL_COLOR = "#AE3030"  # Okabe-Ito position 5, theme-independent
 
 # Difficulty: "easy" / "medium" / "hard" — scales sector density (more sectors = harder maze)
 DIFFICULTY = os.getenv("ANYPLOT_DIFFICULTY", "medium")

--- a/plots/mosaic-categorical/implementations/python/altair.py
+++ b/plots/mosaic-categorical/implementations/python/altair.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito positions 1 and 2
 COLOR_SURVIVED = "#009E73"
-COLOR_NOT_SURVIVED = "#D55E00"
+COLOR_NOT_SURVIVED = "#C475FD"
 
 # Data: Titanic survival by passenger class (contingency table)
 data = pd.DataFrame(

--- a/plots/network-bipartite/implementations/python/altair.py
+++ b/plots/network-bipartite/implementations/python/altair.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 COLOR_A = "#009E73"  # Authors — Okabe-Ito position 1
-COLOR_B = "#D55E00"  # Papers — Okabe-Ito position 2
+COLOR_B = "#C475FD"  # Papers — Okabe-Ito position 2
 
 # Data — researcher-paper affiliation network (bibliometrics)
 author_names = [

--- a/plots/network-directed/implementations/python/altair.py
+++ b/plots/network-directed/implementations/python/altair.py
@@ -73,13 +73,13 @@ edges = [
 ]
 
 # Okabe-Ito palette for groups
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 group_colors = {
-    "main": OKABE_ITO[0],  # Brand green
-    "core": OKABE_ITO[1],  # Vermillion
-    "service": OKABE_ITO[2],  # Blue
-    "util": OKABE_ITO[3],  # Reddish purple
-    "data": OKABE_ITO[4],  # Orange
+    "main": IMPRINT[0],  # Brand green
+    "core": IMPRINT[1],  # Vermillion
+    "service": IMPRINT[2],  # Blue
+    "util": IMPRINT[3],  # Reddish purple
+    "data": IMPRINT[4],  # Orange
 }
 
 # Node positions using hierarchical layout based on dependency depth

--- a/plots/network-force-directed/implementations/python/altair.py
+++ b/plots/network-force-directed/implementations/python/altair.py
@@ -20,7 +20,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 EDGE_COLOR = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito categorical palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: a 50-node organisational network with three communities
 np.random.seed(42)
@@ -128,7 +128,7 @@ nodes_chart = (
         size=alt.Size("size:Q", legend=None, scale=alt.Scale(range=[200, 900])),
         color=alt.Color(
             "community:N",
-            scale=alt.Scale(domain=community_names, range=OKABE_ITO),
+            scale=alt.Scale(domain=community_names, range=IMPRINT),
             legend=alt.Legend(title="Team", titleFontSize=18, labelFontSize=16, symbolSize=400),
         ),
         tooltip=[alt.Tooltip("community:N", title="Team"), alt.Tooltip("degree:Q", title="Connections")],

--- a/plots/network-hierarchical/implementations/python/altair.py
+++ b/plots/network-hierarchical/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for levels
-LEVEL_COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+LEVEL_COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Organizational chart with 25 employees across 4 levels
 np.random.seed(42)

--- a/plots/network-transport-static/implementations/python/altair.py
+++ b/plots/network-transport-static/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Station data - Regional rail network
 stations = [
@@ -160,7 +160,7 @@ node_labels = (
 node_ids = (
     alt.Chart(stations_df)
     .mark_text(fontSize=18, fontWeight="bold")
-    .encode(x=alt.X("x:Q", scale=x_scale), y=alt.Y("y:Q", scale=y_scale), text="id:N", color=alt.value(OKABE_ITO[0]))
+    .encode(x=alt.X("x:Q", scale=x_scale), y=alt.Y("y:Q", scale=y_scale), text="id:N", color=alt.value(IMPRINT[0]))
 )
 
 # Route edges (lines)
@@ -174,7 +174,7 @@ edges = (
         y2="y2:Q",
         color=alt.Color(
             "type:N",
-            scale=alt.Scale(domain=["Express", "Regional", "Local"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Express", "Regional", "Local"], range=IMPRINT),
             legend=alt.Legend(title="Route Type", titleFontSize=16, labelFontSize=14, orient="right"),
         ),
         tooltip=["route:N", "dep:N", "arr:N", "type:N"],
@@ -192,7 +192,7 @@ arrows = (
         y=alt.Y("ay:Q", scale=y_scale),
         angle=alt.Angle("angle_adjusted:Q"),
         color=alt.Color(
-            "type:N", scale=alt.Scale(domain=["Express", "Regional", "Local"], range=OKABE_ITO), legend=None
+            "type:N", scale=alt.Scale(domain=["Express", "Regional", "Local"], range=IMPRINT), legend=None
         ),
     )
 )

--- a/plots/network-weighted/implementations/python/altair.py
+++ b/plots/network-weighted/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Trade network between 15 countries (billions USD)
 np.random.seed(42)
@@ -166,7 +166,7 @@ node_chart = (
         ),
         color=alt.Color(
             "group:N",
-            scale=alt.Scale(domain=["Americas", "Europe", "Asia", "Oceania"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Americas", "Europe", "Asia", "Oceania"], range=IMPRINT),
             legend=alt.Legend(
                 title="Region", titleFontSize=18, labelFontSize=16, orient="right", symbolSize=600, offset=10
             ),

--- a/plots/ohlc-bar/implementations/python/altair.py
+++ b/plots/ohlc-bar/implementations/python/altair.py
@@ -20,7 +20,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 UP_COLOR = "#009E73"  # Okabe-Ito position 1 (brand green)
-DOWN_COLOR = "#D55E00"  # Okabe-Ito position 2 (vermillion)
+DOWN_COLOR = "#AE3030"  # imprint red — down days
 
 # Data - Generate 50 trading days of OHLC data
 np.random.seed(42)

--- a/plots/parallel-basic/implementations/python/altair.py
+++ b/plots/parallel-basic/implementations/python/altair.py
@@ -25,7 +25,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris-like dataset with 4 dimensions and 3 species
 np.random.seed(42)
@@ -90,7 +90,7 @@ spec = (
         detail="id:N",
         color=alt.Color(
             "Species:N",
-            scale=alt.Scale(domain=species_names, range=OKABE_ITO),
+            scale=alt.Scale(domain=species_names, range=IMPRINT),
             legend=alt.Legend(
                 title="Species", titleFontSize=22, labelFontSize=20, symbolSize=300, symbolStrokeWidth=4, orient="right"
             ),

--- a/plots/parallel-categories-basic/implementations/python/altair.py
+++ b/plots/parallel-categories-basic/implementations/python/altair.py
@@ -27,14 +27,14 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette (colorblind-safe)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # brand green (position 1)
-    "#D55E00",  # vermillion (position 2)
-    "#0072B2",  # blue (position 3)
-    "#CC79A7",  # reddish purple (position 4)
-    "#E69F00",  # orange (position 5)
-    "#56B4E9",  # sky blue (position 6)
-    "#F0E442",  # yellow (position 7)
+    "#C475FD",  # vermillion (position 2)
+    "#4467A3",  # blue (position 3)
+    "#BD8233",  # reddish purple (position 4)
+    "#AE3030",  # orange (position 5)
+    "#2ABCCD",  # sky blue (position 6)
+    "#954477",  # yellow (position 7)
 ]
 
 # Data - Customer journey through product categories
@@ -53,21 +53,21 @@ x_pos = {"Channel": 0, "Category": 250, "Outcome": 500}
 
 # Color maps using Okabe-Ito palette
 channel_colors = {
-    "Direct": OKABE_ITO[0],  # brand green
-    "Search": OKABE_ITO[1],  # vermillion
-    "Social": OKABE_ITO[2],  # blue
-    "Email": OKABE_ITO[3],  # reddish purple
+    "Direct": IMPRINT[0],  # brand green
+    "Search": IMPRINT[1],  # vermillion
+    "Social": IMPRINT[2],  # blue
+    "Email": IMPRINT[3],  # reddish purple
 }
 category_colors = {
-    "Electronics": OKABE_ITO[0],  # green
-    "Clothing": OKABE_ITO[1],  # vermillion
-    "Home": OKABE_ITO[2],  # blue
-    "Sports": OKABE_ITO[3],  # reddish purple
+    "Electronics": IMPRINT[0],  # green
+    "Clothing": IMPRINT[1],  # vermillion
+    "Home": IMPRINT[2],  # blue
+    "Sports": IMPRINT[3],  # reddish purple
 }
 outcome_colors = {
-    "Purchase": OKABE_ITO[0],  # green
-    "Abandon": OKABE_ITO[1],  # vermillion
-    "Browse": OKABE_ITO[2],  # blue
+    "Purchase": IMPRINT[0],  # green
+    "Abandon": IMPRINT[1],  # vermillion
+    "Browse": IMPRINT[2],  # blue
 }
 
 scale_factor = 3.5

--- a/plots/parliament-basic/implementations/python/altair.py
+++ b/plots/parliament-basic/implementations/python/altair.py
@@ -36,11 +36,11 @@ np.random.seed(42)
 # Using Okabe-Ito palette, starting with #009E73
 parties = [
     {"party": "Progressive", "seats": 95, "color": "#009E73"},
-    {"party": "Conservative", "seats": 82, "color": "#D55E00"},
-    {"party": "Green", "seats": 45, "color": "#0072B2"},
-    {"party": "Liberal", "seats": 38, "color": "#CC79A7"},
-    {"party": "Social Dem.", "seats": 28, "color": "#E69F00"},
-    {"party": "Independent", "seats": 12, "color": "#56B4E9"},
+    {"party": "Conservative", "seats": 82, "color": "#C475FD"},
+    {"party": "Green", "seats": 45, "color": "#4467A3"},
+    {"party": "Liberal", "seats": 38, "color": "#BD8233"},
+    {"party": "Social Dem.", "seats": 28, "color": "#AE3030"},
+    {"party": "Independent", "seats": 12, "color": "#2ABCCD"},
 ]
 
 total_seats = sum(p["seats"] for p in parties)

--- a/plots/phase-diagram/implementations/python/altair.py
+++ b/plots/phase-diagram/implementations/python/altair.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Damped pendulum simulation
 np.random.seed(42)
@@ -60,7 +60,7 @@ base = (
         color=alt.Color(
             "trajectory:N",
             title="Initial Condition",
-            scale=alt.Scale(range=OKABE_ITO),
+            scale=alt.Scale(range=IMPRINT),
             legend=alt.Legend(titleFontSize=18, labelFontSize=16, symbolStrokeWidth=3),
         ),
         order=alt.Order("order:Q"),
@@ -78,7 +78,7 @@ start_points = df[df["order"] == 0]
 points = (
     alt.Chart(start_points)
     .mark_point(size=400, filled=True, opacity=1.0)
-    .encode(x="x:Q", y="dx_dt:Q", color=alt.Color("trajectory:N", scale=alt.Scale(range=OKABE_ITO), legend=None))
+    .encode(x="x:Q", y="dx_dt:Q", color=alt.Color("trajectory:N", scale=alt.Scale(range=IMPRINT), legend=None))
 )
 
 # Add equilibrium point marker at origin

--- a/plots/pie-drilldown/implementations/python/altair.py
+++ b/plots/pie-drilldown/implementations/python/altair.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 hierarchy_data = [
     {"id": "root", "name": "All Departments", "value": 3200000, "parent": None},
@@ -47,20 +47,20 @@ df = pd.DataFrame(hierarchy_data)
 
 color_map = {
     "All Departments": INK,
-    "Engineering": OKABE_ITO[0],
-    "Marketing": OKABE_ITO[1],
-    "Operations": OKABE_ITO[2],
-    "HR": OKABE_ITO[3],
-    "Frontend": "#56B4E9",
-    "Backend": OKABE_ITO[0],
-    "DevOps": "#0072B2",
+    "Engineering": IMPRINT[0],
+    "Marketing": IMPRINT[1],
+    "Operations": IMPRINT[2],
+    "HR": IMPRINT[3],
+    "Frontend": "#2ABCCD",
+    "Backend": IMPRINT[0],
+    "DevOps": "#4467A3",
     "Digital": "#FFC863",
-    "Content": OKABE_ITO[1],
-    "Events": "#D55E00",
+    "Content": IMPRINT[1],
+    "Events": "#C475FD",
     "Facilities": "#72C472",
-    "IT Support": OKABE_ITO[2],
+    "IT Support": IMPRINT[2],
     "Recruiting": "#BC8FBC",
-    "Training": "#CC79A7",
+    "Training": "#BD8233",
 }
 
 df["color"] = df["name"].map(color_map)
@@ -108,7 +108,7 @@ main_center_df = pd.DataFrame([{"line1": "All Departments", "line2": "$3.20B"}])
 main_center = alt.layer(
     alt.Chart(main_center_df).mark_text(fontSize=22, fontWeight="bold", dy=-20, color=INK).encode(text="line1:N"),
     alt.Chart(main_center_df)
-    .mark_text(fontSize=32, fontWeight="bold", dy=15, color=OKABE_ITO[0])
+    .mark_text(fontSize=32, fontWeight="bold", dy=15, color=IMPRINT[0])
     .encode(text="line2:N"),
 )
 

--- a/plots/point-and-figure-basic/implementations/python/altair.py
+++ b/plots/point-and-figure-basic/implementations/python/altair.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BULL_COLOR = "#009E73"  # Okabe-Ito position 1 — X columns (bullish)
-BEAR_COLOR = "#D55E00"  # Okabe-Ito position 2 — O columns (bearish)
+BEAR_COLOR = "#AE3030"  # imprint red — O columns (bearish)
 
 # Data
 np.random.seed(42)
@@ -144,13 +144,13 @@ pf_marks = (
 
 support_layer = (
     alt.Chart(support_df)
-    .mark_line(strokeDash=[5, 3], strokeWidth=1.5, color="#0072B2", opacity=0.7)
+    .mark_line(strokeDash=[5, 3], strokeWidth=1.5, color="#4467A3", opacity=0.7)
     .encode(x="column:O", y="price:Q")
 )
 
 resist_layer = (
     alt.Chart(resist_df)
-    .mark_line(strokeDash=[5, 3], strokeWidth=1.5, color="#CC79A7", opacity=0.7)
+    .mark_line(strokeDash=[5, 3], strokeWidth=1.5, color="#BD8233", opacity=0.7)
     .encode(x="column:O", y="price:Q")
 )
 

--- a/plots/point-basic/implementations/python/altair.py
+++ b/plots/point-basic/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73 (brand green)
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 REFERENCE_LINE = "#888888"
 
 # Data - Treatment effect estimates with 95% confidence intervals

--- a/plots/polar-bar/implementations/python/altair.py
+++ b/plots/polar-bar/implementations/python/altair.py
@@ -17,7 +17,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Wind direction frequency data
 np.random.seed(42)
@@ -47,7 +47,7 @@ bars = base.mark_arc(stroke=INK_SOFT, strokeWidth=1.5).encode(
     radius=alt.Radius("frequency:Q", scale=alt.Scale(type="linear", zero=True, rangeMin=0)),
     color=alt.Color(
         "direction:N",
-        scale=alt.Scale(range=OKABE_ITO),
+        scale=alt.Scale(range=IMPRINT),
         legend=alt.Legend(
             title="Direction",
             titleFontSize=18,

--- a/plots/polar-line/implementations/python/altair.py
+++ b/plots/polar-line/implementations/python/altair.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-2 for two series)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Seasonal temperature pattern (cyclical)
 np.random.seed(42)
@@ -125,7 +125,7 @@ lines_chart = (
         y="y:Q",
         color=alt.Color(
             "city:N",
-            scale=alt.Scale(domain=["Northern City", "Southern City"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Northern City", "Southern City"], range=IMPRINT),
             legend=alt.Legend(
                 title="City",
                 titleFontSize=20,
@@ -150,7 +150,7 @@ points_chart = (
         x="x:Q",
         y="y:Q",
         color=alt.Color(
-            "city:N", scale=alt.Scale(domain=["Northern City", "Southern City"], range=OKABE_ITO), legend=None
+            "city:N", scale=alt.Scale(domain=["Northern City", "Southern City"], range=IMPRINT), legend=None
         ),
     )
 )

--- a/plots/polar-scatter/implementations/python/altair.py
+++ b/plots/polar-scatter/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1, 2, 3 for three categories)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Synthetic wind measurements with prevailing directions
 np.random.seed(42)
@@ -142,7 +142,7 @@ points = (
         y=alt.Y("y:Q", axis=None, scale=alt.Scale(domain=[-25, 25])),
         color=alt.Color(
             "time_of_day:N",
-            scale=alt.Scale(domain=["Morning", "Afternoon", "Evening"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Morning", "Afternoon", "Evening"], range=IMPRINT),
             title="Time of Day",
         ),
         tooltip=[

--- a/plots/precision-recall/implementations/python/altair.py
+++ b/plots/precision-recall/implementations/python/altair.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 np.random.seed(42)
 
@@ -64,7 +64,7 @@ pr_curves = (
             "Model:N",
             scale=alt.Scale(
                 domain=[f"Logistic Regression (AP = {lr_ap:.3f})", f"Random Forest (AP = {rf_ap:.3f})"],
-                range=[OKABE_ITO[0], OKABE_ITO[1]],
+                range=[IMPRINT[0], IMPRINT[1]],
             ),
             legend=alt.Legend(
                 title="Model",
@@ -96,7 +96,7 @@ pr_curves = (
 baseline_line = (
     alt.Chart(baseline_df)
     .mark_line(strokeWidth=3, strokeDash=[8, 4])
-    .encode(x=alt.X("Recall:Q"), y=alt.Y("Precision:Q"), color=alt.ColorValue(OKABE_ITO[2]))
+    .encode(x=alt.X("Recall:Q"), y=alt.Y("Precision:Q"), color=alt.ColorValue(IMPRINT[2]))
 )
 
 chart = (

--- a/plots/pyramid-basic/implementations/python/altair.py
+++ b/plots/pyramid-basic/implementations/python/altair.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data — population pyramid with pronounced gender gap in older age groups
 age_groups = ["0-9", "10-19", "20-29", "30-39", "40-49", "50-59", "60-69", "70-79", "80+"]
@@ -61,7 +61,7 @@ chart = (
         ),
         color=alt.Color(
             "Gender:N",
-            scale=alt.Scale(domain=["Male", "Female"], range=[OKABE_ITO[0], OKABE_ITO[1]]),
+            scale=alt.Scale(domain=["Male", "Female"], range=[IMPRINT[0], IMPRINT[1]]),
             legend=alt.Legend(title="Gender", titleFontSize=20, labelFontSize=18, orient="bottom"),
         ),
         opacity=alt.condition(selection, alt.value(0.9), alt.value(0.25)),

--- a/plots/radar-basic/implementations/python/altair.py
+++ b/plots/radar-basic/implementations/python/altair.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 categories = ["Communication", "Technical Skills", "Teamwork", "Problem Solving", "Leadership", "Creativity"]
 n = len(categories)
@@ -121,7 +121,7 @@ bob_x_c, bob_y_c = to_xy_closed(bob_vals)
 # Click-based interactive selection: click a vertex point to highlight its series
 selection = alt.selection_point(fields=["Employee"])
 
-color_scale = alt.Scale(domain=["Alice", "Bob"], range=[OKABE_ITO[0], OKABE_ITO[1]])
+color_scale = alt.Scale(domain=["Alice", "Bob"], range=[IMPRINT[0], IMPRINT[1]])
 
 # Static grid rings
 grid_lines = (
@@ -145,13 +145,13 @@ spokes = (
 # Static filled polygons (semi-transparent, one geoshape per series)
 alice_fill = (
     alt.Chart(alt.Data(values=[make_geo(alice_x_c, alice_y_c)]))
-    .mark_geoshape(fill=OKABE_ITO[0], fillOpacity=0.18, stroke="none")
+    .mark_geoshape(fill=IMPRINT[0], fillOpacity=0.18, stroke="none")
     .project(type="identity", reflectY=True)
 )
 
 bob_fill = (
     alt.Chart(alt.Data(values=[make_geo(bob_x_c, bob_y_c)]))
-    .mark_geoshape(fill=OKABE_ITO[1], fillOpacity=0.18, stroke="none")
+    .mark_geoshape(fill=IMPRINT[1], fillOpacity=0.18, stroke="none")
     .project(type="identity", reflectY=True)
 )
 

--- a/plots/radar-multi/implementations/python/altair.py
+++ b/plots/radar-multi/implementations/python/altair.py
@@ -33,7 +33,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Product comparison across key attributes
 categories = ["Price", "Quality", "Durability", "Support", "Features", "Design"]
@@ -112,7 +112,7 @@ value_label_df = pd.DataFrame(value_label_records)
 
 # Series list and colors
 series_list = ["Product A", "Product B", "Product C"]
-color_scale = alt.Scale(domain=series_list, range=OKABE_ITO)
+color_scale = alt.Scale(domain=series_list, range=IMPRINT)
 
 # Chart dimensions for square output (base size with 3x scale factor)
 chart_width = 1600
@@ -155,7 +155,7 @@ value_labels = (
 
 # Create filled polygons for each series
 fill_layers = []
-for series_name, fill_color in zip(series_list, OKABE_ITO, strict=True):
+for series_name, fill_color in zip(series_list, IMPRINT, strict=True):
     series_df = df[df["series"] == series_name].copy()
 
     # Use mark_area for proper polygon fill

--- a/plots/range-interval/implementations/python/altair.py
+++ b/plots/range-interval/implementations/python/altair.py
@@ -19,8 +19,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series - always
-SECONDARY = "#D55E00"
-ACCENT = "#0072B2"
+SECONDARY = "#C475FD"
+ACCENT = "#4467A3"
 
 # Data: Monthly temperature ranges (°C) for a temperate city
 data = pd.DataFrame(

--- a/plots/renko-basic/implementations/python/altair.py
+++ b/plots/renko-basic/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors (positions 1 and 2 for bullish/bearish)
 BULLISH = "#009E73"  # Okabe-Ito position 1
-BEARISH = "#D55E00"  # Okabe-Ito position 2
+BEARISH = "#AE3030"  # imprint red — bearish
 
 # Data - Generate realistic stock price data
 np.random.seed(42)

--- a/plots/residual-plot/implementations/python/altair.py
+++ b/plots/residual-plot/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 OKABE_ITO_1 = "#009E73"  # Brand green for main data
-OKABE_ITO_2 = "#C475FD"  # Vermillion for outliers
+OUTLIER_COLOR = "#AE3030"  # imprint red — outliers (>2σ)
 
 # Data: Simulate a linear regression scenario with some non-linearity
 np.random.seed(42)
@@ -61,7 +61,7 @@ scatter = (
         y=alt.Y("Residuals ($):Q", title="Residuals ($)", scale=alt.Scale(nice=True)),
         color=alt.Color(
             "Outlier:N",
-            scale=alt.Scale(domain=["Normal", "Outlier (>2σ)"], range=[OKABE_ITO_1, OKABE_ITO_2]),
+            scale=alt.Scale(domain=["Normal", "Outlier (>2σ)"], range=[OKABE_ITO_1, OUTLIER_COLOR]),
             legend=alt.Legend(title="Point Type", titleFontSize=18, labelFontSize=16),
         ),
         tooltip=["Fitted Values ($):Q", "Residuals ($):Q", "Outlier:N"],

--- a/plots/residual-plot/implementations/python/altair.py
+++ b/plots/residual-plot/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 OKABE_ITO_1 = "#009E73"  # Brand green for main data
-OKABE_ITO_2 = "#D55E00"  # Vermillion for outliers
+OKABE_ITO_2 = "#C475FD"  # Vermillion for outliers
 
 # Data: Simulate a linear regression scenario with some non-linearity
 np.random.seed(42)

--- a/plots/roc-curve/implementations/python/altair.py
+++ b/plots/roc-curve/implementations/python/altair.py
@@ -33,7 +33,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1
-SECONDARY = "#D55E00"  # Position 2
+SECONDARY = "#C475FD"  # Position 2
 NEUTRAL = INK_MUTED  # Diagonal reference line
 
 # Data - Generate synthetic classification scores and compute ROC curve

--- a/plots/sankey-basic/implementations/python/altair.py
+++ b/plots/sankey-basic/implementations/python/altair.py
@@ -80,9 +80,9 @@ for tgt in targets:
 # Okabe-Ito palette for source colors — distinct, colorblind-safe
 source_colors = {
     "Coal": "#009E73",  # Okabe-Ito #1 (brand green)
-    "Gas": "#D55E00",  # Okabe-Ito #2 (vermillion)
-    "Nuclear": "#0072B2",  # Okabe-Ito #3 (blue)
-    "Renewable": "#CC79A7",  # Okabe-Ito #4 (reddish purple)
+    "Gas": "#C475FD",  # Okabe-Ito #2 (vermillion)
+    "Nuclear": "#4467A3",  # Okabe-Ito #3 (blue)
+    "Renewable": "#BD8233",  # Okabe-Ito #4 (reddish purple)
 }
 
 # Target node colors — muted, distinct from source palette

--- a/plots/scatter-3d/implementations/python/altair.py
+++ b/plots/scatter-3d/implementations/python/altair.py
@@ -17,7 +17,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - create 3D clusters to demonstrate spatial relationships
 np.random.seed(42)
@@ -66,7 +66,7 @@ scatter = (
         y=alt.Y("z_proj:Q", axis=alt.Axis(title="Z Axis", labelFontSize=18, titleFontSize=22)),
         color=alt.Color(
             "cluster:N",
-            scale=alt.Scale(domain=["Cluster 1", "Cluster 2", "Cluster 3"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Cluster 1", "Cluster 2", "Cluster 3"], range=IMPRINT),
             legend=alt.Legend(title="Cluster", titleFontSize=20, labelFontSize=16, orient="top-right", offset=10),
         ),
         opacity=alt.Opacity("opacity:Q", legend=None),

--- a/plots/scatter-animated-controls/implementations/python/altair.py
+++ b/plots/scatter-animated-controls/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: Simulated country development metrics over years
 np.random.seed(42)
@@ -92,7 +92,7 @@ for i, country in enumerate(countries):
 df = pd.DataFrame(data)
 
 # Color scale for regions
-color_scale = alt.Scale(domain=["Region 1", "Region 2", "Region 3"], range=OKABE_ITO[:3])
+color_scale = alt.Scale(domain=["Region 1", "Region 2", "Region 3"], range=IMPRINT[:3])
 
 # Create base scatter plot
 scatter = (

--- a/plots/scatter-brush-zoom/implementations/python/altair.py
+++ b/plots/scatter-brush-zoom/implementations/python/altair.py
@@ -30,7 +30,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Generate clustered data for brush selection demonstration
 np.random.seed(42)
@@ -61,7 +61,7 @@ df["id"] = range(len(df))
 brush = alt.selection_interval()
 
 # Define color scale using Okabe-Ito palette
-color_scale = alt.Scale(domain=["Sensor A", "Sensor B", "Sensor C", "Sensor D"], range=OKABE_ITO)
+color_scale = alt.Scale(domain=["Sensor A", "Sensor B", "Sensor C", "Sensor D"], range=IMPRINT)
 
 # Create the scatter plot with brush selection
 points = (

--- a/plots/scatter-categorical/implementations/python/altair.py
+++ b/plots/scatter-categorical/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris-like measurements by species
 np.random.seed(42)
@@ -49,7 +49,7 @@ chart = (
         y=alt.Y("Petal Width (cm):Q", title="Petal Width (cm)", scale=alt.Scale(zero=False)),
         color=alt.Color(
             "Species:N",
-            scale=alt.Scale(domain=species_names, range=OKABE_ITO),
+            scale=alt.Scale(domain=species_names, range=IMPRINT),
             legend=alt.Legend(
                 title="Species",
                 titleFontSize=20,

--- a/plots/scatter-embedding/implementations/python/altair.py
+++ b/plots/scatter-embedding/implementations/python/altair.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Single-cell RNA-seq scenario with domain-specific cell type labels
 CELL_TYPES = ["T cells", "B cells", "NK cells", "Monocytes", "Dendritic cells", "Macrophages", "Plasma cells"]
@@ -54,7 +54,7 @@ scatter = (
         x=alt.X("tsne_1:Q", axis=alt.Axis(labels=False, ticks=False, title="t-SNE Dimension 1")),
         y=alt.Y("tsne_2:Q", axis=alt.Axis(labels=False, ticks=False, title="t-SNE Dimension 2")),
         color=alt.Color(
-            "cluster:N", scale=alt.Scale(domain=CELL_TYPES, range=OKABE_ITO), legend=alt.Legend(title="Cell Type")
+            "cluster:N", scale=alt.Scale(domain=CELL_TYPES, range=IMPRINT), legend=alt.Legend(title="Cell Type")
         ),
         opacity=alt.condition(selection, alt.value(0.70), alt.value(0.15)),
         stroke=alt.value(PAGE_BG),

--- a/plots/scatter-map-geographic/implementations/python/altair.py
+++ b/plots/scatter-map-geographic/implementations/python/altair.py
@@ -274,11 +274,11 @@ basemap = (
 # Define color scale for regions using Okabe-Ito palette positions
 region_colors = {
     "Asia": "#009E73",  # OI position 1 (brand green)
-    "Africa": "#D55E00",  # OI position 2 (vermillion)
-    "Europe": "#0072B2",  # OI position 3 (blue)
-    "North America": "#CC79A7",  # OI position 4 (reddish purple)
-    "South America": "#E69F00",  # OI position 5 (orange)
-    "Oceania": "#56B4E9",  # OI position 6 (sky blue)
+    "Africa": "#C475FD",  # OI position 2 (vermillion)
+    "Europe": "#4467A3",  # OI position 3 (blue)
+    "North America": "#BD8233",  # OI position 4 (reddish purple)
+    "South America": "#AE3030",  # OI position 5 (orange)
+    "Oceania": "#2ABCCD",  # OI position 6 (sky blue)
 }
 
 # Create scatter points layer

--- a/plots/scatter-matrix-interactive/implementations/python/altair.py
+++ b/plots/scatter-matrix-interactive/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Synthetic Iris-like multivariate data
 np.random.seed(42)
@@ -119,7 +119,7 @@ for row_idx, y_var in enumerate(variables):
                     ),
                     color=alt.Color(
                         "Species:N",
-                        scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=OKABE_ITO),
+                        scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=IMPRINT),
                         legend=None,
                     ),
                 )
@@ -162,7 +162,7 @@ for row_idx, y_var in enumerate(variables):
                     ),
                     color=alt.Color(
                         "Species:N",
-                        scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=OKABE_ITO),
+                        scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=IMPRINT),
                         legend=None,
                     ),
                     tooltip=["Species:N"] + [alt.Tooltip(v, format=".2f") for v in variables],
@@ -179,7 +179,7 @@ legend_chart = (
     .encode(
         y=alt.Y("Species:N", title="", axis=alt.Axis(labelFontSize=18, orient="right")),
         color=alt.Color(
-            "Species:N", scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=OKABE_ITO), legend=None
+            "Species:N", scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=IMPRINT), legend=None
         ),
     )
     .properties(width=50, height=150, title=alt.Title("Species", fontSize=22))
@@ -249,7 +249,7 @@ interactive_chart = (
             brush,
             alt.Color(
                 "Species:N",
-                scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=OKABE_ITO),
+                scale=alt.Scale(domain=["setosa", "versicolor", "virginica"], range=IMPRINT),
                 legend=alt.Legend(titleFontSize=18, labelFontSize=16, orient="right", title="Species"),
             ),
             alt.value(INK_SOFT),

--- a/plots/scatter-matrix/implementations/python/altair.py
+++ b/plots/scatter-matrix/implementations/python/altair.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris-like dataset with 4 variables and 3 species
 np.random.seed(42)
@@ -74,7 +74,7 @@ df = pd.DataFrame(data)
 variables = ["Sepal Length (cm)", "Sepal Width (cm)", "Petal Length (cm)", "Petal Width (cm)"]
 
 # Color scale using Okabe-Ito palette
-color_scale = alt.Scale(domain=["Setosa", "Versicolor", "Virginica"], range=OKABE_ITO)
+color_scale = alt.Scale(domain=["Setosa", "Versicolor", "Virginica"], range=IMPRINT)
 
 # Build scatter matrix grid with histograms on diagonal
 charts = []

--- a/plots/scatter-regression-linear/implementations/python/altair.py
+++ b/plots/scatter-regression-linear/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2 (for regression line)
+ACCENT = "#C475FD"  # Okabe-Ito position 2 (for regression line)
 
 # Data - Temperature vs Energy Consumption
 np.random.seed(42)

--- a/plots/scatter-regression-polynomial/implementations/python/altair.py
+++ b/plots/scatter-regression-polynomial/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series (scatter points)
-SECONDARY = "#D55E00"  # Second series (regression curve)
+SECONDARY = "#C475FD"  # Second series (regression curve)
 
 # Data - Quadratic relationship with noise (fertilizer vs crop yield)
 np.random.seed(42)

--- a/plots/shap-waterfall/implementations/python/altair.py
+++ b/plots/shap-waterfall/implementations/python/altair.py
@@ -18,8 +18,8 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-POS_COLOR = "#D55E00"  # Okabe-Ito vermillion — positive SHAP (pushes prediction up)
-NEG_COLOR = "#0072B2"  # Okabe-Ito blue — negative SHAP (pushes prediction down)
+POS_COLOR = "#AE3030"  # imprint red — positive SHAP (pushes prediction up)
+NEG_COLOR = "#4467A3"  # Okabe-Ito blue — negative SHAP (pushes prediction down)
 
 # Data — loan application: individual credit default prediction
 np.random.seed(42)

--- a/plots/skewt-logp-atmospheric/implementations/python/altair.py
+++ b/plots/skewt-logp-atmospheric/implementations/python/altair.py
@@ -43,7 +43,7 @@ X_MARGIN = 5  # pre-filter margin to exclude vl-convert layout inflation from ou
 # Unified color/dash scheme (single legend covers all 6 element types)
 # Data series first so Temperature gets Okabe-Ito position 1 (#009E73 brand green)
 ALL_LABELS = ["Temperature", "Dewpoint", "Isotherm", "Dry Adiabat", "Moist Adiabat", "Mixing Ratio"]
-ALL_COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+ALL_COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 ALL_DASHES = [[1, 0], [8, 4], [4, 4], [1, 0], [6, 3], [2, 2]]
 
 full_color_scale = alt.Scale(domain=ALL_LABELS, range=ALL_COLORS)

--- a/plots/slope-basic/implementations/python/altair.py
+++ b/plots/slope-basic/implementations/python/altair.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito: position 1 = Increase, position 2 = Decrease
 COLOR_INCREASE = "#009E73"
-COLOR_DECREASE = "#D55E00"
+COLOR_DECREASE = "#AE3030"  # imprint red — decrease
 
 # Data
 data = pd.DataFrame(

--- a/plots/smith-chart-basic/implementations/python/altair.py
+++ b/plots/smith-chart-basic/implementations/python/altair.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — impedance locus
-VSWR_COLOR = "#D55E00"  # Okabe-Ito position 2 — VSWR circles
+VSWR_COLOR = "#C475FD"  # Okabe-Ito position 2 — VSWR circles
 
 # Reference impedance
 Z0 = 50  # ohms

--- a/plots/sn-curve-basic/implementations/python/altair.py
+++ b/plots/sn-curve-basic/implementations/python/altair.py
@@ -21,9 +21,9 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # pos 1 — fatigue test data & Basquin fit
-C_UTS = "#D55E00"  # pos 2 — Ultimate Tensile Strength
-C_YS = "#0072B2"  # pos 3 — Yield Strength
-C_EL = "#CC79A7"  # pos 4 — Endurance Limit
+C_UTS = "#C475FD"  # pos 2 — Ultimate Tensile Strength
+C_YS = "#4467A3"  # pos 3 — Yield Strength
+C_EL = "#BD8233"  # pos 4 — Endurance Limit
 
 # Data — fatigue test results for medium-carbon steel specimens
 np.random.seed(42)

--- a/plots/span-basic/implementations/python/altair.py
+++ b/plots/span-basic/implementations/python/altair.py
@@ -20,8 +20,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito data colors
 BRAND = "#009E73"  # position 1 — main price line
-SPAN1_COLOR = "#E69F00"  # position 5 — recession vertical span
-SPAN2_COLOR = "#D55E00"  # position 2 — threshold horizontal span
+SPAN1_COLOR = "#AE3030"  # position 5 — recession vertical span
+SPAN2_COLOR = "#DDCC77"  # imprint amber — threshold horizontal span (warning)
 
 # Data — stock price with recession dip and warning threshold zone
 np.random.seed(42)

--- a/plots/sparkline-basic/implementations/python/altair.py
+++ b/plots/sparkline-basic/implementations/python/altair.py
@@ -18,8 +18,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7",
-             "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233",
+             "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - 75 consecutive business days: a product's launch-to-maturity user trend
 # with viral spike, long-tail stabilization, and recovery — a classic adoption curve
@@ -47,7 +47,7 @@ highlights["type"] = ["min", "max"]
 # Semi-transparent area fill — Altair's layered chart pattern
 fill = (
     alt.Chart(df)
-    .mark_area(color=OKABE_ITO[0], opacity=0.15)
+    .mark_area(color=IMPRINT[0], opacity=0.15)
     .encode(
         x=alt.X("day:Q", axis=None),
         y=alt.Y("users:Q", axis=None, scale=alt.Scale(zero=False)),
@@ -57,7 +57,7 @@ fill = (
 # Main line
 line = (
     alt.Chart(df)
-    .mark_line(color=OKABE_ITO[0], strokeWidth=3)
+    .mark_line(color=IMPRINT[0], strokeWidth=3)
     .encode(
         x=alt.X("day:Q", axis=None),
         y=alt.Y("users:Q", axis=None, scale=alt.Scale(zero=False)),
@@ -74,7 +74,7 @@ points = (
         color=alt.Color(
             "type:N",
             scale=alt.Scale(domain=["min", "max"],
-                            range=[OKABE_ITO[1], OKABE_ITO[3]]),
+                            range=[IMPRINT[1], IMPRINT[3]]),
             legend=None,
         ),
     )

--- a/plots/strip-basic/implementations/python/altair.py
+++ b/plots/strip-basic/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — always first series
-ACCENT = "#D55E00"  # Okabe-Ito position 2 — mean markers
+ACCENT = "#C475FD"  # Okabe-Ito position 2 — mean markers
 
 # Data — survey response scores by department
 np.random.seed(42)

--- a/plots/subplot-grid/implementations/python/altair.py
+++ b/plots/subplot-grid/implementations/python/altair.py
@@ -19,9 +19,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
-BRAND = OKABE_ITO[0]
-SECONDARY = OKABE_ITO[1]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
+BRAND = IMPRINT[0]
+SECONDARY = IMPRINT[1]
 
 # Data
 np.random.seed(42)

--- a/plots/subplot-mosaic/implementations/python/altair.py
+++ b/plots/subplot-mosaic/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Create diverse datasets for dashboard-style mosaic layout
 np.random.seed(42)
@@ -62,7 +62,7 @@ df_area = pd.DataFrame(
 # Chart A: Wide time series (spans 2 columns at top)
 chart_a = (
     alt.Chart(df_timeseries)
-    .mark_line(strokeWidth=4, color=OKABE_ITO[0])
+    .mark_line(strokeWidth=4, color=IMPRINT[0])
     .encode(
         x=alt.X("date:T", title="Date", axis=alt.Axis(labelFontSize=18, titleFontSize=22)),
         y=alt.Y("value:Q", title="Revenue ($K)", axis=alt.Axis(labelFontSize=18, titleFontSize=22)),
@@ -80,14 +80,14 @@ chart_b_value = (
         outerRadius=80,
         theta=3.14159,
         theta2=alt.expr("3.14159 - (datum.value / datum.max_value) * 3.14159"),
-        color=OKABE_ITO[0],
+        color=IMPRINT[0],
     )
     .encode()
 )
 
 chart_b_text = (
     alt.Chart(df_gauge)
-    .mark_text(fontSize=32, fontWeight="bold", color=OKABE_ITO[0])
+    .mark_text(fontSize=32, fontWeight="bold", color=IMPRINT[0])
     .encode(text=alt.Text("value:Q", format=".0f"))
 )
 
@@ -98,7 +98,7 @@ chart_b = alt.layer(chart_b_bg, chart_b_value, chart_b_text).properties(
 # Chart C: Bar chart (middle left)
 chart_c = (
     alt.Chart(df_bars)
-    .mark_bar(color=OKABE_ITO[1], cornerRadiusTopLeft=4, cornerRadiusTopRight=4)
+    .mark_bar(color=IMPRINT[1], cornerRadiusTopLeft=4, cornerRadiusTopRight=4)
     .encode(
         x=alt.X("region:N", title="Region", axis=alt.Axis(labelFontSize=16, titleFontSize=20, labelAngle=0)),
         y=alt.Y("sales:Q", title="Sales ($K)", axis=alt.Axis(labelFontSize=16, titleFontSize=20)),
@@ -131,7 +131,7 @@ chart_d = (
 # Chart E: Small bar chart (bottom left)
 chart_e = (
     alt.Chart(df_categories)
-    .mark_bar(color=OKABE_ITO[4])
+    .mark_bar(color=IMPRINT[4])
     .encode(
         x=alt.X("type:N", title=None, axis=alt.Axis(labelFontSize=14)),
         y=alt.Y("count:Q", title="Count", axis=alt.Axis(labelFontSize=14, titleFontSize=18)),
@@ -143,7 +143,7 @@ chart_e = (
 # Chart F: Area chart (bottom middle)
 chart_f = (
     alt.Chart(df_area)
-    .mark_area(color=OKABE_ITO[2], opacity=0.7, line={"color": OKABE_ITO[2], "strokeWidth": 3})
+    .mark_area(color=IMPRINT[2], opacity=0.7, line={"color": IMPRINT[2], "strokeWidth": 3})
     .encode(
         x=alt.X("hour:Q", title="Hour", axis=alt.Axis(labelFontSize=14, titleFontSize=18)),
         y=alt.Y("traffic:Q", title="Traffic", axis=alt.Axis(labelFontSize=14, titleFontSize=18)),

--- a/plots/survival-kaplan-meier/implementations/python/altair.py
+++ b/plots/survival-kaplan-meier/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Clinical trial with two treatment groups
 np.random.seed(42)
@@ -119,7 +119,7 @@ for _, row in censored.iterrows():
 censored_df = pd.DataFrame(censored_marks) if censored_marks else pd.DataFrame()
 
 # Define colors using Okabe-Ito palette
-color_scale = alt.Scale(domain=["Treatment A", "Treatment B"], range=[OKABE_ITO[0], OKABE_ITO[1]])
+color_scale = alt.Scale(domain=["Treatment A", "Treatment B"], range=[IMPRINT[0], IMPRINT[1]])
 
 # Step line for survival curves
 survival_line = (

--- a/plots/swarm-basic/implementations/python/altair.py
+++ b/plots/swarm-basic/implementations/python/altair.py
@@ -18,7 +18,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Employee performance scores across departments
 np.random.seed(42)
@@ -72,7 +72,7 @@ swarm = (
         ),
         color=alt.Color(
             "Department:N",
-            scale=alt.Scale(domain=departments, range=OKABE_ITO),
+            scale=alt.Scale(domain=departments, range=IMPRINT),
             legend=alt.Legend(titleFontSize=18, labelFontSize=16, orient="right"),
         ),
         tooltip=["Department", "Performance Score"],

--- a/plots/timeline-basic/implementations/python/altair.py
+++ b/plots/timeline-basic/implementations/python/altair.py
@@ -18,7 +18,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for categories
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Software project milestones
 data = pd.DataFrame(
@@ -77,10 +77,10 @@ data["y_label"] = [2.4 if i % 2 == 0 else -2.4 for i in range(len(data))]
 
 # Color scale using Okabe-Ito palette
 category_colors = {
-    "Planning": OKABE_ITO[0],
-    "Development": OKABE_ITO[1],
-    "Testing": OKABE_ITO[2],
-    "Release": OKABE_ITO[3],
+    "Planning": IMPRINT[0],
+    "Development": IMPRINT[1],
+    "Testing": IMPRINT[2],
+    "Release": IMPRINT[3],
 }
 color_scale = alt.Scale(domain=list(category_colors.keys()), range=list(category_colors.values()))
 

--- a/plots/timeseries-decomposition/implementations/python/altair.py
+++ b/plots/timeseries-decomposition/implementations/python/altair.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (component colors)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Monthly airline passengers
 np.random.seed(42)
@@ -60,7 +60,7 @@ df_long = df_decomp.melt(id_vars=["date"], var_name="component", value_name="val
 component_order = ["Original", "Trend", "Seasonal", "Residual"]
 
 # Color mapping using Okabe-Ito palette
-color_map = {component: OKABE_ITO[i] for i, component in enumerate(component_order)}
+color_map = {component: IMPRINT[i] for i, component in enumerate(component_order)}
 
 # Base chart with encoding
 base_chart = (

--- a/plots/timeseries-forecast-uncertainty/implementations/python/altair.py
+++ b/plots/timeseries-forecast-uncertainty/implementations/python/altair.py
@@ -21,7 +21,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series - historical data
-FORECAST_COLOR = "#D55E00"  # Second series - forecast
+FORECAST_COLOR = "#C475FD"  # Second series - forecast
 
 # Theme-adjusted CI band opacity — orange appears more saturated on dark backgrounds
 # so we reduce opacity in dark mode to keep visual weight consistent across themes
@@ -148,7 +148,7 @@ legend_chart = (
             "type:N",
             scale=alt.Scale(
                 domain=["Historical Data", "Forecast", "80% CI", "95% CI"],
-                range=[BRAND, FORECAST_COLOR, "rgba(213,94,0,0.60)", "rgba(213,94,0,0.25)"],
+                range=[BRAND, FORECAST_COLOR, "rgba(196, 117, 253, 0.60)", "rgba(196, 117, 253, 0.25)"],
             ),
             legend=alt.Legend(title="Series", orient="right", titleFontSize=14, labelFontSize=12),
         )

--- a/plots/tree-phylogenetic/implementations/python/altair.py
+++ b/plots/tree-phylogenetic/implementations/python/altair.py
@@ -19,7 +19,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for clade coloring
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Primate phylogenetic tree with clade assignments
 np.random.seed(42)
@@ -111,7 +111,7 @@ for parent, child, _length, clade in edges:
     child_x = x_positions[child]
     child_y = y_positions[child]
     clade_idx = ["Apes", "Old World Monkeys", "Lesser Apes"].index(clade)
-    color = OKABE_ITO[clade_idx]
+    color = IMPRINT[clade_idx]
 
     lines_data.append(
         {
@@ -148,7 +148,7 @@ for node in all_leaves:
         if clade in ["Apes", "Old World Monkeys", "Lesser Apes"]
         else 0
     )
-    color = OKABE_ITO[clade_idx]
+    color = IMPRINT[clade_idx]
     nodes_data.append(
         {
             "x": x_positions[node],
@@ -172,7 +172,7 @@ for n in internal_nodes:
         if clade in ["Apes", "Old World Monkeys", "Lesser Apes"]
         else 0
     )
-    color = OKABE_ITO[clade_idx]
+    color = IMPRINT[clade_idx]
     internal_data.append({"x": x_positions[n], "y": y_positions[n], "name": n, "clade": clade, "color": color})
 internal_df = pd.DataFrame(internal_data)
 
@@ -185,7 +185,7 @@ branches = (
         y="y:Q",
         x2="x2:Q",
         y2="y2:Q",
-        color=alt.Color("color:N", scale=alt.Scale(domain=OKABE_ITO, range=OKABE_ITO), legend=None),
+        color=alt.Color("color:N", scale=alt.Scale(domain=IMPRINT, range=IMPRINT), legend=None),
         tooltip=["clade:N"],
     )
 )
@@ -197,7 +197,7 @@ leaf_points = (
     .encode(
         x="x:Q",
         y="y:Q",
-        color=alt.Color("color:N", scale=alt.Scale(domain=OKABE_ITO, range=OKABE_ITO), legend=None),
+        color=alt.Color("color:N", scale=alt.Scale(domain=IMPRINT, range=IMPRINT), legend=None),
         tooltip=["species:N", "label:N", "clade:N"],
     )
 )
@@ -216,7 +216,7 @@ internal_points = (
     .encode(
         x="x:Q",
         y="y:Q",
-        color=alt.Color("color:N", scale=alt.Scale(domain=OKABE_ITO, range=OKABE_ITO), legend=None),
+        color=alt.Color("color:N", scale=alt.Scale(domain=IMPRINT, range=IMPRINT), legend=None),
         tooltip=["name:N", "clade:N"],
     )
 )

--- a/plots/treemap-basic/implementations/python/altair.py
+++ b/plots/treemap-basic/implementations/python/altair.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Market capitalization by sector and company (in billions USD)
 data = [
@@ -102,7 +102,7 @@ min_area_for_label = width * height * 0.02
 # Map categories to colors using Okabe-Ito palette
 color_map = {}
 for i, cat in enumerate(sorted_cats):
-    color_map[cat] = OKABE_ITO[i % len(OKABE_ITO)]
+    color_map[cat] = IMPRINT[i % len(IMPRINT)]
 
 # Treemap rectangles with borders matching theme
 stroke_color = INK_SOFT

--- a/plots/upset-basic/implementations/python/altair.py
+++ b/plots/upset-basic/implementations/python/altair.py
@@ -25,10 +25,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 BRAND = "#009E73"
-C2 = "#D55E00"
-C3 = "#0072B2"
-C4 = "#CC79A7"
-C5 = "#E69F00"
+C2 = "#C475FD"
+C3 = "#4467A3"
+C4 = "#BD8233"
+C5 = "#AE3030"
 
 # Data — gene sets from 5 genomic experiments
 np.random.seed(42)

--- a/plots/venn-basic/implementations/python/altair.py
+++ b/plots/venn-basic/implementations/python/altair.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Three overlapping research disciplines
 set_labels = ["Machine Learning", "Statistics", "Data Engineering"]
@@ -70,7 +70,7 @@ fill_centers = pd.DataFrame(
     {
         "x": [cx_a, cx_b, cx_c],
         "y": [cy_a, cy_b, cy_c],
-        "color": OKABE_ITO[0:3],
+        "color": IMPRINT[0:3],
         "set": set_labels,
         "size": [circle_size_a, circle_size_b, circle_size_c],
     }

--- a/plots/venn-labeled-items/implementations/python/altair.py
+++ b/plots/venn-labeled-items/implementations/python/altair.py
@@ -25,8 +25,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette: brand green, vermillion, blue
 COLOR_A = "#009E73"
-COLOR_B = "#D55E00"
-COLOR_C = "#0072B2"
+COLOR_B = "#C475FD"
+COLOR_C = "#4467A3"
 
 # Symmetric three-circle Venn layout on a 1200x1200 square canvas
 CANVAS = 1200

--- a/plots/violin-box/implementations/python/altair.py
+++ b/plots/violin-box/implementations/python/altair.py
@@ -17,7 +17,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Generate realistic response time data for different server tiers
 np.random.seed(42)
@@ -54,7 +54,7 @@ violin = (
             title=None,
             axis=alt.Axis(labels=False, values=[0], grid=False, ticks=False),
         ),
-        color=alt.Color("Server Tier:N", scale=alt.Scale(domain=groups, range=OKABE_ITO)),
+        color=alt.Color("Server Tier:N", scale=alt.Scale(domain=groups, range=IMPRINT)),
     )
 )
 

--- a/plots/violin-grouped-swarm/implementations/python/altair.py
+++ b/plots/violin-grouped-swarm/implementations/python/altair.py
@@ -25,7 +25,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Response times across task types and expertise levels
 np.random.seed(42)
@@ -56,7 +56,7 @@ df = pd.DataFrame(data)
 base = alt.Chart(df).encode(
     color=alt.Color(
         "Expertise:N",
-        scale=alt.Scale(domain=["Novice", "Expert"], range=OKABE_ITO[:2]),
+        scale=alt.Scale(domain=["Novice", "Expert"], range=IMPRINT[:2]),
         legend=alt.Legend(
             title="Expertise", titleFontSize=22, labelFontSize=20, orient="right", symbolSize=400, offset=20
         ),
@@ -92,7 +92,7 @@ swarm = (
             scale=alt.Scale(domain=[-1, 1]),
         ),
         y=alt.Y("Response Time (s):Q"),
-        color=alt.Color("Expertise:N", scale=alt.Scale(domain=["Novice", "Expert"], range=OKABE_ITO[:2]), legend=None),
+        color=alt.Color("Expertise:N", scale=alt.Scale(domain=["Novice", "Expert"], range=IMPRINT[:2]), legend=None),
     )
     .transform_calculate(jitter='(random() - 0.5) * 0.15 + (datum.Expertise === "Novice" ? -0.3 : 0.3)')
 )

--- a/plots/violin-split/implementations/python/altair.py
+++ b/plots/violin-split/implementations/python/altair.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-2)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data: Test scores (%) by department comparing control vs treatment groups
 np.random.seed(42)
@@ -79,7 +79,7 @@ split_violin = (
         y=alt.Y("Score (%):Q", title="Score (%)", scale=alt.Scale(domain=[30, 100])),
         color=alt.Color(
             "Group:N",
-            scale=alt.Scale(domain=["Control", "Treatment"], range=OKABE_ITO),
+            scale=alt.Scale(domain=["Control", "Treatment"], range=IMPRINT),
             legend=alt.Legend(
                 title="Group",
                 titleFontSize=20,
@@ -104,7 +104,7 @@ iqr_rule = (
         y=alt.Y("q1:Q", scale=alt.Scale(domain=[30, 100])),
         y2="q3:Q",
         xOffset=alt.XOffset("Group:N", scale=alt.Scale(domain=["Control", "Treatment"], range=[-20, 20])),
-        color=alt.Color("Group:N", scale=alt.Scale(domain=["Control", "Treatment"], range=OKABE_ITO)),
+        color=alt.Color("Group:N", scale=alt.Scale(domain=["Control", "Treatment"], range=IMPRINT)),
     )
 )
 
@@ -117,7 +117,7 @@ median_marker = (
         y=alt.Y("median:Q", scale=alt.Scale(domain=[30, 100])),
         xOffset=alt.XOffset("Group:N", scale=alt.Scale(domain=["Control", "Treatment"], range=[-20, 20])),
         color=alt.value("white"),
-        stroke=alt.Color("Group:N", scale=alt.Scale(domain=["Control", "Treatment"], range=OKABE_ITO)),
+        stroke=alt.Color("Group:N", scale=alt.Scale(domain=["Control", "Treatment"], range=IMPRINT)),
         strokeWidth=alt.value(2),
     )
 )

--- a/plots/violin-swarm/implementations/python/altair.py
+++ b/plots/violin-swarm/implementations/python/altair.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Reaction times (ms) across 4 experimental conditions
 np.random.seed(42)
@@ -90,7 +90,7 @@ violin_df["x_left"] = violin_df["x"] - violin_df["width"]
 violin_df["x_right"] = violin_df["x"] + violin_df["width"]
 
 # Color scale using Okabe-Ito palette
-color_scale = alt.Scale(domain=conditions, range=OKABE_ITO)
+color_scale = alt.Scale(domain=conditions, range=IMPRINT)
 
 # Y axis scale
 y_scale = alt.Scale(domain=[y_min - 10, y_max + 10])

--- a/plots/volcano-basic/implementations/python/altair.py
+++ b/plots/volcano-basic/implementations/python/altair.py
@@ -55,7 +55,7 @@ hline_data = pd.DataFrame({"y": [pval_threshold]})
 # Color mapping using Okabe-Ito palette
 color_scale = alt.Scale(
     domain=["Up-regulated", "Down-regulated", "Not Significant"],
-    range=["#009E73", "#D55E00", INK_SOFT],  # Green, orange, adaptive gray
+    range=["#009E73", "#C475FD", INK_SOFT],  # Green, orange, adaptive gray
 )
 
 # Main scatter plot

--- a/plots/volcano-basic/implementations/python/altair.py
+++ b/plots/volcano-basic/implementations/python/altair.py
@@ -55,7 +55,7 @@ hline_data = pd.DataFrame({"y": [pval_threshold]})
 # Color mapping using Okabe-Ito palette
 color_scale = alt.Scale(
     domain=["Up-regulated", "Down-regulated", "Not Significant"],
-    range=["#009E73", "#C475FD", INK_SOFT],  # Green, orange, adaptive gray
+    range=["#009E73", "#AE3030", INK_SOFT],  # imprint green (up) / red (down) / adaptive gray (n.s.)
 )
 
 # Main scatter plot

--- a/plots/voronoi-basic/implementations/python/altair.py
+++ b/plots/voronoi-basic/implementations/python/altair.py
@@ -31,7 +31,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Generate seed points for weather stations
 np.random.seed(42)
@@ -81,7 +81,7 @@ for point_idx in range(n_points):
     sorted_x = clipped_x[sorted_indices]
     sorted_y = clipped_y[sorted_indices]
 
-    color = OKABE_ITO[point_idx % len(OKABE_ITO)]
+    color = IMPRINT[point_idx % len(IMPRINT)]
     station = labels[point_idx]
 
     # Add vertices for filled polygon
@@ -110,7 +110,7 @@ df_points = pd.DataFrame(
         "y": y_points,
         "label": labels,
         "station": labels,
-        "color": [OKABE_ITO[i % len(OKABE_ITO)] for i in range(n_points)],
+        "color": [IMPRINT[i % len(IMPRINT)] for i in range(n_points)],
     }
 )
 
@@ -123,7 +123,7 @@ voronoi_cells = (
         y=alt.Y("y:Q", scale=alt.Scale(domain=[y_min - 2, y_max + 2]), title="Y Coordinate"),
         color=alt.Color(
             "station:N",
-            scale=alt.Scale(domain=labels, range=OKABE_ITO[:n_points]),
+            scale=alt.Scale(domain=labels, range=IMPRINT[:n_points]),
             legend=alt.Legend(
                 title="Weather Stations",
                 titleFontSize=16,
@@ -147,7 +147,7 @@ points_layer = (
     .encode(
         x="x:Q",
         y="y:Q",
-        color=alt.Color("station:N", scale=alt.Scale(domain=labels, range=OKABE_ITO[:n_points]), legend=None),
+        color=alt.Color("station:N", scale=alt.Scale(domain=labels, range=IMPRINT[:n_points]), legend=None),
         tooltip=[
             alt.Tooltip("label:N", title="Station"),
             alt.Tooltip("x:Q", format=".1f", title="X"),

--- a/plots/waffle-basic/implementations/python/altair.py
+++ b/plots/waffle-basic/implementations/python/altair.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series is #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Budget allocation with 5 categories including a small one
 categories = ["Engineering", "Marketing", "Operations", "Design", "Legal"]
@@ -36,7 +36,7 @@ values = [40, 28, 18, 10, 4]  # Percentages (sum to 100)
 # Build 10x10 grid (100 squares, each = 1%)
 squares = []
 square_idx = 0
-for cat, val, color in zip(categories, values, OKABE_ITO, strict=True):
+for cat, val, color in zip(categories, values, IMPRINT, strict=True):
     for _ in range(val):
         row = square_idx // 10
         col = square_idx % 10
@@ -54,7 +54,7 @@ chart = (
         y=alt.Y("row:O", axis=None, sort="descending"),
         color=alt.Color(
             "category:N",
-            scale=alt.Scale(domain=categories, range=OKABE_ITO),
+            scale=alt.Scale(domain=categories, range=IMPRINT),
             legend=alt.Legend(
                 title="Category",
                 titleFontSize=22,

--- a/plots/waterfall-basic/implementations/python/altair.py
+++ b/plots/waterfall-basic/implementations/python/altair.py
@@ -19,8 +19,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for waterfall types
 POSITIVE_COLOR = "#009E73"  # Position 1: brand green for positive
-NEGATIVE_COLOR = "#D55E00"  # Position 2: vermillion/red for negative
-TOTAL_COLOR = "#0072B2"  # Position 3: blue for totals
+NEGATIVE_COLOR = "#AE3030"  # imprint red — negative
+TOTAL_COLOR = "#4467A3"  # Position 3: blue for totals
 
 # Data: Quarterly financial breakdown from revenue to net income
 categories = ["Revenue", "Cost of Goods", "Gross Profit", "Operating Expenses", "Other Income", "Taxes", "Net Income"]

--- a/plots/wordcloud-basic/implementations/python/altair.py
+++ b/plots/wordcloud-basic/implementations/python/altair.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Tech industry buzzwords with frequencies
 np.random.seed(42)
@@ -131,7 +131,7 @@ for i, (word, freq) in enumerate(sorted_words):
     x_positions.append(found_x)
     y_positions.append(found_y)
     font_sizes.append(size)
-    colors.append(OKABE_ITO[i % len(OKABE_ITO)])
+    colors.append(IMPRINT[i % len(IMPRINT)])
 
 # Create DataFrame
 df = pd.DataFrame({"word": words_list, "x": x_positions, "y": y_positions, "size": font_sizes, "color": colors})


### PR DESCRIPTION
## Summary

- Positional hex + rgba replacement across **135 altair impls** with light+dark renders.
- Proactive semantic-anchor fixes for 14 altair impls (red/amber/green where slot-1 lavender broke meaning).
- `SECONDARY` constants for purely-categorical second series (gain-curve baseline, scatter-regression curve, roc-curve second model, bland-altman LoA lines) intentionally left on lavender — those don't trip the semantic "red = bad" trap.

## Test plan

- [x] `ruff check .` + format green
- [ ] CI green
- [ ] Copilot triage
- [ ] After merge: Stage B for 135 altair impls → GCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)