### PR TITLE
chore(palette): migrate highcharts impls from Okabe-Ito to imprint

### DIFF
--- a/plots/alluvial-basic/implementations/python/highcharts.py
+++ b/plots/alluvial-basic/implementations/python/highcharts.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Voter migration between political parties across 3 elections
 # Format: [from_node, to_node, flow_count]
@@ -52,9 +52,9 @@ flows = [
 
 # Party colors using Okabe-Ito palette
 party_colors = {
-    "Democratic": OKABE_ITO[0],  # #009E73
-    "Independent": OKABE_ITO[1],  # #D55E00
-    "Republican": OKABE_ITO[2],  # #0072B2
+    "Democratic": IMPRINT[0],  # #009E73
+    "Independent": IMPRINT[1],  # #C475FD
+    "Republican": IMPRINT[2],  # #4467A3
 }
 
 # Column positions for time ordering
@@ -212,15 +212,15 @@ legend_html = f"""
 <div id="custom-legend" style="position: absolute; bottom: 60px; left: 50%; transform: translateX(-50%);
      display: flex; gap: 60px; font-family: Arial, sans-serif; font-size: 18px; color: {INK_SOFT};">
     <div style="display: flex; align-items: center; gap: 15px;">
-        <div style="width: 40px; height: 30px; background-color: {OKABE_ITO[0]};"></div>
+        <div style="width: 40px; height: 30px; background-color: {IMPRINT[0]};"></div>
         <span>Democratic</span>
     </div>
     <div style="display: flex; align-items: center; gap: 15px;">
-        <div style="width: 40px; height: 30px; background-color: {OKABE_ITO[1]};"></div>
+        <div style="width: 40px; height: 30px; background-color: {IMPRINT[1]};"></div>
         <span>Independent</span>
     </div>
     <div style="display: flex; align-items: center; gap: 15px;">
-        <div style="width: 40px; height: 30px; background-color: {OKABE_ITO[2]};"></div>
+        <div style="width: 40px; height: 30px; background-color: {IMPRINT[2]};"></div>
         <span>Republican</span>
     </div>
 </div>

--- a/plots/andrews-curves/implementations/python/highcharts.py
+++ b/plots/andrews-curves/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 iris = load_iris()
 X = StandardScaler().fit_transform(iris.data)
@@ -125,7 +125,7 @@ for species_idx in range(3):
         series = SplineSeries()
         series.data = data_points
         series.name = species_names[species_idx]
-        series.color = OKABE_ITO[species_idx]
+        series.color = IMPRINT[species_idx]
         series.opacity = 0.5
         series.show_in_legend = i == 0
         series.line_width = 2

--- a/plots/area-cumulative-flow/implementations/python/highcharts.py
+++ b/plots/area-cumulative-flow/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — 90-day Kanban board with 5 workflow stages
 np.random.seed(42)
@@ -131,11 +131,11 @@ chart.options.tooltip = {
 # Highcharts reversedStacks=true (default): first added series = visual TOP.
 # Add top→bottom so Done (green #009E73) is at the bottom and Backlog at the top.
 stages = [
-    ("Backlog", backlog_band, OKABE_ITO[4]),
-    ("Analysis", analysis_band, OKABE_ITO[3]),
-    ("Development", dev_band, OKABE_ITO[2]),
-    ("Testing", testing_band, OKABE_ITO[1]),
-    ("Done", done_band, OKABE_ITO[0]),
+    ("Backlog", backlog_band, IMPRINT[4]),
+    ("Analysis", analysis_band, IMPRINT[3]),
+    ("Development", dev_band, IMPRINT[2]),
+    ("Testing", testing_band, IMPRINT[1]),
+    ("Done", done_band, IMPRINT[0]),
 ]
 
 for name, data, color in stages:

--- a/plots/area-stacked-percent/implementations/python/highcharts.py
+++ b/plots/area-stacked-percent/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Market share evolution over time (2018-2025)
 years = ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"]
@@ -115,25 +115,25 @@ chart.options.tooltip = {
 }
 
 # Color palette - Okabe-Ito
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Add series
 series_a = AreaSeries()
 series_a.name = "Product A"
 series_a.data = product_a
-series_a.color = OKABE_ITO[0]
+series_a.color = IMPRINT[0]
 chart.add_series(series_a)
 
 series_b = AreaSeries()
 series_b.name = "Product B"
 series_b.data = product_b
-series_b.color = OKABE_ITO[1]
+series_b.color = IMPRINT[1]
 chart.add_series(series_b)
 
 series_c = AreaSeries()
 series_c.name = "Product C"
 series_c.data = product_c
-series_c.color = OKABE_ITO[2]
+series_c.color = IMPRINT[2]
 chart.add_series(series_c)
 
 # Download Highcharts JS for inline embedding

--- a/plots/area-stacked/implementations/python/highcharts.py
+++ b/plots/area-stacked/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette: first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Monthly revenue by product category (in thousands $) over 2 years
 months = [
@@ -196,7 +196,7 @@ chart.options.tooltip = {
 }
 
 # Set Okabe-Ito colors
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Add series (ordered by average size, largest first per spec)
 series_data = [

--- a/plots/bar-3d-categorical/implementations/python/highcharts.py
+++ b/plots/bar-3d-categorical/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: quarterly revenue ($ thousands) for five product categories
 categories = ["Electronics", "Clothing", "Food", "Sports", "Books"]
@@ -122,13 +122,13 @@ chart.options.legend = {
     "layout": "vertical",
 }
 
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 for i, quarter in enumerate(quarters):
     series = ColumnSeries()
     series.name = quarter
     series.data = sales_data[quarter]
-    series.color = OKABE_ITO[i]
+    series.color = IMPRINT[i]
     # Emphasize Q4 (peak quarter) with a prominent border to guide the viewer
     if quarter == "Q4":
         series.border_color = INK_SOFT

--- a/plots/bar-diverging/implementations/python/highcharts.py
+++ b/plots/bar-diverging/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 POSITIVE = "#009E73"  # bluish green (brand, position 1)
-NEGATIVE = "#D55E00"  # vermillion (position 2)
+NEGATIVE = "#AE3030"  # imprint red — negative
 
 # Data - Customer satisfaction survey results by department
 categories = [

--- a/plots/bar-drilldown/implementations/python/highcharts.py
+++ b/plots/bar-drilldown/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Download Highcharts JS and drilldown module (inline required for headless Chrome)
 highcharts_url = "https://unpkg.com/highcharts/highcharts.js"
@@ -78,7 +78,7 @@ chart.options.y_axis = {
 
 chart.options.legend = {"enabled": False}
 chart.options.credits = {"enabled": False}
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 chart.options.tooltip = {
     "headerFormat": '<span style="font-size: 44px; font-weight: bold">{series.name}</span><br>',

--- a/plots/bar-grouped/implementations/python/highcharts.py
+++ b/plots/bar-grouped/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Quarterly revenue by product line (realistic business scenario)
 categories = ["Q1", "Q2", "Q3", "Q4"]
@@ -122,7 +122,7 @@ for i, (product_name, values) in enumerate(products.items()):
     series = ColumnSeries()
     series.name = product_name
     series.data = values
-    series.color = OKABE_ITO[i]
+    series.color = IMPRINT[i]
     chart.add_series(series)
 
 # Download Highcharts JS for inline embedding (required for headless Chrome)

--- a/plots/bar-race-animated/implementations/python/highcharts.py
+++ b/plots/bar-race-animated/implementations/python/highcharts.py
@@ -31,12 +31,12 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 # Okabe-Ito palette (positions 1–7) + adaptive neutral for 8 entities
 OI_COLORS = [
     "#009E73",  # position 1: bluish green
-    "#D55E00",  # position 2: vermillion
-    "#0072B2",  # position 3: blue
-    "#CC79A7",  # position 4: reddish purple
-    "#E69F00",  # position 5: orange
-    "#56B4E9",  # position 6: sky blue
-    "#F0E442",  # position 7: yellow
+    "#C475FD",  # position 2: vermillion
+    "#4467A3",  # position 3: blue
+    "#BD8233",  # position 4: reddish purple
+    "#AE3030",  # position 5: orange
+    "#2ABCCD",  # position 6: sky blue
+    "#954477",  # position 7: yellow
     "#1A1A1A" if THEME == "light" else "#E8E8E0",  # position 8: adaptive neutral
 ]
 

--- a/plots/bar-spine/implementations/python/highcharts.py
+++ b/plots/bar-spine/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Annual customer satisfaction survey (n=5,000) across industry sectors
 sectors = ["Technology", "Healthcare", "Finance", "Retail", "Manufacturing"]
@@ -162,7 +162,7 @@ chart.options.tooltip = {
 }
 
 # Add one series per satisfaction rating (stacked bottom-to-top: best first)
-for i, (rating, color) in enumerate(zip(ratings, OKABE_ITO, strict=True)):
+for i, (rating, color) in enumerate(zip(ratings, IMPRINT, strict=True)):
     series = ColumnSeries()
     series.name = rating
     series.color = color

--- a/plots/bar-stacked-percent/implementations/python/highcharts.py
+++ b/plots/bar-stacked-percent/implementations/python/highcharts.py
@@ -32,7 +32,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data: Market share by quarter for different companies
 categories = ["Q1 2024", "Q2 2024", "Q3 2024", "Q4 2024", "Q1 2025"]
@@ -127,7 +127,7 @@ for i, (name, data) in enumerate(series_data.items()):
     series = ColumnSeries()
     series.name = name
     series.data = data
-    series.color = OKABE_ITO[i % len(OKABE_ITO)]
+    series.color = IMPRINT[i % len(IMPRINT)]
     chart.add_series(series)
 
 # Download Highcharts JS (required for headless Chrome)

--- a/plots/bar-stacked/implementations/python/highcharts.py
+++ b/plots/bar-stacked/implementations/python/highcharts.py
@@ -35,7 +35,7 @@ components = {
 }
 
 # Okabe-Ito palette: first series is always #009E73
-colors = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+colors = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Create chart with container
 chart = Chart(container="container")

--- a/plots/biplot-pca/implementations/python/highcharts.py
+++ b/plots/biplot-pca/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"  # Okabe-Ito position 1
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]  # Positions 1-3 for species
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]  # Positions 1-3 for species
 
 # Data - Iris dataset for PCA
 np.random.seed(42)
@@ -129,7 +129,7 @@ for i, species in enumerate(target_names):
     series = ScatterSeries()
     series.name = species.capitalize()
     series.data = [{"x": float(scores[j, 0]), "y": float(scores[j, 1])} for j in range(len(y)) if mask[j]]
-    series.color = OKABE_ITO[i]
+    series.color = IMPRINT[i]
     series.marker = {"radius": 8}
     chart.add_series(series)
 
@@ -143,7 +143,7 @@ chart.options.plot_options = {
 }
 
 # Set colors for chart-level consistency
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Download Highcharts JS with retries and fallback CDN URLs
 cdn_urls = [

--- a/plots/box-grouped/implementations/python/highcharts.py
+++ b/plots/box-grouped/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Employee performance scores by department and experience level
 np.random.seed(42)
@@ -86,11 +86,11 @@ for idx, subcat in enumerate(subcategories):
     series = BoxPlotSeries()
     series.name = subcat
     series.data = box_data
-    series.color = OKABE_ITO[idx]
-    series.fill_color = OKABE_ITO[idx]
+    series.color = IMPRINT[idx]
+    series.fill_color = IMPRINT[idx]
     series.median_color = INK
-    series.stem_color = OKABE_ITO[idx]
-    series.whisker_color = OKABE_ITO[idx]
+    series.stem_color = IMPRINT[idx]
+    series.whisker_color = IMPRINT[idx]
     series_list.append(series)
 
     # Add outliers as scatter points if any exist
@@ -98,7 +98,7 @@ for idx, subcat in enumerate(subcategories):
         scatter = ScatterSeries()
         scatter.name = f"{subcat} (outliers)"
         scatter.data = outliers_data
-        scatter.color = OKABE_ITO[idx]
+        scatter.color = IMPRINT[idx]
         scatter.marker = {"radius": 6}
         scatter.show_in_legend = False
         series_list.append(scatter)

--- a/plots/box-notched/implementations/python/highcharts.py
+++ b/plots/box-notched/implementations/python/highcharts.py
@@ -43,7 +43,7 @@ data_dict["Placebo"] = np.append(data_dict["Placebo"], [15, 85])
 data_dict["Medium Dose"] = np.append(data_dict["Medium Dose"], [30, 95])
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Calculate box plot statistics inline (KISS - no functions)
 box_data = []
@@ -85,7 +85,7 @@ for i, cat in enumerate(categories):
             "median": round(median, 2),
             "q3": round(q3, 2),
             "high": round(upper_whisker, 2),
-            "color": OKABE_ITO[i],
+            "color": IMPRINT[i],
         }
     )
 
@@ -153,7 +153,7 @@ chart_config = {
             "medianWidth": 6,
             "medianColor": INK,
             "colorByPoint": True,
-            "colors": OKABE_ITO,
+            "colors": IMPRINT,
         },
         "errorbar": {"lineWidth": 8, "whiskerLength": "40%", "color": INK, "stemWidth": 0},
     },
@@ -185,7 +185,7 @@ chart_config = {
             "marker": {
                 "symbol": "circle",
                 "radius": 14,
-                "fillColor": OKABE_ITO[0],
+                "fillColor": IMPRINT[0],
                 "lineColor": PAGE_BG,
                 "lineWidth": 2,
             },

--- a/plots/boxen-basic/implementations/python/highcharts.py
+++ b/plots/boxen-basic/implementations/python/highcharts.py
@@ -140,8 +140,8 @@ median_series = {
     "name": "Median",
     "type": "scatter",
     "data": median_data,
-    "color": "#E69F00",
-    "marker": {"symbol": "diamond", "radius": 12, "fillColor": "#E69F00", "lineColor": colors[0], "lineWidth": 3},
+    "color": "#AE3030",
+    "marker": {"symbol": "diamond", "radius": 12, "fillColor": "#AE3030", "lineColor": colors[0], "lineWidth": 3},
     "zIndex": 10,
 }
 js_series.append(median_series)
@@ -151,8 +151,8 @@ outlier_series = {
     "name": "Outliers",
     "type": "scatter",
     "data": outlier_data,
-    "color": "#D55E00",
-    "marker": {"radius": 8, "symbol": "circle", "fillColor": "#D55E00", "lineColor": colors[0], "lineWidth": 2},
+    "color": "#C475FD",
+    "marker": {"radius": 8, "symbol": "circle", "fillColor": "#C475FD", "lineColor": colors[0], "lineWidth": 2},
     "tooltip": {"pointFormat": "Response time: {point.y:.1f} ms"},
 }
 js_series.append(outlier_series)

--- a/plots/bubble-map-geographic/implementations/python/highcharts.py
+++ b/plots/bubble-map-geographic/implementations/python/highcharts.py
@@ -26,10 +26,10 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 # Okabe-Ito palette — continents in canonical order, first is always #009E73
 CONTINENT_COLORS = {
     "Asia": "#009E73",
-    "Africa": "#D55E00",
-    "Europe": "#0072B2",
-    "Americas": "#CC79A7",
-    "Oceania": "#E69F00",
+    "Africa": "#C475FD",
+    "Europe": "#4467A3",
+    "Americas": "#BD8233",
+    "Oceania": "#AE3030",
 }
 
 # Data — major world cities, metropolitan population (millions)

--- a/plots/candlestick-volume/implementations/python/highcharts.py
+++ b/plots/candlestick-volume/implementations/python/highcharts.py
@@ -82,8 +82,8 @@ ohlc_data = []
 volume_data = []
 
 # Colorblind-friendly colors: blue for up, orange for down
-UP_COLOR = "#0072B2"  # Blue (Okabe-Ito position 3)
-DOWN_COLOR = "#E69F00"  # Orange (Okabe-Ito position 5)
+UP_COLOR = "#4467A3"  # Blue (Okabe-Ito position 3)
+DOWN_COLOR = "#AE3030"  # Orange (Okabe-Ito position 5)
 
 for i in range(n_days):
     ohlc_data.append(

--- a/plots/cat-box-strip/implementations/python/highcharts.py
+++ b/plots/cat-box-strip/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 — always first series
-OI_SECONDARY = "#D55E00"  # Position 2
+OI_SECONDARY = "#C475FD"  # Position 2
 
 # Data - Plant growth measurements under different light conditions
 np.random.seed(42)

--- a/plots/chernoff-basic/implementations/python/highcharts.py
+++ b/plots/chernoff-basic/implementations/python/highcharts.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -141,7 +141,7 @@ for idx in range(9):
     y_pos = cell_y + (cell_height - face_size - 60) // 2
 
     species_idx = y_sample[idx]
-    color = OKABE_ITO[species_idx]
+    color = IMPRINT[species_idx]
     label = f"{species_names[species_idx]} #{(idx % 3) + 1}"
 
     faces_svg += create_face_svg(X_norm[idx], color, label, x_pos, y_pos, face_size)
@@ -154,7 +154,7 @@ legend_svg = f"""
 <text x="{legend_x + 35}" y="{legend_y + 60}" font-size="44" font-family="Arial, sans-serif" font-weight="bold" fill="{INK}">Species</text>
 """
 
-for i, (species, color) in enumerate(zip(species_names, OKABE_ITO, strict=True)):
+for i, (species, color) in enumerate(zip(species_names, IMPRINT, strict=True)):
     ly_item = legend_y + 130 + i * 80
     legend_svg += f"""
     <circle cx="{legend_x + 60}" cy="{ly_item}" r="30" fill="{color}" stroke="{INK}" stroke-width="3"/>

--- a/plots/circlepacking-basic/implementations/python/highcharts.py
+++ b/plots/circlepacking-basic/implementations/python/highcharts.py
@@ -24,14 +24,14 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Company organizational structure across 3 hierarchy levels
 # Root (Company) -> Departments -> Teams -> Team Members (40+ nodes total)
 series_data = [
     {
         "name": "Engineering",
-        "color": OKABE_ITO[0],
+        "color": IMPRINT[0],
         "data": [
             {"name": "Frontend", "value": 8},
             {"name": "  - React Team", "value": 5},
@@ -49,7 +49,7 @@ series_data = [
     },
     {
         "name": "Product",
-        "color": OKABE_ITO[1],
+        "color": IMPRINT[1],
         "data": [
             {"name": "Product Management", "value": 5},
             {"name": "  - Platform PM", "value": 2},
@@ -64,7 +64,7 @@ series_data = [
     },
     {
         "name": "Operations",
-        "color": OKABE_ITO[2],
+        "color": IMPRINT[2],
         "data": [
             {"name": "Sales", "value": 9},
             {"name": "  - Enterprise", "value": 5},

--- a/plots/circos-basic/implementations/python/highcharts.py
+++ b/plots/circos-basic/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Simulating trade flows between 8 chromosomes with expression tracks
 np.random.seed(42)
@@ -56,7 +56,7 @@ for i in range(n_chrs):
             connections.append([chromosomes[i], chromosomes[j], float(round(flow_matrix[i, j], 1))])
 
 # Use Okabe-Ito palette for chromosomes (cycling through palette)
-chr_colors = [OKABE_ITO[i % len(OKABE_ITO)] for i in range(n_chrs)]
+chr_colors = [IMPRINT[i % len(IMPRINT)] for i in range(n_chrs)]
 
 # Create nodes with colors
 nodes = [{"id": chromosomes[i], "color": chr_colors[i]} for i in range(n_chrs)]
@@ -105,7 +105,7 @@ chart_config = {
         "title": {"text": "Chromosomes", "style": {"fontSize": "28px", "fontWeight": "bold", "color": INK}},
     },
     "plotOptions": {"dependencywheel": {"showInLegend": False}, "pie": {"showInLegend": False}},
-    "colors": OKABE_ITO,
+    "colors": IMPRINT,
     "series": [
         {
             "type": "dependencywheel",

--- a/plots/contour-decision-boundary/implementations/python/highcharts.py
+++ b/plots/contour-decision-boundary/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - always first series
-SERIES_2 = "#D55E00"
+SERIES_2 = "#C475FD"
 
 # Data: Generate moon-shaped classification dataset
 np.random.seed(42)

--- a/plots/dashboard-synchronized-crosshair/implementations/python/highcharts.py
+++ b/plots/dashboard-synchronized-crosshair/implementations/python/highcharts.py
@@ -27,8 +27,8 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # anyplot palette
 COLOR_PRICE = "#009E73"  # position 1 — brand green
-COLOR_VOLUME = "#9418DB"  # position 2
-COLOR_RSI = "#B71D27"  # position 3
+COLOR_VOLUME = "#C475FD"  # position 2
+COLOR_RSI = "#AE3030"  # position 3
 
 # Data — stock-like price, volume, RSI over 150 trading days
 np.random.seed(42)
@@ -257,7 +257,7 @@ html_content = f"""<!DOCTYPE html>
                 }}, {{
                     from: 70,
                     to: 100,
-                    color: 'rgba(183,29,39,0.10)',
+                    color: 'rgba(174, 48, 48, 0.10)',
                     label: {{
                         text: 'Overbought',
                         style: {{ fontSize: '40px', color: '{COLOR_RSI}' }}

--- a/plots/dendrogram-radial/implementations/python/highcharts.py
+++ b/plots/dendrogram-radial/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data: simulated gene expression clustering (40 genes, 5 functional groups)
 np.random.seed(42)
@@ -80,7 +80,7 @@ def get_merge_cluster(x_left, x_right):
 
 
 def cluster_color(cl):
-    return OKABE_ITO[cl - 1] if cl > 0 else INK_SOFT
+    return IMPRINT[cl - 1] if cl > 0 else INK_SOFT
 
 
 # Build Cartesian line segments grouped by cluster (0=neutral, 1-5=clusters)
@@ -119,7 +119,7 @@ for i, leaf_idx in enumerate(leaves):
     a = to_angle_rad(5 + 10 * i)
     cl = int(cluster_ids[leaf_idx])
     x, y = p2c(a, max_d * 0.995)
-    leaf_data.append({"x": round(x, 5), "y": round(y, 5), "color": OKABE_ITO[cl - 1]})
+    leaf_data.append({"x": round(x, 5), "y": round(y, 5), "color": IMPRINT[cl - 1]})
 
 cluster_names = ["Cross-cluster", "Cluster A", "Cluster B", "Cluster C", "Cluster D", "Cluster E"]
 

--- a/plots/density-rug/implementations/python/highcharts.py
+++ b/plots/density-rug/implementations/python/highcharts.py
@@ -120,8 +120,8 @@ chart.add_series(kde_series)
 rug_series = ScatterSeries()
 rug_series.name = "Rug (Individual Points)"
 rug_series.data = [[float(v), rug_y_position] for v in values]
-rug_series.color = "#D55E00"  # Okabe-Ito position 2
-rug_series.marker = {"symbol": "diamond", "radius": 8, "fillColor": "#D55E00", "lineWidth": 1, "lineColor": INK_SOFT}
+rug_series.color = "#C475FD"  # Okabe-Ito position 2
+rug_series.marker = {"symbol": "diamond", "radius": 8, "fillColor": "#C475FD", "lineWidth": 1, "lineColor": INK_SOFT}
 
 chart.add_series(rug_series)
 

--- a/plots/diagnostic-regression-panel/implementations/python/highcharts.py
+++ b/plots/diagnostic-regression-panel/implementations/python/highcharts.py
@@ -26,8 +26,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"
-SMOOTHER = "#D55E00"
-COOK_COLOR = "#CC79A7"
+SMOOTHER = "#C475FD"
+COOK_COLOR = "#BD8233"
 
 # Data — OLS regression with injected influential observations
 np.random.seed(42)

--- a/plots/donut-basic/implementations/python/highcharts.py
+++ b/plots/donut-basic/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first segment is always brand green)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Annual budget allocation by department (USD thousands)
 categories = ["Engineering", "Operations", "Marketing", "Sales", "Support"]
@@ -61,7 +61,7 @@ chart.options.subtitle = {
     "y": 0,
 }
 
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 chart.options.plot_options = {
     "pie": {

--- a/plots/donut-nested/implementations/python/highcharts.py
+++ b/plots/donut-nested/implementations/python/highcharts.py
@@ -26,12 +26,12 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73 (brand green)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Budget allocation: departments (inner) and expense categories (outer)
 departments = ["Engineering", "Marketing", "Operations", "Sales"]
 dept_values = [4500000, 2800000, 1900000, 2200000]
-dept_colors = OKABE_ITO
+dept_colors = IMPRINT
 
 # Outer ring: Expense categories with color variants per department
 expenses = [
@@ -41,16 +41,16 @@ expenses = [
     {"name": "Training", "y": 450000, "color": "#38D4A3"},
     {"name": "Software", "y": 350000, "color": "#50EEB2"},
     # Marketing (vermillion family - Okabe-Ito position 2 variants)
-    {"name": "Advertising", "y": 1400000, "color": "#D55E00"},
+    {"name": "Advertising", "y": 1400000, "color": "#C475FD"},
     {"name": "Events", "y": 700000, "color": "#E1791D"},
     {"name": "Content", "y": 400000, "color": "#ED9439"},
     {"name": "Research", "y": 300000, "color": "#F9AF56"},
     # Operations (blue family - Okabe-Ito position 3 variants)
-    {"name": "Facilities", "y": 800000, "color": "#0072B2"},
+    {"name": "Facilities", "y": 800000, "color": "#4467A3"},
     {"name": "IT Support", "y": 600000, "color": "#2287CC"},
     {"name": "Logistics", "y": 500000, "color": "#449CE6"},
     # Sales (reddish purple family - Okabe-Ito position 4 variants)
-    {"name": "Commissions", "y": 1100000, "color": "#CC79A7"},
+    {"name": "Commissions", "y": 1100000, "color": "#BD8233"},
     {"name": "Travel", "y": 600000, "color": "#DB8FBB"},
     {"name": "Client Entertainment", "y": 300000, "color": "#EAA5CF"},
     {"name": "CRM Tools", "y": 200000, "color": "#F9BBE3"},

--- a/plots/dot-matrix-proportional/implementations/python/highcharts.py
+++ b/plots/dot-matrix-proportional/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — Tech Survey: Preferred Code Editor (100 developers)
 categories = [
@@ -112,7 +112,7 @@ chart.options.plot_options = {
     "scatter": {"marker": {"radius": 85, "symbol": "circle", "lineWidth": 0}, "enableMouseTracking": False}
 }
 chart.options.tooltip = {"enabled": False}
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 chart.options.credits = {"enabled": False}
 
 # Include percentage in each legend entry per spec note on count/percentage annotations

--- a/plots/drawdown-basic/implementations/python/highcharts.py
+++ b/plots/drawdown-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Drawdown uses red — semantic exception (loss/down) → anyplot palette position 3
-DRAWDOWN_COLOR = "#B71D27"
+DRAWDOWN_COLOR = "#AE3030"
 
 # Data — simulated portfolio (geometric Brownian motion)
 np.random.seed(42)
@@ -167,7 +167,7 @@ chart.options.series = [
         "color": DRAWDOWN_COLOR,
         "fillColor": {
             "linearGradient": {"x1": 0, "y1": 0, "x2": 0, "y2": 1},
-            "stops": [[0, "rgba(183, 29, 39, 0.05)"], [1, "rgba(183, 29, 39, 0.55)"]],
+            "stops": [[0, "rgba(174, 48, 48, 0.05)"], [1, "rgba(174, 48, 48, 0.55)"]],
         },
         "lineColor": DRAWDOWN_COLOR,
         "lineWidth": 4,

--- a/plots/dumbbell-basic/implementations/python/highcharts.py
+++ b/plots/dumbbell-basic/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 CONNECTOR = "rgba(26,26,23,0.40)" if THEME == "light" else "rgba(240,239,232,0.40)"
 
 BEFORE_COLOR = "#009E73"  # Okabe-Ito 1 — brand
-AFTER_COLOR = "#D55E00"  # Okabe-Ito 2
+AFTER_COLOR = "#C475FD"  # Okabe-Ito 2
 
 # Employee satisfaction scores (0-100) before and after policy changes.
 # Mix of strong gains, modest gains, and two declines for full coverage.

--- a/plots/elbow-curve/implementations/python/highcharts.py
+++ b/plots/elbow-curve/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-SECONDARY = "#D55E00"  # Okabe-Ito position 2
+SECONDARY = "#C475FD"  # Okabe-Ito position 2
 
 # Data - simulate elbow curve from K-means clustering
 np.random.seed(42)

--- a/plots/errorbar-asymmetric/implementations/python/highcharts.py
+++ b/plots/errorbar-asymmetric/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - first categorical series
-SECONDARY = "#D55E00"  # Position 2
+SECONDARY = "#C475FD"  # Position 2
 
 # Data - Quarterly sales forecast with asymmetric confidence intervals
 np.random.seed(42)

--- a/plots/facet-grid/implementations/python/highcharts.py
+++ b/plots/facet-grid/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for soil types
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -149,7 +149,7 @@ for row_idx, soil in enumerate(soil_types):
                 "marker": {
                     "radius": 12,
                     "symbol": "circle",
-                    "fillColor": OKABE_ITO[row_idx % len(OKABE_ITO)],
+                    "fillColor": IMPRINT[row_idx % len(IMPRINT)],
                     "lineWidth": 2,
                     "lineColor": PAGE_BG,
                 },

--- a/plots/flowmap-origin-destination/implementations/python/highcharts.py
+++ b/plots/flowmap-origin-destination/implementations/python/highcharts.py
@@ -170,7 +170,7 @@ chart_config = {
             "color": BRAND,
             "fillColor": {
                 "linearGradient": {"x1": 0, "y1": 0, "x2": 1, "y2": 0},
-                "stops": [[0, "rgba(0, 158, 115, 0.60)"], [1, "rgba(0, 114, 178, 0.60)"]],
+                "stops": [[0, "rgba(0, 158, 115, 0.60)"], [1, "rgba(68, 103, 163, 0.60)"]],
             },
         },
     ],

--- a/plots/forest-basic/implementations/python/highcharts.py
+++ b/plots/forest-basic/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 
 # Data: Meta-analysis of treatment effect studies (mean difference)
 studies = [

--- a/plots/frequency-polygon-basic/implementations/python/highcharts.py
+++ b/plots/frequency-polygon-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Test scores for three different classes
 np.random.seed(42)
@@ -127,23 +127,23 @@ chart.options.plot_options = {
 series_a = SplineSeries()
 series_a.name = "Class A (Avg: 72)"
 series_a.data = [[float(x), int(y)] for x, y in zip(extended_centers, freq_a_extended, strict=True)]
-series_a.color = OKABE_ITO[0]  # #009E73 - brand green
-series_a.fill_color = OKABE_ITO[0]
-series_a.marker = {"fillColor": OKABE_ITO[0], "lineWidth": 2, "lineColor": PAGE_BG}
+series_a.color = IMPRINT[0]  # #009E73 - brand green
+series_a.fill_color = IMPRINT[0]
+series_a.marker = {"fillColor": IMPRINT[0], "lineWidth": 2, "lineColor": PAGE_BG}
 
 series_b = SplineSeries()
 series_b.name = "Class B (Avg: 80)"
 series_b.data = [[float(x), int(y)] for x, y in zip(extended_centers, freq_b_extended, strict=True)]
-series_b.color = OKABE_ITO[1]  # #D55E00 - vermillion
-series_b.fill_color = OKABE_ITO[1]
-series_b.marker = {"fillColor": OKABE_ITO[1], "lineWidth": 2, "lineColor": PAGE_BG}
+series_b.color = IMPRINT[1]  # #C475FD - vermillion
+series_b.fill_color = IMPRINT[1]
+series_b.marker = {"fillColor": IMPRINT[1], "lineWidth": 2, "lineColor": PAGE_BG}
 
 series_c = SplineSeries()
 series_c.name = "Class C (Bimodal)"
 series_c.data = [[float(x), int(y)] for x, y in zip(extended_centers, freq_c_extended, strict=True)]
-series_c.color = OKABE_ITO[2]  # #0072B2 - blue
-series_c.fill_color = OKABE_ITO[2]
-series_c.marker = {"fillColor": OKABE_ITO[2], "lineWidth": 2, "lineColor": PAGE_BG}
+series_c.color = IMPRINT[2]  # #4467A3 - blue
+series_c.fill_color = IMPRINT[2]
+series_c.marker = {"fillColor": IMPRINT[2], "lineWidth": 2, "lineColor": PAGE_BG}
 
 # Add series to chart
 chart.add_series(series_a)

--- a/plots/frontier-efficient/implementations/python/highcharts.py
+++ b/plots/frontier-efficient/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Generate random portfolios and efficient frontier
 np.random.seed(42)
@@ -189,21 +189,21 @@ chart.options.plot_options = {
 low_sharpe_series = ScatterSeries()
 low_sharpe_series.data = low_sharpe
 low_sharpe_series.name = "Low Sharpe Ratio"
-low_sharpe_series.color = OKABE_ITO[1]
+low_sharpe_series.color = IMPRINT[1]
 low_sharpe_series.marker = {"symbol": "circle", "radius": 8}
 chart.add_series(low_sharpe_series)
 
 mid_sharpe_series = ScatterSeries()
 mid_sharpe_series.data = mid_sharpe
 mid_sharpe_series.name = "Medium Sharpe Ratio"
-mid_sharpe_series.color = OKABE_ITO[2]
+mid_sharpe_series.color = IMPRINT[2]
 mid_sharpe_series.marker = {"symbol": "circle", "radius": 8}
 chart.add_series(mid_sharpe_series)
 
 high_sharpe_series = ScatterSeries()
 high_sharpe_series.data = high_sharpe
 high_sharpe_series.name = "High Sharpe Ratio"
-high_sharpe_series.color = OKABE_ITO[0]
+high_sharpe_series.color = IMPRINT[0]
 high_sharpe_series.marker = {"symbol": "circle", "radius": 8}
 chart.add_series(high_sharpe_series)
 
@@ -214,7 +214,7 @@ frontier_data = [
 frontier_series = LineSeries()
 frontier_series.data = frontier_data
 frontier_series.name = "Efficient Frontier"
-frontier_series.color = OKABE_ITO[3]
+frontier_series.color = IMPRINT[3]
 frontier_series.line_width = 8
 frontier_series.marker = {"enabled": False}
 frontier_series.z_index = 5
@@ -224,7 +224,7 @@ chart.add_series(frontier_series)
 min_var_series = ScatterSeries()
 min_var_series.data = [{"x": round(min_var_risk * 100, 2), "y": round(min_var_return * 100, 2)}]
 min_var_series.name = "Minimum Variance"
-min_var_series.color = OKABE_ITO[4]
+min_var_series.color = IMPRINT[4]
 min_var_series.marker = {"symbol": "square", "radius": 14, "lineWidth": 3, "lineColor": INK}
 min_var_series.z_index = 10
 chart.add_series(min_var_series)
@@ -233,7 +233,7 @@ chart.add_series(min_var_series)
 tangency_series = ScatterSeries()
 tangency_series.data = [{"x": round(tangency_risk * 100, 2), "y": round(tangency_return * 100, 2)}]
 tangency_series.name = "Maximum Sharpe Ratio"
-tangency_series.color = OKABE_ITO[5]
+tangency_series.color = IMPRINT[5]
 tangency_series.marker = {"symbol": "triangle", "radius": 16, "lineWidth": 3, "lineColor": INK}
 tangency_series.z_index = 10
 chart.add_series(tangency_series)
@@ -248,7 +248,7 @@ cml_data = [
 cml_series = LineSeries()
 cml_series.data = cml_data
 cml_series.name = "Capital Market Line"
-cml_series.color = OKABE_ITO[6]
+cml_series.color = IMPRINT[6]
 cml_series.dash_style = "Dash"
 cml_series.line_width = 5
 cml_series.marker = {"enabled": False}

--- a/plots/funnel-basic/implementations/python/highcharts.py
+++ b/plots/funnel-basic/implementations/python/highcharts.py
@@ -24,14 +24,14 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito categorical palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Sales funnel: visitors progressing from initial awareness through purchase.
 stages = ["Awareness", "Interest", "Consideration", "Intent", "Purchase"]
 values = [1000, 600, 400, 200, 100]
 
 funnel_data = [
-    {"name": stage, "y": value, "color": OKABE_ITO[i]}
+    {"name": stage, "y": value, "color": IMPRINT[i]}
     for i, (stage, value) in enumerate(zip(stages, values, strict=True))
 ]
 

--- a/plots/gain-curve/implementations/python/highcharts.py
+++ b/plots/gain-curve/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2 for baseline
+ACCENT = "#C475FD"  # Okabe-Ito position 2 for baseline
 
 # Data: Customer response model with predicted probabilities
 np.random.seed(42)

--- a/plots/gantt-basic/implementations/python/highcharts.py
+++ b/plots/gantt-basic/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Project tasks with start/end dates and categories
 tasks = [
@@ -49,10 +49,10 @@ tasks = [
 
 # Map categories to Okabe-Ito colors
 category_colors = {
-    "Planning": OKABE_ITO[0],  # #009E73
-    "Development": OKABE_ITO[1],  # #D55E00
-    "Testing": OKABE_ITO[2],  # #0072B2
-    "Deployment": OKABE_ITO[3],  # #CC79A7
+    "Planning": IMPRINT[0],  # #009E73
+    "Development": IMPRINT[1],  # #C475FD
+    "Testing": IMPRINT[2],  # #4467A3
+    "Deployment": IMPRINT[3],  # #BD8233
 }
 
 task_names = [t["name"] for t in tasks]
@@ -120,7 +120,7 @@ html_content = f"""<!DOCTYPE html>
                 marginLeft: 360,
                 marginTop: 150,
             }},
-            colors: ['{OKABE_ITO[0]}', '{OKABE_ITO[1]}', '{OKABE_ITO[2]}', '{OKABE_ITO[3]}'],
+            colors: ['{IMPRINT[0]}', '{IMPRINT[1]}', '{IMPRINT[2]}', '{IMPRINT[3]}'],
             title: {{
                 text: 'gantt-basic · highcharts · anyplot.ai',
                 style: {{fontSize: '28px', fontWeight: 'bold', color: '{INK}'}},
@@ -199,22 +199,22 @@ html_content = f"""<!DOCTYPE html>
                 {{
                     name: 'Planning',
                     data: {str(series_data_planning)},
-                    color: '{OKABE_ITO[0]}'
+                    color: '{IMPRINT[0]}'
                 }},
                 {{
                     name: 'Development',
                     data: {str(series_data_development)},
-                    color: '{OKABE_ITO[1]}'
+                    color: '{IMPRINT[1]}'
                 }},
                 {{
                     name: 'Testing',
                     data: {str(series_data_testing)},
-                    color: '{OKABE_ITO[2]}'
+                    color: '{IMPRINT[2]}'
                 }},
                 {{
                     name: 'Deployment',
                     data: {str(series_data_deployment)},
-                    color: '{OKABE_ITO[3]}'
+                    color: '{IMPRINT[3]}'
                 }}
             ],
             credits: {{enabled: false}}

--- a/plots/gauge-basic/implementations/python/highcharts.py
+++ b/plots/gauge-basic/implementations/python/highcharts.py
@@ -23,10 +23,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-# Okabe-Ito zones: low / mid / high (intuitive + colorblind-safe)
-ZONE_LOW = "#D55E00"  # vermillion (bad)
-ZONE_MID = "#E69F00"  # orange (warning)
-ZONE_HIGH = "#009E73"  # brand bluish green (good)
+# imprint semantic anchors: low / mid / high (red / amber / green)
+ZONE_LOW = "#AE3030"  # imprint red — bad
+ZONE_MID = "#DDCC77"  # imprint amber — warning
+ZONE_HIGH = "#009E73"  # imprint green — good
 
 # Data
 value = 72

--- a/plots/hierarchy-toggle-view/implementations/python/highcharts.py
+++ b/plots/hierarchy-toggle-view/implementations/python/highcharts.py
@@ -23,7 +23,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for departments (positions 1-4)
-DEPT_COLORS = {"engineering": "#009E73", "sales": "#D55E00", "operations": "#0072B2", "hr": "#CC79A7"}
+DEPT_COLORS = {"engineering": "#009E73", "sales": "#C475FD", "operations": "#4467A3", "hr": "#BD8233"}
 
 # Hierarchical data: Company organizational structure
 # Format: [id, parent, label, value]

--- a/plots/histogram-density/implementations/python/highcharts.py
+++ b/plots/histogram-density/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Generate right-skewed response time data
 np.random.seed(42)
@@ -110,7 +110,7 @@ chart.options.plot_options = {
 }
 
 # Colors
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Add histogram series (using column chart)
 histogram_series = ColumnSeries()
@@ -124,7 +124,7 @@ chart.add_series(histogram_series)
 pdf_series = AreaSplineSeries()
 pdf_series.name = "Gamma PDF"
 pdf_series.data = [[float(x), float(y)] for x, y in zip(x_pdf, y_pdf, strict=True)]
-pdf_series.color = "#D55E00"
+pdf_series.color = "#C475FD"
 
 chart.add_series(pdf_series)
 

--- a/plots/histogram-kde/implementations/python/highcharts.py
+++ b/plots/histogram-kde/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-SECONDARY = "#D55E00"  # Okabe-Ito position 2
+SECONDARY = "#C475FD"  # Okabe-Ito position 2
 
 # Data: Simulated stock returns with realistic distribution
 np.random.seed(42)

--- a/plots/histogram-overlapping/implementations/python/highcharts.py
+++ b/plots/histogram-overlapping/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Employee performance scores by department
 np.random.seed(42)
@@ -121,19 +121,19 @@ chart.add_series(
         "type": "column",
         "name": "Engineering (n=150)",
         "data": eng_counts.tolist(),
-        "color": OKABE_ITO[0],
+        "color": IMPRINT[0],
         "opacity": 0.55,
     }
 )
 
 # Sales (Okabe-Ito vermillion) - middle layer
 chart.add_series(
-    {"type": "column", "name": "Sales (n=150)", "data": sales_counts.tolist(), "color": OKABE_ITO[1], "opacity": 0.55}
+    {"type": "column", "name": "Sales (n=150)", "data": sales_counts.tolist(), "color": IMPRINT[1], "opacity": 0.55}
 )
 
 # Marketing (Okabe-Ito blue) - back layer
 chart.add_series(
-    {"type": "column", "name": "Marketing (n=150)", "data": mkt_counts.tolist(), "color": OKABE_ITO[2], "opacity": 0.55}
+    {"type": "column", "name": "Marketing (n=150)", "data": mkt_counts.tolist(), "color": IMPRINT[2], "opacity": 0.55}
 )
 
 # Tooltip

--- a/plots/histogram-returns-distribution/implementations/python/highcharts.py
+++ b/plots/histogram-returns-distribution/implementations/python/highcharts.py
@@ -31,8 +31,8 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette positions
 BRAND = "#009E73"  # position 1 — main histogram bars
-COLOR_2 = "#D55E00"  # position 2 — tail regions
-COLOR_3 = "#0072B2"  # position 3 — normal distribution curve
+COLOR_2 = "#C475FD"  # position 2 — tail regions
+COLOR_3 = "#4467A3"  # position 3 — normal distribution curve
 
 # Data
 np.random.seed(42)

--- a/plots/histogram-stacked/implementations/python/highcharts.py
+++ b/plots/histogram-stacked/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first color always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Generate three groups with different distributions
 np.random.seed(42)
@@ -110,17 +110,17 @@ chart.options.legend = {
 series_a = ColumnSeries()
 series_a.data = [int(c) for c in counts_a]
 series_a.name = "Group A"
-series_a.color = OKABE_ITO[0]
+series_a.color = IMPRINT[0]
 
 series_b = ColumnSeries()
 series_b.data = [int(c) for c in counts_b]
 series_b.name = "Group B"
-series_b.color = OKABE_ITO[1]
+series_b.color = IMPRINT[1]
 
 series_c = ColumnSeries()
 series_c.data = [int(c) for c in counts_c]
 series_c.name = "Group C"
-series_c.color = OKABE_ITO[2]
+series_c.color = IMPRINT[2]
 
 chart.add_series(series_a)
 chart.add_series(series_b)

--- a/plots/hive-basic/implementations/python/highcharts.py
+++ b/plots/hive-basic/implementations/python/highcharts.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Software module dependency network
 # Nodes assigned to 3 axes by module type: Core, Utility, Interface (deterministic data)
@@ -116,7 +116,7 @@ for axis_idx in range(num_axes):
     y1 = center_y + inner_radius * math.sin(angle)
     x2 = center_x + (outer_radius + 50) * math.cos(angle)
     y2 = center_y + (outer_radius + 50) * math.sin(angle)
-    color = OKABE_ITO[axis_idx]
+    color = IMPRINT[axis_idx]
 
     renderer_commands.append(
         f"chart.renderer.path(['M', {x1:.0f}, {y1:.0f}, 'L', {x2:.0f}, {y2:.0f}], null)"
@@ -143,7 +143,7 @@ for edge in edges:
     mid_y = (y1 + y2) / 2
     ctrl_x = center_x + (mid_x - center_x) * 0.15
     ctrl_y = center_y + (mid_y - center_y) * 0.15
-    edge_color = OKABE_ITO[source["axis"]]
+    edge_color = IMPRINT[source["axis"]]
     stroke_width = 3 + weight * 2
 
     renderer_commands.append(
@@ -160,7 +160,7 @@ renderer_commands.append(
 # Draw nodes as circles
 for node in nodes:
     x, y = node_coords[node["id"]]
-    color = OKABE_ITO[node["axis"]]
+    color = IMPRINT[node["axis"]]
 
     renderer_commands.append(
         f"chart.renderer.circle({x:.0f}, {y:.0f}, 32).attr({{fill: '{color}', stroke: '{PAGE_BG}', 'stroke-width': 5, zIndex: 10}}).add();"
@@ -193,7 +193,7 @@ legend_items = (
 for i, label in enumerate(axis_labels):
     legend_items += f"""
             <div style="display: flex; align-items: center; margin-bottom: 24px;">
-                <div style="width: 50px; height: 50px; border-radius: 50%; background: {OKABE_ITO[i]}; margin-right: 24px; border: 3px solid {PAGE_BG}; box-shadow: 0 2px 4px rgba(0,0,0,0.2);"></div>
+                <div style="width: 50px; height: 50px; border-radius: 50%; background: {IMPRINT[i]}; margin-right: 24px; border: 3px solid {PAGE_BG}; box-shadow: 0 2px 4px rgba(0,0,0,0.2);"></div>
                 <span style="font-size: 34px; color: {INK};">{label}</span>
             </div>"""
 legend_items += f"""

--- a/plots/horizon-basic/implementations/python/highcharts.py
+++ b/plots/horizon-basic/implementations/python/highcharts.py
@@ -49,8 +49,8 @@ n_bands = 3
 # Color scheme: Okabe-Ito green shades for positive, orange shades for negative
 # Positive: from light to dark shades of #009E73 (Okabe-Ito position 1)
 colors_pos = ["#6FD8C0", "#009E73", "#004A3A"]  # Light to dark green
-# Negative: from light to dark shades of #D55E00 (Okabe-Ito position 2)
-colors_neg = ["#F4B3A0", "#D55E00", "#6B2F00"]  # Light to dark orange
+# Negative: from light to dark shades of imprint red
+colors_neg = ["#E07070", "#AE3030", "#7A1F1F"]  # imprint red ramp
 
 # Calculate global max for consistent band sizing
 all_values = np.concatenate([np.array(d["values"]) for d in data])

--- a/plots/ice-basic/implementations/python/highcharts.py
+++ b/plots/ice-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — ICE lines
-PDP_COLOR = "#D55E00"  # Okabe-Ito position 2 — PDP overlay
+PDP_COLOR = "#C475FD"  # Okabe-Ito position 2 — PDP overlay
 ICE_COLOR = "rgba(0,158,115,0.20)"  # BRAND at 20% opacity
 
 # Data

--- a/plots/icicle-basic/implementations/python/highcharts.py
+++ b/plots/icicle-basic/implementations/python/highcharts.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for main categories
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - File system hierarchy with folders and files
 hierarchy = {
@@ -42,7 +42,7 @@ hierarchy = {
 }
 
 # Category colors from Okabe-Ito palette
-cat_colors = {"src": OKABE_ITO[0], "docs": OKABE_ITO[1], "tests": OKABE_ITO[2], "assets": OKABE_ITO[3]}
+cat_colors = {"src": IMPRINT[0], "docs": IMPRINT[1], "tests": IMPRINT[2], "assets": IMPRINT[3]}
 
 # Flatten hierarchy into list of nodes with calculated sizes
 all_nodes = []
@@ -93,7 +93,7 @@ level_height = 2300 // (max_level + 1) if max_level > 0 else 500
 for lv in sorted(level_groups.keys()):
     for parent, children in level_groups[lv].items():
         top_cat = parent if parent in cat_colors else "src"
-        color = cat_colors.get(top_cat, OKABE_ITO[0])
+        color = cat_colors.get(top_cat, IMPRINT[0])
 
         total_val = sum(c["value"] for c in children)
         x_pos = 200
@@ -190,10 +190,10 @@ chart_config = f"""
 
                     // Draw legend
                     var cats = [
-                        {{ name: 'src', color: '{OKABE_ITO[0]}' }},
-                        {{ name: 'docs', color: '{OKABE_ITO[1]}' }},
-                        {{ name: 'tests', color: '{OKABE_ITO[2]}' }},
-                        {{ name: 'assets', color: '{OKABE_ITO[3]}' }}
+                        {{ name: 'src', color: '{IMPRINT[0]}' }},
+                        {{ name: 'docs', color: '{IMPRINT[1]}' }},
+                        {{ name: 'tests', color: '{IMPRINT[2]}' }},
+                        {{ name: 'assets', color: '{IMPRINT[3]}' }}
                     ];
 
                     var legendY = 2520;

--- a/plots/indicator-bollinger/implementations/python/highcharts.py
+++ b/plots/indicator-bollinger/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Generate 120 days of stock price data with Bollinger Bands
 np.random.seed(42)
@@ -205,13 +205,13 @@ Highcharts.chart('container', {{
         }}
     }},
 
-    colors: {json.dumps(OKABE_ITO)},
+    colors: {json.dumps(IMPRINT)},
 
     series: [{{
         type: 'arearange',
         name: 'Bollinger Bands',
         data: {band_json},
-        color: '{OKABE_ITO[2]}',
+        color: '{IMPRINT[2]}',
         fillOpacity: 0.2,
         lineWidth: 0,
         zIndex: 0,
@@ -220,7 +220,7 @@ Highcharts.chart('container', {{
         type: 'line',
         name: 'Upper Band (+2σ)',
         data: {upper_json},
-        color: '{OKABE_ITO[2]}',
+        color: '{IMPRINT[2]}',
         lineWidth: 4,
         dashStyle: 'Dash',
         zIndex: 1
@@ -228,7 +228,7 @@ Highcharts.chart('container', {{
         type: 'line',
         name: 'Lower Band (-2σ)',
         data: {lower_json},
-        color: '{OKABE_ITO[2]}',
+        color: '{IMPRINT[2]}',
         lineWidth: 4,
         dashStyle: 'Dash',
         zIndex: 1
@@ -236,7 +236,7 @@ Highcharts.chart('container', {{
         type: 'line',
         name: '20-Day SMA',
         data: {sma_json},
-        color: '{OKABE_ITO[1]}',
+        color: '{IMPRINT[1]}',
         lineWidth: 5,
         dashStyle: 'Dot',
         zIndex: 2
@@ -244,7 +244,7 @@ Highcharts.chart('container', {{
         type: 'line',
         name: 'Close Price',
         data: {close_json},
-        color: '{OKABE_ITO[0]}',
+        color: '{IMPRINT[0]}',
         lineWidth: 6,
         zIndex: 3
     }}]

--- a/plots/indicator-ema/implementations/python/highcharts.py
+++ b/plots/indicator-ema/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data
 np.random.seed(42)
@@ -127,7 +127,7 @@ chart.options.plot_options = {
 price_series = LineSeries()
 price_series.name = "Close Price"
 price_series.data = [[t, round(p, 2)] for t, p in zip(timestamps, df["close"], strict=True)]
-price_series.color = OKABE_ITO[0]
+price_series.color = IMPRINT[0]
 price_series.line_width = 5
 price_series.z_index = 3
 chart.add_series(price_series)
@@ -136,7 +136,7 @@ chart.add_series(price_series)
 ema12_series = LineSeries()
 ema12_series.name = "EMA 12"
 ema12_series.data = [[t, round(e, 2)] for t, e in zip(timestamps, df["ema_12"], strict=True)]
-ema12_series.color = OKABE_ITO[1]
+ema12_series.color = IMPRINT[1]
 ema12_series.line_width = 3
 ema12_series.z_index = 2
 chart.add_series(ema12_series)
@@ -145,7 +145,7 @@ chart.add_series(ema12_series)
 ema26_series = LineSeries()
 ema26_series.name = "EMA 26"
 ema26_series.data = [[t, round(e, 2)] for t, e in zip(timestamps, df["ema_26"], strict=True)]
-ema26_series.color = OKABE_ITO[2]
+ema26_series.color = IMPRINT[2]
 ema26_series.line_width = 3
 ema26_series.dash_style = "ShortDash"
 ema26_series.z_index = 1
@@ -155,7 +155,7 @@ chart.add_series(ema26_series)
 crossover_series = ScatterSeries()
 crossover_series.name = "Crossover"
 crossover_series.data = [[t, round(e, 2)] for t, e in zip(crossover_timestamps, crossover_df["ema_12"], strict=True)]
-crossover_series.color = OKABE_ITO[3]
+crossover_series.color = IMPRINT[3]
 crossover_series.marker = {"symbol": "diamond", "radius": 14}
 crossover_series.z_index = 4
 chart.add_series(crossover_series)

--- a/plots/indicator-macd/implementations/python/highcharts.py
+++ b/plots/indicator-macd/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for lines
 MACD_COLOR = "#009E73"  # Position 1 - brand
-SIGNAL_COLOR = "#D55E00"  # Position 2 - vermillion
+SIGNAL_COLOR = "#BD8233"  # imprint ochre — signal line (categorical contrast)
 HISTOGRAM_POS_COLOR = "#22C55E"  # Green for positive histogram
 HISTOGRAM_NEG_COLOR = "#EF4444"  # Red for negative histogram
 

--- a/plots/indicator-sma/implementations/python/highcharts.py
+++ b/plots/indicator-sma/implementations/python/highcharts.py
@@ -29,9 +29,9 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito colors (canonical order)
 CLOSE_COLOR = "#009E73"  # position 1 — brand green — close price
-SMA20_COLOR = "#D55E00"  # position 2 — vermillion — SMA 20
-SMA50_COLOR = "#0072B2"  # position 3 — blue — SMA 50
-SMA200_COLOR = "#CC79A7"  # position 4 — reddish purple — SMA 200
+SMA20_COLOR = "#C475FD"  # position 2 — vermillion — SMA 20
+SMA50_COLOR = "#4467A3"  # position 3 — blue — SMA 50
+SMA200_COLOR = "#BD8233"  # position 4 — reddish purple — SMA 200
 
 # Data: stock price with mean-reverting (Ornstein-Uhlenbeck) dynamics
 np.random.seed(42)

--- a/plots/kagi-basic/implementations/python/highcharts.py
+++ b/plots/kagi-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 YANG_COLOR = "#009E73"  # Green (bullish) - first series
-YIN_COLOR = "#D55E00"  # Vermillion (bearish) - second series
+YIN_COLOR = "#AE3030"  # imprint red — bearish
 
 # Generate realistic stock price data
 np.random.seed(42)

--- a/plots/learning-curve-basic/implementations/python/highcharts.py
+++ b/plots/learning-curve-basic/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - first series
-ORANGE = "#D55E00"  # Position 2
+ORANGE = "#C475FD"  # Position 2
 
 # Data - Simulated learning curve from a classification model
 np.random.seed(42)

--- a/plots/line-3d-trajectory/implementations/python/highcharts.py
+++ b/plots/line-3d-trajectory/implementations/python/highcharts.py
@@ -178,8 +178,8 @@ Highcharts.chart('container', {{
         max: 1,
         stops: [
             [0, '{BRAND}'],
-            [0.5, '#D55E00'],
-            [1, '#0072B2']
+            [0.5, '#C475FD'],
+            [1, '#4467A3']
         ],
         showInLegend: true
     }},

--- a/plots/line-annotated-events/implementations/python/highcharts.py
+++ b/plots/line-annotated-events/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"  # Okabe-Ito position 1 — first series always
-ACCENT = "#D55E00"  # Okabe-Ito position 2 — event markers
+ACCENT = "#C475FD"  # Okabe-Ito position 2 — event markers
 
 # Data - Simulated daily product metrics over 6 months with event annotations
 np.random.seed(42)

--- a/plots/line-loss-training/implementations/python/highcharts.py
+++ b/plots/line-loss-training/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Training loss (first series)
-SECONDARY = "#D55E00"  # Validation loss
+SECONDARY = "#C475FD"  # Validation loss
 
 # Data - Simulate training and validation loss over epochs
 np.random.seed(42)

--- a/plots/line-markers/implementations/python/highcharts.py
+++ b/plots/line-markers/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Stock price tracking with different patterns
 np.random.seed(42)
@@ -49,7 +49,7 @@ chart_config = {
         "spacingBottom": 50,
         "style": {"color": INK},
     },
-    "colors": OKABE_ITO,
+    "colors": IMPRINT,
     "title": {"text": "line-markers · highcharts · anyplot.ai", "style": {"fontSize": "28px", "color": INK}},
     "xAxis": {
         "title": {"text": "Day", "style": {"fontSize": "22px", "color": INK}},
@@ -87,20 +87,20 @@ chart_config = {
         {
             "name": "Stock A",
             "data": [[int(d), round(float(p), 1)] for d, p in zip(days, stock_a, strict=False)],
-            "color": OKABE_ITO[0],
-            "marker": {"symbol": "circle", "fillColor": OKABE_ITO[0]},
+            "color": IMPRINT[0],
+            "marker": {"symbol": "circle", "fillColor": IMPRINT[0]},
         },
         {
             "name": "Stock B",
             "data": [[int(d), round(float(p), 1)] for d, p in zip(days, stock_b, strict=False)],
-            "color": OKABE_ITO[1],
-            "marker": {"symbol": "diamond", "fillColor": OKABE_ITO[1]},
+            "color": IMPRINT[1],
+            "marker": {"symbol": "diamond", "fillColor": IMPRINT[1]},
         },
         {
             "name": "Stock C",
             "data": [[int(d), round(float(p), 1)] for d, p in zip(days, stock_c, strict=False)],
-            "color": OKABE_ITO[2],
-            "marker": {"symbol": "triangle", "fillColor": OKABE_ITO[2]},
+            "color": IMPRINT[2],
+            "marker": {"symbol": "triangle", "fillColor": IMPRINT[2]},
         },
     ],
 }

--- a/plots/line-multi/implementations/python/highcharts.py
+++ b/plots/line-multi/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Monthly sales for 4 product lines over 12 months
 np.random.seed(42)
@@ -114,34 +114,34 @@ chart.options.plot_options = {
 }
 
 # Set colors for the chart
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Add series - Electronics
 series1 = LineSeries()
 series1.name = "Electronics"
 series1.data = electronics
-series1.color = OKABE_ITO[0]
+series1.color = IMPRINT[0]
 chart.add_series(series1)
 
 # Add series - Clothing
 series2 = LineSeries()
 series2.name = "Clothing"
 series2.data = clothing
-series2.color = OKABE_ITO[1]
+series2.color = IMPRINT[1]
 chart.add_series(series2)
 
 # Add series - Home & Garden
 series3 = LineSeries()
 series3.name = "Home & Garden"
 series3.data = home_garden
-series3.color = OKABE_ITO[2]
+series3.color = IMPRINT[2]
 chart.add_series(series3)
 
 # Add series - Sports Equipment
 series4 = LineSeries()
 series4.name = "Sports Equipment"
 series4.data = sports
-series4.color = OKABE_ITO[3]
+series4.color = IMPRINT[3]
 chart.add_series(series4)
 
 # Download Highcharts JS for inline embedding

--- a/plots/line-stock-comparison/implementations/python/highcharts.py
+++ b/plots/line-stock-comparison/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3", "#99B314", "#D359A7", "#BA843E"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3", "#99B314", "#954477", "#BD8233"]
 
 # Data — synthetic semiconductor sector vs S&P 500, 2024 (252 trading days)
 np.random.seed(42)
@@ -127,7 +127,7 @@ chart.options.legend = {
 
 chart.options.plot_options = {"line": {"lineWidth": 3.5, "marker": {"enabled": False}}}
 
-chart.options.colors = ANYPLOT_PALETTE
+chart.options.colors = IMPRINT
 
 for symbol, price_data in prices.items():
     series = LineSeries()

--- a/plots/line-styled/implementations/python/highcharts.py
+++ b/plots/line-styled/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"  # Okabe-Ito position 1
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Monthly temperature data for 4 cities
 np.random.seed(42)
@@ -105,7 +105,7 @@ chart.options.plot_options = {"line": {"lineWidth": 6, "marker": {"enabled": Tru
 series1 = LineSeries()
 series1.name = "Madrid"
 series1.data = [round(float(v), 1) for v in madrid]
-series1.color = OKABE_ITO[0]
+series1.color = IMPRINT[0]
 series1.dash_style = "Solid"
 chart.add_series(series1)
 
@@ -113,7 +113,7 @@ chart.add_series(series1)
 series2 = LineSeries()
 series2.name = "Berlin"
 series2.data = [round(float(v), 1) for v in berlin]
-series2.color = OKABE_ITO[1]
+series2.color = IMPRINT[1]
 series2.dash_style = "Dash"
 chart.add_series(series2)
 
@@ -121,7 +121,7 @@ chart.add_series(series2)
 series3 = LineSeries()
 series3.name = "Edinburgh"
 series3.data = [round(float(v), 1) for v in edinburgh]
-series3.color = OKABE_ITO[2]
+series3.color = IMPRINT[2]
 series3.dash_style = "Dot"
 chart.add_series(series3)
 
@@ -129,7 +129,7 @@ chart.add_series(series3)
 series4 = LineSeries()
 series4.name = "Oslo"
 series4.data = [round(float(v), 1) for v in oslo]
-series4.color = OKABE_ITO[3]
+series4.color = IMPRINT[3]
 series4.dash_style = "DashDot"
 chart.add_series(series4)
 

--- a/plots/line-timeseries-rolling/implementations/python/highcharts.py
+++ b/plots/line-timeseries-rolling/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1
-ACCENT = "#D55E00"  # Position 2
+ACCENT = "#C475FD"  # Position 2
 BRAND_SEMI = "rgba(0, 158, 115, 0.5)"
 
 # Data - Daily temperature readings with 7-day rolling average

--- a/plots/linked-views-selection/implementations/python/highcharts.py
+++ b/plots/linked-views-selection/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Load Iris dataset
 iris = load_iris()
@@ -36,7 +36,7 @@ value = iris.data[:, 2]  # Petal length
 categories = [str(iris.target_names[t]) for t in iris.target]
 
 # Category colors from Okabe-Ito palette
-category_colors = {"setosa": OKABE_ITO[0], "versicolor": OKABE_ITO[1], "virginica": OKABE_ITO[2]}
+category_colors = {"setosa": IMPRINT[0], "versicolor": IMPRINT[1], "virginica": IMPRINT[2]}
 
 # Prepare data as JavaScript-friendly format
 data_points = []
@@ -113,7 +113,7 @@ html_content = f"""<!DOCTYPE html>
         .reset-btn {{
             padding: 16px 48px;
             font-size: 24px;
-            background: {OKABE_ITO[0]};
+            background: {IMPRINT[0]};
             color: white;
             border: none;
             border-radius: 8px;
@@ -151,9 +151,9 @@ html_content = f"""<!DOCTYPE html>
         // Data points
         const allData = {json.dumps(data_points)};
         const categoryColors = {{
-            "setosa": "{OKABE_ITO[0]}",
-            "versicolor": "{OKABE_ITO[1]}",
-            "virginica": "{OKABE_ITO[2]}"
+            "setosa": "{IMPRINT[0]}",
+            "versicolor": "{IMPRINT[1]}",
+            "virginica": "{IMPRINT[2]}"
         }};
         const categoryList = ["setosa", "versicolor", "virginica"];
         const pageColor = "{PAGE_BG}";

--- a/plots/logistic-regression/implementations/python/highcharts.py
+++ b/plots/logistic-regression/implementations/python/highcharts.py
@@ -32,8 +32,8 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Semantic color mapping: Pass→green (good), Fail→red (bad)
 COLOR_PASS = "#009E73"  # anyplot position 1 — semantic: pass/good
-COLOR_FAIL = "#B71D27"  # anyplot position 3 — semantic: fail/bad
-COLOR_CURVE = "#9418DB"  # anyplot position 2 — logistic curve
+COLOR_FAIL = "#AE3030"  # anyplot position 3 — semantic: fail/bad
+COLOR_CURVE = "#C475FD"  # anyplot position 2 — logistic curve
 
 # Data — exam pass/fail as a function of study hours
 np.random.seed(42)
@@ -185,7 +185,7 @@ chart.add_series(curve_series)
 scatter_fail = ScatterSeries()
 scatter_fail.data = [[x_fail[i], y_fail[i]] for i in range(len(x_fail))]
 scatter_fail.name = "Fail (0)"
-scatter_fail.color = "rgba(183, 29, 39, 0.6)"  # #B71D27 at 0.6 alpha
+scatter_fail.color = "rgba(174, 48, 48, 0.6)"  # #AE3030 at 0.6 alpha
 scatter_fail.marker = {"radius": 8, "symbol": "circle"}
 chart.add_series(scatter_fail)
 

--- a/plots/lollipop-grouped/implementations/python/highcharts.py
+++ b/plots/lollipop-grouped/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product line across regions
 np.random.seed(42)
@@ -106,7 +106,7 @@ all_series = []
 n_series = len(series_names)
 offsets = [(i - (n_series - 1) / 2) * 0.2 for i in range(n_series)]
 
-for series_name, color, offset in zip(series_names, OKABE_ITO, offsets, strict=True):
+for series_name, color, offset in zip(series_names, IMPRINT, offsets, strict=True):
     values = data[series_name]
     # Create scatter points for the markers
     scatter_data = []

--- a/plots/manhattan-gwas/implementations/python/highcharts.py
+++ b/plots/manhattan-gwas/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for alternating chromosomes
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Simulated GWAS data with random p-values and significant peaks
 np.random.seed(42)
@@ -99,8 +99,8 @@ series_data = []
 for chrom in range(1, 23):
     chrom_points = [[d["x"], d["y"]] for d in all_data if d["chr"] == chrom]
     # Use alternating Okabe-Ito colors
-    color_idx = (chrom - 1) % len(OKABE_ITO)
-    color = OKABE_ITO[color_idx]
+    color_idx = (chrom - 1) % len(IMPRINT)
+    color = IMPRINT[color_idx]
     series_data.append(
         {
             "name": f"Chr {chrom}",

--- a/plots/map-drilldown-geographic/implementations/python/highcharts.py
+++ b/plots/map-drilldown-geographic/implementations/python/highcharts.py
@@ -40,9 +40,9 @@ chart_config = f"""
 
     var REGION_COLORS = {{
         'west': '#009E73',
-        'south': '#9418DB',
-        'midwest': '#B71D27',
-        'northeast': '#16B8F3'
+        'south': '#C475FD',
+        'midwest': '#AE3030',
+        'northeast': '#4467A3'
     }};
 
     var stateRegions = {{

--- a/plots/map-marker-clustered/implementations/python/highcharts.py
+++ b/plots/map-marker-clustered/implementations/python/highcharts.py
@@ -29,9 +29,9 @@ MAP_BORDER = "#B0AC9F" if THEME == "light" else "#4A4A44"
 # anyplot palette for the four store categories
 CATEGORY_COLORS = {
     "Grocery": "#009E73",  # position 1 — brand green
-    "Electronics": "#9418DB",  # position 2 — purple
-    "Clothing": "#B71D27",  # position 3 — red
-    "Home Goods": "#16B8F3",  # position 4 — sky blue
+    "Electronics": "#C475FD",  # position 2 — purple
+    "Clothing": "#AE3030",  # position 3 — red
+    "Home Goods": "#4467A3",  # position 4 — sky blue
 }
 
 # Data: retail stores clustered around 15 major US cities

--- a/plots/map-projections/implementations/python/highcharts.py
+++ b/plots/map-projections/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # anyplot palette
 LAND_COLOR = "#009E73"  # position 1 — brand green (land masses)
-GRATICULE_COLOR = "#9418DB"  # position 2 — purple (lat/lon grid)
+GRATICULE_COLOR = "#C475FD"  # position 2 — purple (lat/lon grid)
 
 W, H = 3200, 1800
 
@@ -79,7 +79,7 @@ for proj in projections:
                 "nullColor": LAND_COLOR,
                 "borderColor": PAGE_BG,
                 "borderWidth": 1.5,
-                "states": {"hover": {"color": "#B71D27"}, "inactive": {"opacity": 1}},
+                "states": {"hover": {"color": "#AE3030"}, "inactive": {"opacity": 1}},
             },
             {
                 "type": "mapline",

--- a/plots/map-route-path/implementations/python/highcharts.py
+++ b/plots/map-route-path/implementations/python/highcharts.py
@@ -195,7 +195,7 @@ html_inline = f"""<!DOCTYPE html>
                 marker: {{
                     symbol: 'triangle',
                     radius: 14,
-                    fillColor: '#0072B2',
+                    fillColor: '#4467A3',
                     lineWidth: 2,
                     lineColor: '{PAGE_BG}',
                     rotation: 90 - pt.angle
@@ -220,7 +220,7 @@ html_inline = f"""<!DOCTYPE html>
             marker: {{
                 symbol: 'circle',
                 radius: 8,
-                fillColor: '#E69F00',
+                fillColor: '#AE3030',
                 lineWidth: 2,
                 lineColor: '{PAGE_BG}'
             }},
@@ -260,12 +260,12 @@ html_inline = f"""<!DOCTYPE html>
             type: 'mappoint',
             name: 'End (6 hrs)',
             showInLegend: true,
-            color: '#D55E00',
+            color: '#C475FD',
             zIndex: 20,
             marker: {{
                 symbol: 'square',
                 radius: 18,
-                fillColor: '#D55E00',
+                fillColor: '#C475FD',
                 lineWidth: 4,
                 lineColor: '{PAGE_BG}'
             }},
@@ -275,7 +275,7 @@ html_inline = f"""<!DOCTYPE html>
                 style: {{
                     fontSize: '38px',
                     fontWeight: 'bold',
-                    color: '#D55E00',
+                    color: '#C475FD',
                     textOutline: '3px {PAGE_BG}'
                 }},
                 y: -50
@@ -400,7 +400,7 @@ html_cdn = f"""<!DOCTYPE html>
                 var arrowData = arrowPoints.map(function(pt) {{
                     return {{
                         lat: pt.lat, lon: pt.lon,
-                        marker: {{ symbol: 'triangle', radius: 7, fillColor: '#0072B2',
+                        marker: {{ symbol: 'triangle', radius: 7, fillColor: '#4467A3',
                                    lineWidth: 1, lineColor: '#fff', rotation: 90 - pt.angle }}
                     }};
                 }});
@@ -408,7 +408,7 @@ html_cdn = f"""<!DOCTYPE html>
                                zIndex: 16, enableMouseTracking: false, data: arrowData }});
                 series.push({{ type: 'mappoint', name: 'Waypoints', showInLegend: false,
                                zIndex: 15, marker: {{ symbol: 'circle', radius: 4,
-                               fillColor: '#E69F00', lineWidth: 1, lineColor: '#fff' }},
+                               fillColor: '#AE3030', lineWidth: 1, lineColor: '#fff' }},
                                data: waypointData }});
                 series.push({{
                     type: 'mappoint', name: 'Start (0 hrs)', showInLegend: true,
@@ -422,12 +422,12 @@ html_cdn = f"""<!DOCTYPE html>
                 }});
                 series.push({{
                     type: 'mappoint', name: 'End (6 hrs)', showInLegend: true,
-                    color: '#D55E00', zIndex: 20,
-                    marker: {{ symbol: 'square', radius: 9, fillColor: '#D55E00',
+                    color: '#C475FD', zIndex: 20,
+                    marker: {{ symbol: 'square', radius: 9, fillColor: '#C475FD',
                                lineWidth: 2, lineColor: '#fff' }},
                     dataLabels: {{ enabled: true, format: 'END',
                                    style: {{ fontSize: '13px', fontWeight: 'bold',
-                                             color: '#D55E00', textOutline: '2px #fff' }}, y: -22 }},
+                                             color: '#C475FD', textOutline: '2px #fff' }}, y: -22 }},
                     data: [{{ lat: endPoint.lat, lon: endPoint.lon }}]
                 }});
                 Highcharts.mapChart('container', {{

--- a/plots/marimekko-basic/implementations/python/highcharts.py
+++ b/plots/marimekko-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ regions = ["North America", "Europe", "Asia Pacific", "Latin America", "Middle E
 region_sizes = [450, 380, 520, 180, 120]  # Market size in millions USD
 
 products = ["Enterprise", "SMB", "Consumer", "Government"]
-colors = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]  # Okabe-Ito positions 1-4
+colors = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]  # Okabe-Ito positions 1-4
 
 market_share = {
     "North America": [42, 28, 22, 8],

--- a/plots/maze-circular/implementations/python/highcharts.py
+++ b/plots/maze-circular/implementations/python/highcharts.py
@@ -204,7 +204,7 @@ arrow_stem_path = [[arrow_base_x, arrow_base_y], [arrow_tip_x, arrow_tip_y]]
 # Bold yellow arrow with dark outline for contrast on both themes
 for path in [arrow_left_path, arrow_right_path, arrow_stem_path]:
     series_data.append(
-        {"type": "line", "data": path, "color": "#E69F00", "lineWidth": 22, "marker": {"enabled": False}}
+        {"type": "line", "data": path, "color": "#AE3030", "lineWidth": 22, "marker": {"enabled": False}}
     )
     series_data.append(
         {"type": "line", "data": path, "color": wall_color, "lineWidth": 6, "marker": {"enabled": False}}

--- a/plots/mosaic-categorical/implementations/python/highcharts.py
+++ b/plots/mosaic-categorical/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-PALETTE = ["#009E73", "#D55E00", "#0072B2"]
+PALETTE = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data — Physical activity level by age group (population health survey)
 np.random.seed(42)

--- a/plots/network-basic/implementations/python/highcharts.py
+++ b/plots/network-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette positions 1–4 for the four communities
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: A small social network with 20 people in 4 communities
 nodes = [
@@ -112,7 +112,7 @@ group_indices = {0: 0, 1: 0, 2: 0, 3: 0}
 for node in nodes:
     node_id = node["id"]
     group = node["group"]
-    color = OKABE_ITO[group]
+    color = IMPRINT[group]
     radius = 65 + degrees[node_id] * 8
     center_x, center_y = group_centers[group]
     idx = group_indices[group]
@@ -194,7 +194,7 @@ chart.options.legend = {
 }
 chart.add_series(series)
 
-for color, name in zip(OKABE_ITO, group_names, strict=True):
+for color, name in zip(IMPRINT, group_names, strict=True):
     legend_series = ScatterSeries()
     legend_series.name = name
     legend_series.color = color

--- a/plots/network-bipartite/implementations/python/highcharts.py
+++ b/plots/network-bipartite/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 COLOR_A = "#009E73"  # Students — Okabe-Ito position 1
-COLOR_B = "#0072B2"  # Courses — Okabe-Ito position 3
+COLOR_B = "#4467A3"  # Courses — Okabe-Ito position 3
 EDGE_COLOR = "rgba(74,74,68,0.22)" if THEME == "light" else "rgba(184,183,176,0.25)"
 
 # Data — student course enrollment network

--- a/plots/network-directed/implementations/python/highcharts.py
+++ b/plots/network-directed/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first position for nodes, others for edge variants if needed)
 BRAND = "#009E73"  # First series, always
-SECONDARY = "#D55E00"  # For arrow highlights if multi-directional
+SECONDARY = "#C475FD"  # For arrow highlights if multi-directional
 
 # Data - Software module dependencies showing import direction
 nodes = [

--- a/plots/network-force-directed/implementations/python/highcharts.py
+++ b/plots/network-force-directed/implementations/python/highcharts.py
@@ -36,7 +36,7 @@ communities = {
 }
 
 # Community colors — Okabe-Ito positions 1-4
-community_colors = {"Tech": "#009E73", "Marketing": "#D55E00", "Finance": "#0072B2", "Design": "#CC79A7"}
+community_colors = {"Tech": "#009E73", "Marketing": "#C475FD", "Finance": "#4467A3", "Design": "#BD8233"}
 
 # Build nodes with community info
 nodes = []
@@ -119,9 +119,9 @@ Highcharts.chart('container', {{
         text: '<span style="font-size:32px;color:{INK_SOFT};">Communication ties across four departments — dense within, sparse between</span><br/>'
             + '<span style="font-size:30px;">'
             + '<span style="color:#009E73;">&#9679;</span> <span style="color:{INK};">Tech</span> &nbsp;&nbsp;&nbsp;'
-            + '<span style="color:#D55E00;">&#9679;</span> <span style="color:{INK};">Marketing</span> &nbsp;&nbsp;&nbsp;'
-            + '<span style="color:#0072B2;">&#9679;</span> <span style="color:{INK};">Finance</span> &nbsp;&nbsp;&nbsp;'
-            + '<span style="color:#CC79A7;">&#9679;</span> <span style="color:{INK};">Design</span>'
+            + '<span style="color:#C475FD;">&#9679;</span> <span style="color:{INK};">Marketing</span> &nbsp;&nbsp;&nbsp;'
+            + '<span style="color:#4467A3;">&#9679;</span> <span style="color:{INK};">Finance</span> &nbsp;&nbsp;&nbsp;'
+            + '<span style="color:#BD8233;">&#9679;</span> <span style="color:{INK};">Design</span>'
             + '</span>',
         style: {{fontSize: '32px', color: '{INK_SOFT}'}}
     }},

--- a/plots/network-hierarchical/implementations/python/highcharts.py
+++ b/plots/network-hierarchical/implementations/python/highcharts.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Build hierarchical data using Sankey diagram (alternative to organization chart)
 # Nodes for each level
@@ -44,23 +44,23 @@ managers = {
 
 # Build nodes list with colors by level
 nodes_list = [ceo]
-node_colors = [OKABE_ITO[0]]  # CEO is level 0
+node_colors = [IMPRINT[0]]  # CEO is level 0
 
 for vp in vps:
     nodes_list.append(vp)
-    node_colors.append(OKABE_ITO[1])
+    node_colors.append(IMPRINT[1])
 
 for vp in vps:
     for director in directors[vp]:
         if director not in nodes_list:
             nodes_list.append(director)
-            node_colors.append(OKABE_ITO[2])
+            node_colors.append(IMPRINT[2])
 
 for directors_group in managers.values():
     for mgr in directors_group:
         if mgr not in nodes_list:
             nodes_list.append(mgr)
-            node_colors.append(OKABE_ITO[3])
+            node_colors.append(IMPRINT[3])
 
 # Build links (from-to pairs with equal weight)
 links_list = []

--- a/plots/network-transport-static/implementations/python/highcharts.py
+++ b/plots/network-transport-static/implementations/python/highcharts.py
@@ -151,9 +151,9 @@ station_lookup = {s["id"]: s for s in stations}
 
 # Route type colors - Okabe-Ito palette: first series brand green, then orange, blue, purple
 route_colors = {
-    "EX": "#0072B2",  # Express - Okabe-Ito blue
-    "RE": "#D55E00",  # Regional - Okabe-Ito orange
-    "LC": "#CC79A7",  # Local - Okabe-Ito reddish purple
+    "EX": "#4467A3",  # Express - Okabe-Ito blue
+    "RE": "#C475FD",  # Regional - Okabe-Ito orange
+    "LC": "#BD8233",  # Local - Okabe-Ito reddish purple
 }
 
 # Build series data for routes
@@ -186,7 +186,7 @@ for route in routes:
     ty = target["y"] + perp_y
 
     route_prefix = route["route_id"].split()[0]
-    color = route_colors.get(route_prefix, "#E69F00")
+    color = route_colors.get(route_prefix, "#AE3030")
     label_text = f"{route['route_id']} | {route['departure_time']} → {route['arrival_time']}"
 
     route_series_list.append(
@@ -264,10 +264,10 @@ for route in routes:
     mid_y = (sy + ty) / 2
 
     route_prefix = route["route_id"].split()[0]
-    color = route_colors.get(route_prefix, "#E69F00")
+    color = route_colors.get(route_prefix, "#AE3030")
 
     # Determine text color based on background brightness
-    text_color = "#1A1A17" if color not in ["#0072B2"] else "#FFFDF6"
+    text_color = "#1A1A17" if color not in ["#4467A3"] else "#FFFDF6"
 
     label_text = f"{route['route_id']} | {route['departure_time']} → {route['arrival_time']}"
 
@@ -347,7 +347,7 @@ chart_options = {
         "style": {"fontSize": "28px", "fontWeight": "medium", "color": INK},
     },
     "subtitle": {
-        "text": 'Regional Rail Network - 12 Stations, 19 Routes<br/><span style="font-size:20px;"><span style="color:#0072B2;">■</span> Express (EX) &nbsp;&nbsp;&nbsp; <span style="color:#D55E00;">■</span> Regional (RE) &nbsp;&nbsp;&nbsp; <span style="color:#CC79A7;">■</span> Local (LC)</span>',
+        "text": 'Regional Rail Network - 12 Stations, 19 Routes<br/><span style="font-size:20px;"><span style="color:#4467A3;">■</span> Express (EX) &nbsp;&nbsp;&nbsp; <span style="color:#C475FD;">■</span> Regional (RE) &nbsp;&nbsp;&nbsp; <span style="color:#BD8233;">■</span> Local (LC)</span>',
         "useHTML": True,
         "style": {"fontSize": "22px", "color": INK_SOFT},
     },

--- a/plots/network-weighted/implementations/python/highcharts.py
+++ b/plots/network-weighted/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Research collaboration network between university departments
 np.random.seed(42)
@@ -85,7 +85,7 @@ nodes_data = []
 for i, dept in enumerate(departments):
     deg = weighted_degree[dept["id"]]
     marker_size = 50 + 70 * (deg - min_degree) / (max_degree - min_degree)
-    color = OKABE_ITO[i % len(OKABE_ITO)]
+    color = IMPRINT[i % len(IMPRINT)]
     nodes_data.append({"id": dept["id"], "name": dept["name"], "marker": {"radius": int(marker_size)}, "color": color})
 
 # Create links with width based on weight
@@ -151,7 +151,7 @@ html_content = f"""<!DOCTYPE html>
             height: 0;
             margin-right: 20px;
             border-top-style: solid;
-            border-top-color: {OKABE_ITO[0]};
+            border-top-color: {IMPRINT[0]};
         }}
         .legend-line.thin {{ width: 80px; border-top-width: 4px; }}
         .legend-line.medium {{ width: 80px; border-top-width: 14px; }}

--- a/plots/ohlc-bar/implementations/python/highcharts.py
+++ b/plots/ohlc-bar/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Semantic exception: finance — green=bullish/up, red=bearish/down (anyplot positions 1 and 3)
 UP_COLOR = "#009E73"
-DOWN_COLOR = "#B71D27"
+DOWN_COLOR = "#AE3030"
 
 # Data — 50 trading days of simulated stock prices
 np.random.seed(42)

--- a/plots/parallel-basic/implementations/python/highcharts.py
+++ b/plots/parallel-basic/implementations/python/highcharts.py
@@ -67,9 +67,9 @@ series_config = []
 for i, row in enumerate(setosa_data):
     series_config.append({"name": "Setosa", "data": row, "color": "rgba(0,158,115,0.65)", "showInLegend": i == 0})
 for i, row in enumerate(versicolor_data):
-    series_config.append({"name": "Versicolor", "data": row, "color": "rgba(213,94,0,0.65)", "showInLegend": i == 0})
+    series_config.append({"name": "Versicolor", "data": row, "color": "rgba(196, 117, 253, 0.65)", "showInLegend": i == 0})
 for i, row in enumerate(virginica_data):
-    series_config.append({"name": "Virginica", "data": row, "color": "rgba(0,114,178,0.65)", "showInLegend": i == 0})
+    series_config.append({"name": "Virginica", "data": row, "color": "rgba(68, 103, 163, 0.65)", "showInLegend": i == 0})
 
 # Load Highcharts modules from local npm install (CDN blocked in headless Chrome on file://)
 hc_base = Path("/tmp/hc/node_modules/highcharts")

--- a/plots/parallel-categories-basic/implementations/python/highcharts.py
+++ b/plots/parallel-categories-basic/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Titanic survival by Class → Sex → Age Group → Survival
 flows = [
@@ -175,17 +175,17 @@ column_map = {
 node_colors = {}
 for node in display_names:
     if "Survived" in node:
-        node_colors[node] = OKABE_ITO[0]  # green
+        node_colors[node] = IMPRINT[0]  # green
     elif "Died" in node:
-        node_colors[node] = OKABE_ITO[1]  # orange
+        node_colors[node] = IMPRINT[1]  # orange
     elif node.startswith("1st") or node.startswith("2nd") or node.startswith("3rd"):
-        node_colors[node] = OKABE_ITO[2]  # blue
+        node_colors[node] = IMPRINT[2]  # blue
     elif display_names[node] == "Male":
-        node_colors[node] = OKABE_ITO[3]  # purple
+        node_colors[node] = IMPRINT[3]  # purple
     elif display_names[node] == "Female":
-        node_colors[node] = OKABE_ITO[4]  # yellow-ish
+        node_colors[node] = IMPRINT[4]  # yellow-ish
     else:
-        node_colors[node] = OKABE_ITO[5]  # sky blue
+        node_colors[node] = IMPRINT[5]  # sky blue
 
 # Build nodes list
 nodes_set = set()
@@ -198,7 +198,7 @@ nodes_data = [
         "id": node,
         "name": display_names.get(node, node),
         "column": column_map.get(node, 0),
-        "color": node_colors.get(node, OKABE_ITO[0]),
+        "color": node_colors.get(node, IMPRINT[0]),
     }
     for node in nodes_set
 ]

--- a/plots/parliament-basic/implementations/python/highcharts.py
+++ b/plots/parliament-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Legislative assembly with 6 parties (neutral context, no real politics)
 parties = [
@@ -146,7 +146,7 @@ chart.options.tooltip = {
 }
 
 # Set color palette
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Add a series for each party
 for idx, party in enumerate(parties):
@@ -156,7 +156,7 @@ for idx, party in enumerate(parties):
     series = ScatterSeries()
     series.name = f"{party['name']} ({party['seats']} seats)"
     series.data = party_seats
-    series.color = OKABE_ITO[idx % len(OKABE_ITO)]
+    series.color = IMPRINT[idx % len(IMPRINT)]
     series.marker = {"radius": 8, "symbol": "circle", "lineWidth": 1, "lineColor": PAGE_BG}
 
     chart.add_series(series)

--- a/plots/phase-diagram/implementations/python/highcharts.py
+++ b/plots/phase-diagram/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Damped harmonic oscillator: d²x/dt² + 2*gamma*dx/dt + omega²*x = 0
 np.random.seed(42)
@@ -116,7 +116,7 @@ chart.options.legend = {
     "padding": 15,
 }
 
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 chart.options.credits = {"enabled": False}
 
@@ -125,7 +125,7 @@ for i, (x, dx_dt) in enumerate(trajectories):
     series = ScatterSeries()
     series.data = [{"x": float(xi), "y": float(dxi)} for xi, dxi in zip(x, dx_dt, strict=False)]
     series.name = names[i]
-    series.color = OKABE_ITO[i]
+    series.color = IMPRINT[i]
     series.line_width = 2
     series.marker = {"radius": 4, "enabled": True}
     chart.add_series(series)

--- a/plots/pie-drilldown/implementations/python/highcharts.py
+++ b/plots/pie-drilldown/implementations/python/highcharts.py
@@ -23,7 +23,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (position 1 is brand green #009E73, then follow canonical order)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 
 # Download Highcharts JS and drilldown module (required for headless Chrome)
@@ -75,7 +75,7 @@ Highcharts.chart('container', {{
             color: '{INK_SOFT}'
         }}
     }},
-    colors: {OKABE_ITO},
+    colors: {IMPRINT},
     accessibility: {{
         announceNewData: {{
             enabled: true

--- a/plots/point-and-figure-basic/implementations/python/highcharts.py
+++ b/plots/point-and-figure-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BULL = "#009E73"  # Okabe-Ito position 1 — X (Rising, bullish)
-BEAR = "#D55E00"  # Okabe-Ito position 2 — O (Falling, bearish)
+BEAR = "#AE3030"  # imprint red — O (Falling, bearish)
 
 # Data - Generate realistic stock price with multiple market phases
 np.random.seed(42)

--- a/plots/point-basic/implementations/python/highcharts.py
+++ b/plots/point-basic/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series - always
-CI_COLOR = "#D55E00"  # Second series - confidence interval
+CI_COLOR = "#C475FD"  # Second series - confidence interval
 
 # Data - Performance metrics by department with confidence intervals
 np.random.seed(42)

--- a/plots/polar-bar/implementations/python/highcharts.py
+++ b/plots/polar-bar/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Wind direction frequency by speed category
 np.random.seed(42)
@@ -128,10 +128,10 @@ chart.options.plot_options = {
 
 # Add series with Okabe-Ito colors
 series_data = [
-    {"name": "Calm (<1 mph)", "data": calm, "color": OKABE_ITO[0]},
-    {"name": "Light (1-10 mph)", "data": light, "color": OKABE_ITO[1]},
-    {"name": "Moderate (10-20 mph)", "data": moderate, "color": OKABE_ITO[2]},
-    {"name": "Strong (>20 mph)", "data": strong, "color": OKABE_ITO[3]},
+    {"name": "Calm (<1 mph)", "data": calm, "color": IMPRINT[0]},
+    {"name": "Light (1-10 mph)", "data": light, "color": IMPRINT[1]},
+    {"name": "Moderate (10-20 mph)", "data": moderate, "color": IMPRINT[2]},
+    {"name": "Strong (>20 mph)", "data": strong, "color": IMPRINT[3]},
 ]
 
 chart.options.series = series_data

--- a/plots/polar-basic/implementations/python/highcharts.py
+++ b/plots/polar-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.12)" if THEME == "light" else "rgba(240,239,232,0.12)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-PEAK_COLOR = "#D55E00"  # Okabe-Ito position 2 - peak highlight
+PEAK_COLOR = "#C475FD"  # Okabe-Ito position 2 - peak highlight
 
 # Data - 24-hour temperature cycle
 np.random.seed(42)

--- a/plots/polar-line/implementations/python/highcharts.py
+++ b/plots/polar-line/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Monthly temperature pattern (cyclical, degrees around year)
 months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
@@ -95,8 +95,8 @@ chart.options.legend = {
 
 # Add series data with Okabe-Ito colors
 chart.options.series = [
-    {"type": "line", "name": "Continental City", "data": city_a, "color": OKABE_ITO[0], "marker": {"symbol": "circle"}},
-    {"type": "line", "name": "Oceanic City", "data": city_b, "color": OKABE_ITO[1], "marker": {"symbol": "diamond"}},
+    {"type": "line", "name": "Continental City", "data": city_a, "color": IMPRINT[0], "marker": {"symbol": "circle"}},
+    {"type": "line", "name": "Oceanic City", "data": city_b, "color": IMPRINT[1], "marker": {"symbol": "diamond"}},
 ]
 
 # Download Highcharts JS and Highcharts More for polar charts

--- a/plots/polar-scatter/implementations/python/highcharts.py
+++ b/plots/polar-scatter/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Wind measurements with prevailing directions
 np.random.seed(42)
@@ -62,9 +62,9 @@ speeds = np.array(speeds)
 
 # Colors for categories using Okabe-Ito palette
 colors = {
-    "Morning": OKABE_ITO[0],  # #009E73
-    "Afternoon": OKABE_ITO[1],  # #D55E00
-    "Evening": OKABE_ITO[2],  # #0072B2
+    "Morning": IMPRINT[0],  # #009E73
+    "Afternoon": IMPRINT[1],  # #C475FD
+    "Evening": IMPRINT[2],  # #4467A3
 }
 
 # Build series data for each category

--- a/plots/precision-recall/implementations/python/highcharts.py
+++ b/plots/precision-recall/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series (primary)
-SECONDARY = "#F0E442"  # Baseline reference
+SECONDARY = "#954477"  # Baseline reference
 
 # Data - simulate binary classification results
 np.random.seed(42)

--- a/plots/pyramid-basic/implementations/python/highcharts.py
+++ b/plots/pyramid-basic/implementations/python/highcharts.py
@@ -111,7 +111,7 @@ chart_options = {
         {
             "name": "Female",
             "data": female_values,
-            "color": "#D55E00",  # Okabe-Ito position 2
+            "color": "#C475FD",  # Okabe-Ito position 2
         },
     ],
     "credits": {"enabled": False},

--- a/plots/qq-basic/implementations/python/highcharts.py
+++ b/plots/qq-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 # Warm accent for tail-deviation bands — Okabe-Ito orange, theme-adaptive opacity
-BAND_COLOR = "rgba(213,94,0,0.12)" if THEME == "light" else "rgba(230,159,0,0.22)"
+BAND_COLOR = "rgba(196, 117, 253, 0.12)" if THEME == "light" else "rgba(174, 48, 48, 0.22)"
 
 # Data - mixed normal to demonstrate Q-Q characteristics (slight right skew)
 np.random.seed(42)

--- a/plots/radar-basic/implementations/python/highcharts.py
+++ b/plots/radar-basic/implementations/python/highcharts.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Employee performance metrics comparison
 categories = ["Communication", "Technical Skills", "Teamwork", "Problem Solving", "Leadership", "Creativity"]
@@ -67,8 +67,8 @@ chart_config = {
         "backgroundColor": ELEVATED_BG,
     },
     "series": [
-        {"type": "area", "name": "Employee A", "data": employee_a_values, "color": OKABE_ITO[0], "fillOpacity": 0.25},
-        {"type": "area", "name": "Employee B", "data": employee_b_values, "color": OKABE_ITO[1], "fillOpacity": 0.25},
+        {"type": "area", "name": "Employee A", "data": employee_a_values, "color": IMPRINT[0], "fillOpacity": 0.25},
+        {"type": "area", "name": "Employee B", "data": employee_b_values, "color": IMPRINT[1], "fillOpacity": 0.25},
     ],
     "credits": {"enabled": False},
 }

--- a/plots/radar-multi/implementations/python/highcharts.py
+++ b/plots/radar-multi/implementations/python/highcharts.py
@@ -44,7 +44,7 @@ product_c = [60, 70, 65, 70, 65, 75]
 product_d = [45, 85, 80, 75, 100, 40]
 
 # Okabe-Ito palette - first series always #009E73
-colors = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+colors = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Create chart
 chart = Chart(container="container")

--- a/plots/renko-basic/implementations/python/highcharts.py
+++ b/plots/renko-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Bullish (position 1)
-BEARISH = "#D55E00"  # Bearish (position 2)
+BEARISH = "#AE3030"  # imprint red — bearish
 
 # Data - Generate synthetic stock price data
 np.random.seed(42)

--- a/plots/residual-plot/implementations/python/highcharts.py
+++ b/plots/residual-plot/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # bluish green — ALWAYS first series
-ACCENT_1 = "#D55E00"  # vermillion
+ACCENT_1 = "#C475FD"  # vermillion
 
 # Data: Linear regression example with housing price predictions
 np.random.seed(42)

--- a/plots/sankey-basic/implementations/python/highcharts.py
+++ b/plots/sankey-basic/implementations/python/highcharts.py
@@ -42,19 +42,19 @@ flows = [
 ]
 
 # Node colors - Okabe-Ito palette (canonical order for source nodes)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 node_colors = {
-    "Coal": OKABE_ITO[0],
-    "Natural Gas": OKABE_ITO[1],
-    "Nuclear": OKABE_ITO[2],
-    "Petroleum": OKABE_ITO[3],
-    "Renewable": OKABE_ITO[4],
-    "Electricity": OKABE_ITO[5],
-    "Transportation": OKABE_ITO[6],
-    "Industrial": OKABE_ITO[0],
-    "Residential": OKABE_ITO[1],
-    "Commercial": OKABE_ITO[2],
+    "Coal": IMPRINT[0],
+    "Natural Gas": IMPRINT[1],
+    "Nuclear": IMPRINT[2],
+    "Petroleum": IMPRINT[3],
+    "Renewable": IMPRINT[4],
+    "Electricity": IMPRINT[5],
+    "Transportation": IMPRINT[6],
+    "Industrial": IMPRINT[0],
+    "Residential": IMPRINT[1],
+    "Commercial": IMPRINT[2],
 }
 
 nodes_set = set()
@@ -62,7 +62,7 @@ for source, target, _ in flows:
     nodes_set.add(source)
     nodes_set.add(target)
 
-nodes_data = [{"id": node, "name": node, "color": node_colors.get(node, OKABE_ITO[0])} for node in nodes_set]
+nodes_data = [{"id": node, "name": node, "color": node_colors.get(node, IMPRINT[0])} for node in nodes_set]
 links_data = [{"from": source, "to": target, "weight": value} for source, target, value in flows]
 
 # Chart

--- a/plots/scatter-3d/implementations/python/highcharts.py
+++ b/plots/scatter-3d/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - 3D clustered data demonstrating spatial relationships
 np.random.seed(42)
@@ -93,21 +93,21 @@ series_data = [
         "type": "scatter3d",
         "name": "Cluster A",
         "data": cluster1_data,
-        "color": OKABE_ITO[0],  # Green
+        "color": IMPRINT[0],  # Green
         "marker": {"radius": 14, "symbol": "circle"},
     },
     {
         "type": "scatter3d",
         "name": "Cluster B",
         "data": cluster2_data,
-        "color": OKABE_ITO[1],  # Orange
+        "color": IMPRINT[1],  # Orange
         "marker": {"radius": 14, "symbol": "circle"},
     },
     {
         "type": "scatter3d",
         "name": "Cluster C",
         "data": cluster3_data,
-        "color": OKABE_ITO[2],  # Blue
+        "color": IMPRINT[2],  # Blue
         "marker": {"radius": 14, "symbol": "circle"},
     },
 ]

--- a/plots/scatter-animated-controls/implementations/python/highcharts.py
+++ b/plots/scatter-animated-controls/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Simulated country data over 20 years (Gapminder-style)
 np.random.seed(42)
@@ -62,7 +62,7 @@ countries = [
 # Region assignment for color coding
 regions = ["Region 1", "Region 2", "Region 3", "Region 4"]
 country_regions = [regions[i % 4] for i in range(n_countries)]
-region_colors = {regions[i]: OKABE_ITO[i % len(OKABE_ITO)] for i in range(len(regions))}
+region_colors = {regions[i]: IMPRINT[i % len(IMPRINT)] for i in range(len(regions))}
 
 # Generate time-series data for each country
 # GDP per capita (x): starts between 1000-50000, grows with some noise

--- a/plots/scatter-brush-zoom/implementations/python/highcharts.py
+++ b/plots/scatter-brush-zoom/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is always position 1)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Generate multi-cluster dataset for demonstrating brush selection
 np.random.seed(42)
@@ -39,22 +39,22 @@ clusters = []
 # Cluster 1: Lower-left (Batch A) - Okabe-Ito position 1 (brand green)
 x1 = np.random.normal(25, 6, n_per_cluster)
 y1 = np.random.normal(30, 7, n_per_cluster)
-clusters.append(("Batch A", x1, y1, OKABE_ITO[0]))
+clusters.append(("Batch A", x1, y1, IMPRINT[0]))
 
 # Cluster 2: Upper-right (Batch B) - Okabe-Ito position 2 (vermillion)
 x2 = np.random.normal(75, 8, n_per_cluster)
 y2 = np.random.normal(80, 6, n_per_cluster)
-clusters.append(("Batch B", x2, y2, OKABE_ITO[1]))
+clusters.append(("Batch B", x2, y2, IMPRINT[1]))
 
 # Cluster 3: Center (Batch C) - Okabe-Ito position 3 (blue)
 x3 = np.random.normal(50, 10, n_per_cluster)
 y3 = np.random.normal(50, 10, n_per_cluster)
-clusters.append(("Batch C", x3, y3, OKABE_ITO[2]))
+clusters.append(("Batch C", x3, y3, IMPRINT[2]))
 
 # Cluster 4: Upper-left (Batch D) - Okabe-Ito position 4 (reddish purple)
 x4 = np.random.normal(20, 5, n_per_cluster)
 y4 = np.random.normal(75, 6, n_per_cluster)
-clusters.append(("Batch D", x4, y4, OKABE_ITO[3]))
+clusters.append(("Batch D", x4, y4, IMPRINT[3]))
 
 # Create chart with container
 chart = Chart(container="container")
@@ -73,8 +73,8 @@ chart.options.chart = {
     "resetZoomButton": {
         "position": {"align": "right", "verticalAlign": "top", "x": -60, "y": 30},
         "theme": {
-            "fill": OKABE_ITO[0],
-            "stroke": OKABE_ITO[0],
+            "fill": IMPRINT[0],
+            "stroke": IMPRINT[0],
             "style": {"color": PAGE_BG, "fontSize": "22px", "fontWeight": "bold"},
             "r": 10,
             "padding": 16,

--- a/plots/scatter-categorical/implementations/python/highcharts.py
+++ b/plots/scatter-categorical/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Plant growth study with three fertilizer types
 np.random.seed(42)
@@ -61,11 +61,11 @@ for i, category in enumerate(categories):
         {
             "name": category,
             "data": data_by_category[category],
-            "color": OKABE_ITO[i],
+            "color": IMPRINT[i],
             "type": "scatter",
             "marker": {
                 "radius": 8,
-                "fillColor": OKABE_ITO[i],
+                "fillColor": IMPRINT[i],
                 "lineWidth": 2,
                 "lineColor": PAGE_BG,
                 "fillOpacity": 0.8,

--- a/plots/scatter-embedding/implementations/python/highcharts.py
+++ b/plots/scatter-embedding/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data — simulate scRNA-seq cell types, project to 2D via t-SNE
 np.random.seed(42)
@@ -140,7 +140,7 @@ chart.options.plot_options = {
 }
 
 # One series per immune cell type
-for i, (label, color) in enumerate(zip(cell_types, OKABE_ITO, strict=True)):
+for i, (label, color) in enumerate(zip(cell_types, IMPRINT, strict=True)):
     series = ScatterSeries()
     series.name = label
     series.color = color

--- a/plots/scatter-map-geographic/implementations/python/highcharts.py
+++ b/plots/scatter-map-geographic/implementations/python/highcharts.py
@@ -25,14 +25,14 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for region colors
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # 1: brand green
-    "#D55E00",  # 2: vermillion
-    "#0072B2",  # 3: blue
-    "#CC79A7",  # 4: reddish purple
-    "#E69F00",  # 5: orange
-    "#56B4E9",  # 6: sky blue
-    "#F0E442",  # 7: yellow
+    "#C475FD",  # 2: vermillion
+    "#4467A3",  # 3: blue
+    "#BD8233",  # 4: reddish purple
+    "#AE3030",  # 5: orange
+    "#2ABCCD",  # 6: sky blue
+    "#954477",  # 7: yellow
 ]
 
 # Data - Major earthquake epicenters (synthetic but realistic data)
@@ -84,7 +84,7 @@ earthquakes = [
 
 # Assign colors by region using Okabe-Ito palette (first 7 regions)
 region_list = ["Japan", "South America", "Indonesia", "North America", "Mediterranean", "Asia", "Pacific", "Caribbean"]
-region_colors = {region: OKABE_ITO[i % len(OKABE_ITO)] for i, region in enumerate(region_list)}
+region_colors = {region: IMPRINT[i % len(IMPRINT)] for i, region in enumerate(region_list)}
 
 # Prepare data for mapbubble series - group by region
 regions_data = {}
@@ -105,7 +105,7 @@ for region, data in regions_data.items():
             "type": "mapbubble",
             "name": region,
             "data": data,
-            "color": region_colors.get(region, OKABE_ITO[0]),
+            "color": region_colors.get(region, IMPRINT[0]),
             "marker": {"fillOpacity": 0.7, "lineWidth": 2, "lineColor": PAGE_BG},
             "minSize": 20,
             "maxSize": 100,

--- a/plots/scatter-matrix-interactive/implementations/python/highcharts.py
+++ b/plots/scatter-matrix-interactive/implementations/python/highcharts.py
@@ -27,8 +27,8 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first color is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
-COLORS = OKABE_ITO[:3]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
+COLORS = IMPRINT[:3]
 
 # Data - Iris dataset (4 variables for a 4x4 matrix)
 iris = load_iris()

--- a/plots/scatter-matrix/implementations/python/highcharts.py
+++ b/plots/scatter-matrix/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for 3 categories
-COLORS = ["#009E73", "#D55E00", "#0072B2"]
+COLORS = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris dataset (classic multivariate example)
 np.random.seed(42)

--- a/plots/scatter-regression-linear/implementations/python/highcharts.py
+++ b/plots/scatter-regression-linear/implementations/python/highcharts.py
@@ -28,13 +28,13 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # Brand green (primary)
-    "#D55E00",  # Vermillion
-    "#0072B2",  # Blue
-    "#CC79A7",  # Reddish purple
-    "#E69F00",  # Orange
-    "#56B4E9",  # Sky blue
+    "#C475FD",  # Vermillion
+    "#4467A3",  # Blue
+    "#BD8233",  # Reddish purple
+    "#AE3030",  # Orange
+    "#2ABCCD",  # Sky blue
 ]
 
 # Data: Advertising spend vs sales revenue
@@ -148,7 +148,7 @@ line_data = [[float(x_sorted[i]), float(y_fit[i])] for i in range(len(x_sorted))
 line_series = LineSeries()
 line_series.data = line_data
 line_series.name = "Regression Line"
-line_series.color = OKABE_ITO[2]  # Blue
+line_series.color = IMPRINT[2]  # Blue
 chart.add_series(line_series)
 
 # Series 3: Scatter points (using brand green)
@@ -156,11 +156,11 @@ scatter_data = [[float(x[i]), float(y[i])] for i in range(n_points)]
 scatter_series = ScatterSeries()
 scatter_series.data = scatter_data
 scatter_series.name = "Data Points"
-scatter_series.color = OKABE_ITO[0]  # Brand green
+scatter_series.color = IMPRINT[0]  # Brand green
 chart.add_series(scatter_series)
 
 # Set colors for the chart
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Credits
 chart.options.credits = {"enabled": False}

--- a/plots/scatter-regression-lowess/implementations/python/highcharts.py
+++ b/plots/scatter-regression-lowess/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2 for LOWESS curve
+ACCENT = "#C475FD"  # Okabe-Ito position 2 for LOWESS curve
 
 
 def lowess(x, y, frac=0.3):

--- a/plots/scatter-regression-polynomial/implementations/python/highcharts.py
+++ b/plots/scatter-regression-polynomial/implementations/python/highcharts.py
@@ -138,7 +138,7 @@ scatter_series.opacity = 0.65
 regression_series = SplineSeries()
 regression_series.data = [[float(xi), float(yi)] for xi, yi in zip(x_fit, y_fit, strict=True)]
 regression_series.name = f"Polynomial Fit (R² = {r_squared:.3f})"
-regression_series.color = "#D55E00"
+regression_series.color = "#C475FD"
 regression_series.lineWidth = 3
 regression_series.marker = {"enabled": False}
 
@@ -147,7 +147,7 @@ chart.add_series(scatter_series)
 chart.add_series(regression_series)
 
 # Color palette
-chart.options.colors = [BRAND, "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+chart.options.colors = [BRAND, "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Download Highcharts JS from alternative CDN
 highcharts_urls = [

--- a/plots/scatter-text/implementations/python/highcharts.py
+++ b/plots/scatter-text/implementations/python/highcharts.py
@@ -28,11 +28,11 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # position 1 (brand green - ALWAYS first series)
-    "#D55E00",  # position 2
-    "#0072B2",  # position 3
-    "#CC79A7",  # position 4
+    "#C475FD",  # position 2
+    "#4467A3",  # position 3
+    "#BD8233",  # position 4
 ]
 
 # Data - Simulated word embeddings after dimensionality reduction
@@ -131,10 +131,10 @@ chart.options.legend = {
 
 # Create data with text labels
 categories = {
-    "Programming Languages": (programming_words, OKABE_ITO[0], 0),
-    "Data Science": (data_words, OKABE_ITO[1], len(programming_words)),
-    "Web Frameworks": (web_words, OKABE_ITO[2], len(programming_words) + len(data_words)),
-    "Databases": (database_words, OKABE_ITO[3], len(programming_words) + len(data_words) + len(web_words)),
+    "Programming Languages": (programming_words, IMPRINT[0], 0),
+    "Data Science": (data_words, IMPRINT[1], len(programming_words)),
+    "Web Frameworks": (web_words, IMPRINT[2], len(programming_words) + len(data_words)),
+    "Databases": (database_words, IMPRINT[3], len(programming_words) + len(data_words) + len(web_words)),
 }
 
 for cat_name, (words, color, start_idx) in categories.items():

--- a/plots/shap-waterfall/implementations/python/highcharts.py
+++ b/plots/shap-waterfall/implementations/python/highcharts.py
@@ -24,8 +24,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito pos 1 — baseline & prediction bars
-POSITIVE_COLOR = "#D55E00"  # Okabe-Ito pos 2 — positive SHAP (pushes risk up)
-NEGATIVE_COLOR = "#0072B2"  # Okabe-Ito pos 3 — negative SHAP (pushes risk down)
+POSITIVE_COLOR = "#AE3030"  # imprint red — positive SHAP (pushes risk up)
+NEGATIVE_COLOR = "#4467A3"  # Okabe-Ito pos 3 — negative SHAP (pushes risk down)
 
 # Data — credit scoring model explaining a single loan application
 # Features sorted by absolute SHAP value (largest contribution first = top of chart)

--- a/plots/silhouette-basic/implementations/python/highcharts.py
+++ b/plots/silhouette-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for clusters
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Simulated silhouette scores for 3-cluster solution
 np.random.seed(42)
@@ -114,7 +114,7 @@ chart.options.x_axis = {
         {
             "from": 0 if i == 0 else cluster_boundaries[i - 1] + 0.5,
             "to": cluster_boundaries[i] + 0.5,
-            "color": f"rgba({int(OKABE_ITO[i][1:3], 16)}, {int(OKABE_ITO[i][3:5], 16)}, {int(OKABE_ITO[i][5:7], 16)}, 0.08)",
+            "color": f"rgba({int(IMPRINT[i][1:3], 16)}, {int(IMPRINT[i][3:5], 16)}, {int(IMPRINT[i][5:7], 16)}, 0.08)",
             "label": {
                 "text": f"Cluster {i}<br>Avg: {np.mean(cluster_data[i]):.3f}",
                 "style": {"fontSize": "20px", "color": INK},
@@ -193,7 +193,7 @@ for cluster_id in range(n_clusters):
     series = BarSeries()
     series.name = f"Cluster {cluster_id} (n={len(cluster_data[cluster_id])})"
     series.data = all_series_data[cluster_id]
-    series.color = OKABE_ITO[cluster_id]
+    series.color = IMPRINT[cluster_id]
     chart.add_series(series)
 
 # Export to PNG via Selenium

--- a/plots/skewt-logp-atmospheric/implementations/python/highcharts.py
+++ b/plots/skewt-logp-atmospheric/implementations/python/highcharts.py
@@ -29,10 +29,10 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
 TEMP_COLOR = "#009E73"  # green — temperature profile (first/primary)
-DEW_COLOR = "#D55E00"  # vermillion — dewpoint profile
-DRY_AD_COLOR = "#0072B2"  # blue — dry adiabats
-MOIST_AD_COLOR = "#CC79A7"  # pink — moist adiabats
-MIX_COLOR = "#E69F00"  # orange — mixing ratio lines
+DEW_COLOR = "#C475FD"  # vermillion — dewpoint profile
+DRY_AD_COLOR = "#4467A3"  # blue — dry adiabats
+MOIST_AD_COLOR = "#BD8233"  # pink — moist adiabats
+MIX_COLOR = "#AE3030"  # orange — mixing ratio lines
 
 # Pressure/temperature extents
 TEMP_MIN, TEMP_MAX = -80, 50
@@ -279,7 +279,7 @@ temp_series.marker = {
 temp_series.z_index = 10
 chart.add_series(temp_series)
 
-# 6. Dewpoint profile — #D55E00, dashed thick
+# 6. Dewpoint profile — #C475FD, dashed thick
 x_dew = dewpoint - (1 - yfrac_s) * SKEW_FACTOR
 dew_data = [[float(x), float(p)] for x, p in zip(x_dew, pressure, strict=False)]
 dew_series = LineSeries()

--- a/plots/smith-chart-basic/implementations/python/highcharts.py
+++ b/plots/smith-chart-basic/implementations/python/highcharts.py
@@ -177,7 +177,7 @@ chart.add_series(h_axis_series)
 
 # VSWR circles — Okabe-Ito positions 2, 3, 4
 vswr_values = [1.5, 2.0, 3.0]
-vswr_colors = ["#D55E00", "#0072B2", "#CC79A7"]
+vswr_colors = ["#C475FD", "#4467A3", "#BD8233"]
 for i, vswr in enumerate(vswr_values):
     gm = (vswr - 1) / (vswr + 1)
     v_theta = np.linspace(0, 2 * np.pi, 200)
@@ -200,7 +200,7 @@ match_series.marker = {
     "enabled": True,
     "radius": 16,
     "symbol": "diamond",
-    "fillColor": "#E69F00",
+    "fillColor": "#AE3030",
     "lineColor": INK,
     "lineWidth": 2,
 }

--- a/plots/sn-curve-basic/implementations/python/highcharts.py
+++ b/plots/sn-curve-basic/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito #1 — test data scatter
-FIT_COLOR = "#D55E00"  # Okabe-Ito #2 — Basquin fit line
+FIT_COLOR = "#C475FD"  # Okabe-Ito #2 — Basquin fit line
 
 # Data: Simulated fatigue test results for structural steel specimens
 np.random.seed(42)
@@ -96,7 +96,7 @@ region_bands = [
     {
         "from": 100,
         "to": 10000,
-        "color": "rgba(213,94,0,0.07)",
+        "color": "rgba(196, 117, 253, 0.07)",
         "label": {
             "text": "Low-Cycle Fatigue",
             "style": {"fontSize": "36px", "color": INK_SOFT},
@@ -108,7 +108,7 @@ region_bands = [
     {
         "from": 10000,
         "to": 1000000,
-        "color": "rgba(0,114,178,0.05)",
+        "color": "rgba(68, 103, 163, 0.05)",
         "label": {
             "text": "High-Cycle Fatigue",
             "style": {"fontSize": "36px", "color": INK_SOFT},
@@ -162,13 +162,13 @@ chart.options.y_axis = {
     "plotLines": [
         {
             "value": ultimate_strength,
-            "color": "#CC79A7",
+            "color": "#BD8233",
             "width": 4,
             "dashStyle": "Dash",
             "label": {
                 "text": f"Ultimate Strength ({ultimate_strength} MPa)",
                 "align": "left",
-                "style": {"fontSize": "34px", "color": "#CC79A7", "fontWeight": "bold"},
+                "style": {"fontSize": "34px", "color": "#BD8233", "fontWeight": "bold"},
                 "x": 10,
                 "y": -10,
             },
@@ -176,13 +176,13 @@ chart.options.y_axis = {
         },
         {
             "value": yield_strength,
-            "color": "#E69F00",
+            "color": "#AE3030",
             "width": 4,
             "dashStyle": "Dash",
             "label": {
                 "text": f"Yield Strength ({yield_strength} MPa)",
                 "align": "left",
-                "style": {"fontSize": "34px", "color": "#E69F00", "fontWeight": "bold"},
+                "style": {"fontSize": "34px", "color": "#AE3030", "fontWeight": "bold"},
                 "x": 10,
                 "y": -10,
             },
@@ -190,13 +190,13 @@ chart.options.y_axis = {
         },
         {
             "value": endurance_limit,
-            "color": "#56B4E9",
+            "color": "#2ABCCD",
             "width": 4,
             "dashStyle": "Dash",
             "label": {
                 "text": f"Endurance Limit ({endurance_limit} MPa)",
                 "align": "left",
-                "style": {"fontSize": "34px", "color": "#56B4E9", "fontWeight": "bold"},
+                "style": {"fontSize": "34px", "color": "#2ABCCD", "fontWeight": "bold"},
                 "x": 10,
                 "y": -10,
             },

--- a/plots/span-basic/implementations/python/highcharts.py
+++ b/plots/span-basic/implementations/python/highcharts.py
@@ -82,10 +82,10 @@ chart.options.x_axis = {
         {
             "from": 3.5,
             "to": 8.5,
-            "color": "rgba(213,94,0,0.18)",
+            "color": "rgba(174, 48, 48, 0.18)",  # imprint red — crisis band
             "label": {
                 "text": "Financial Crisis",
-                "style": {"fontSize": "40px", "color": "#D55E00", "fontWeight": "bold"},
+                "style": {"fontSize": "40px", "color": "#AE3030", "fontWeight": "bold"},
                 "verticalAlign": "top",
                 "y": 80,
             },
@@ -106,10 +106,10 @@ chart.options.y_axis = {
         {
             "from": 600,
             "to": 1000,
-            "color": "rgba(230,159,0,0.18)",
+            "color": "rgba(174, 48, 48, 0.18)",
             "label": {
                 "text": "Bear Market Zone",
-                "style": {"fontSize": "36px", "color": "#E69F00", "fontWeight": "500"},
+                "style": {"fontSize": "36px", "color": "#AE3030", "fontWeight": "500"},
                 "align": "left",
                 "x": 40,
                 "y": -15,

--- a/plots/sparkline-basic/implementations/python/highcharts.py
+++ b/plots/sparkline-basic/implementations/python/highcharts.py
@@ -26,8 +26,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 # Okabe-Ito categorical palette — identical across themes; only chrome flips.
 LINE_COLOR = "#009E73"
 FILL_COLOR_RGBA = "rgba(0, 158, 115, 0.18)"
-MIN_COLOR = "#D55E00"
-MAX_COLOR = "#0072B2"
+MIN_COLOR = "#C475FD"
+MAX_COLOR = "#4467A3"
 
 # Data — 30 trading days of daily closing prices for a hypothetical mid-cap
 # stock. Geometric random walk with mild positive drift, an earnings-week

--- a/plots/spectrum-basic/implementations/python/highcharts.py
+++ b/plots/spectrum-basic/implementations/python/highcharts.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Data - Generate a synthetic audio signal with multiple frequency components
 np.random.seed(42)

--- a/plots/streamgraph-basic/implementations/python/highcharts.py
+++ b/plots/streamgraph-basic/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Monthly streaming hours by music genre over two years
 np.random.seed(42)
@@ -121,7 +121,7 @@ chart.options.legend = {
     "symbolRadius": 6,
 }
 
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 for genre in genres:
     series = StreamGraphSeries()

--- a/plots/strip-basic/implementations/python/highcharts.py
+++ b/plots/strip-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 NEUTRAL = "#1A1A1A" if THEME == "light" else "#E8E8E0"
 
 # Okabe-Ito palette — first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — student test scores by subject
 np.random.seed(42)
@@ -131,7 +131,7 @@ chart.options.tooltip = {
 for cat_idx, cat in enumerate(categories):
     series = ScatterSeries()
     series.name = cat
-    series.color = OKABE_ITO[cat_idx]
+    series.color = IMPRINT[cat_idx]
     series.data = [{"x": float(pt["x"]), "y": pt["y"]} for pt in strip_data if pt["category"] == cat]
     series.marker = {"radius": 12, "symbol": "circle", "fillOpacity": 0.65, "lineWidth": 1, "lineColor": PAGE_BG}
     chart.add_series(series)

--- a/plots/subplot-grid/implementations/python/highcharts.py
+++ b/plots/subplot-grid/implementations/python/highcharts.py
@@ -30,9 +30,9 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series - ALWAYS
-COLOR2 = "#D55E00"
-COLOR3 = "#0072B2"
-COLOR4 = "#CC79A7"
+COLOR2 = "#C475FD"
+COLOR3 = "#4467A3"
+COLOR4 = "#BD8233"
 
 # Data - Financial dashboard with price, volume, returns
 np.random.seed(42)

--- a/plots/sunburst-basic/implementations/python/highcharts.py
+++ b/plots/sunburst-basic/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette — first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Total budget for center focal point annotation
 TOTAL_BUDGET = 1240  # Engineering 720 + Marketing 310 + Operations 210 ($K)
@@ -34,9 +34,9 @@ data = [
     # Root (center circle) — background-colored so it appears as text-only focal point
     {"id": "root", "name": f"${TOTAL_BUDGET:,}K", "color": PAGE_BG},
     # Level 1: Departments (innermost ring) — Okabe-Ito in canonical order
-    {"id": "engineering", "name": "Engineering", "parent": "root", "color": OKABE_ITO[0]},
-    {"id": "marketing", "name": "Marketing", "parent": "root", "color": OKABE_ITO[1]},
-    {"id": "operations", "name": "Operations", "parent": "root", "color": OKABE_ITO[2]},
+    {"id": "engineering", "name": "Engineering", "parent": "root", "color": IMPRINT[0]},
+    {"id": "marketing", "name": "Marketing", "parent": "root", "color": IMPRINT[1]},
+    {"id": "operations", "name": "Operations", "parent": "root", "color": IMPRINT[2]},
     # Level 2: Teams within each department
     {"id": "frontend", "name": "Frontend", "parent": "engineering", "value": 280},
     {"id": "backend", "name": "Backend", "parent": "engineering", "value": 350},

--- a/plots/survival-kaplan-meier/implementations/python/highcharts.py
+++ b/plots/survival-kaplan-meier/implementations/python/highcharts.py
@@ -29,7 +29,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (position 1 for first series, position 2 for second)
 COLOR_PRIMARY = "#009E73"  # First series - brand green
-COLOR_SECONDARY = "#D55E00"  # Second series - vermillion
+COLOR_SECONDARY = "#C475FD"  # Second series - vermillion
 
 # Generate synthetic clinical trial survival data
 np.random.seed(42)

--- a/plots/swarm-basic/implementations/python/highcharts.py
+++ b/plots/swarm-basic/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 NEUTRAL = "#1A1A1A" if THEME == "light" else "#E8E8E0"
 
 # Okabe-Ito palette (positions 1-4)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — employee performance scores by department
 np.random.seed(42)
@@ -140,7 +140,7 @@ chart.options.tooltip = {
 for cat_idx, cat in enumerate(categories):
     series = ScatterSeries()
     series.name = cat
-    series.color = OKABE_ITO[cat_idx]
+    series.color = IMPRINT[cat_idx]
     cat_data = swarm_by_cat[cat]
     series.data = [
         {"x": float(cat_idx + x_off), "y": float(val)}
@@ -149,7 +149,7 @@ for cat_idx, cat in enumerate(categories):
     series.marker = {
         "radius": 14,
         "symbol": "circle",
-        "fillColor": OKABE_ITO[cat_idx],
+        "fillColor": IMPRINT[cat_idx],
         "lineWidth": 2,
         "lineColor": PAGE_BG,
     }

--- a/plots/timeline-basic/implementations/python/highcharts.py
+++ b/plots/timeline-basic/implementations/python/highcharts.py
@@ -24,7 +24,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Software project milestones
 events = [
@@ -41,7 +41,7 @@ events = [
 ]
 
 category_order = ["Planning", "Design", "Development", "Testing", "Release"]
-category_colors = {cat: OKABE_ITO[i] for i, cat in enumerate(category_order)}
+category_colors = {cat: IMPRINT[i] for i, cat in enumerate(category_order)}
 
 # Build series data for each category
 series_data = {cat: [] for cat in category_colors}

--- a/plots/timeseries-decomposition/implementations/python/highcharts.py
+++ b/plots/timeseries-decomposition/implementations/python/highcharts.py
@@ -28,7 +28,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for decomposition components
-COLORS = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+COLORS = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 COMPONENT_NAMES = ["Original", "Trend", "Seasonal", "Residual"]
 
 # Data - Monthly airline passengers (classic time series dataset)

--- a/plots/timeseries-forecast-uncertainty/implementations/python/highcharts.py
+++ b/plots/timeseries-forecast-uncertainty/implementations/python/highcharts.py
@@ -26,12 +26,12 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
-FORECAST_BG = "rgba(213,94,0,0.06)" if THEME == "light" else "rgba(213,94,0,0.10)"
+FORECAST_BG = "rgba(196, 117, 253, 0.06)" if THEME == "light" else "rgba(196, 117, 253, 0.10)"
 
 # Okabe-Ito palette (sequential positions)
 BRAND = "#009E73"  # position 1 — historical data
-FORECAST_COLOR = "#D55E00"  # position 2 — forecast line
-CI_COLOR = "#0072B2"  # position 3 — both CI bands (opacity differentiates)
+FORECAST_COLOR = "#C475FD"  # position 2 — forecast line
+CI_COLOR = "#4467A3"  # position 3 — both CI bands (opacity differentiates)
 
 # Theme-adaptive CI fill opacity for dark-mode distinction
 FILL_OP_80 = 0.30 if THEME == "light" else 0.40

--- a/plots/tree-phylogenetic/implementations/python/highcharts.py
+++ b/plots/tree-phylogenetic/implementations/python/highcharts.py
@@ -23,7 +23,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for categorical data
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Primate phylogenetic tree with branch lengths (MYA - Million Years Ago)
 phylo_nodes = {
@@ -99,12 +99,12 @@ for node in phylo_nodes:
 
 # Rank color mapping using Okabe-Ito palette
 rank_colors = {
-    "Order": OKABE_ITO[0],
-    "Superfamily": OKABE_ITO[1],
-    "Family": OKABE_ITO[2],
-    "Tribe": OKABE_ITO[3],
-    "Subfamily": OKABE_ITO[4],
-    "Species": OKABE_ITO[5],
+    "Order": IMPRINT[0],
+    "Superfamily": IMPRINT[1],
+    "Family": IMPRINT[2],
+    "Tribe": IMPRINT[3],
+    "Subfamily": IMPRINT[4],
+    "Species": IMPRINT[5],
 }
 
 # Generate branch lines

--- a/plots/treemap-basic/implementations/python/highcharts.py
+++ b/plots/treemap-basic/implementations/python/highcharts.py
@@ -25,16 +25,16 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (positions 1-7)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Budget allocation by department and project
 data = [
     # Parent categories (level 1) with Okabe-Ito colors
-    {"id": "engineering", "name": "Engineering", "color": OKABE_ITO[0]},
-    {"id": "marketing", "name": "Marketing", "color": OKABE_ITO[1]},
-    {"id": "operations", "name": "Operations", "color": OKABE_ITO[2]},
-    {"id": "sales", "name": "Sales", "color": OKABE_ITO[3]},
-    {"id": "hr", "name": "HR", "color": OKABE_ITO[4]},
+    {"id": "engineering", "name": "Engineering", "color": IMPRINT[0]},
+    {"id": "marketing", "name": "Marketing", "color": IMPRINT[1]},
+    {"id": "operations", "name": "Operations", "color": IMPRINT[2]},
+    {"id": "sales", "name": "Sales", "color": IMPRINT[3]},
+    {"id": "hr", "name": "HR", "color": IMPRINT[4]},
     # Engineering subcategories
     {"name": "Backend Dev", "parent": "engineering", "value": 45000},
     {"name": "Frontend Dev", "parent": "engineering", "value": 38000},
@@ -96,7 +96,7 @@ series_config = {
     "name": "Budget",
     "layoutAlgorithm": "squarified",
     "allowDrillToNode": True,
-    "colors": OKABE_ITO,
+    "colors": IMPRINT,
     "dataLabels": {"enabled": True, "style": {"fontSize": "20px", "color": INK}},
     "levels": [
         {

--- a/plots/venn-basic/implementations/python/highcharts.py
+++ b/plots/venn-basic/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Download Highcharts JS and Venn module (required for headless Chrome)
 headers = {
@@ -89,7 +89,7 @@ series.data_labels = {
 }
 
 # Use Okabe-Ito palette (first series #009E73)
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 chart.add_series(series)
 

--- a/plots/venn-labeled-items/implementations/python/highcharts.py
+++ b/plots/venn-labeled-items/implementations/python/highcharts.py
@@ -25,8 +25,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito categorical palette: first series is brand green
-CIRCLE_COLORS = ["#009E73", "#D55E00", "#0072B2"]
-CIRCLE_FILLS = ["rgba(0,158,115,0.22)", "rgba(213,94,0,0.22)", "rgba(0,114,178,0.22)"]
+CIRCLE_COLORS = ["#009E73", "#C475FD", "#4467A3"]
+CIRCLE_FILLS = ["rgba(0,158,115,0.22)", "rgba(196, 117, 253, 0.22)", "rgba(68, 103, 163, 0.22)"]
 
 # Editorial Chartgeist-style commentary on tech/culture
 circles = [{"name": "Overhyped"}, {"name": "Actually Useful"}, {"name": "Secretly Loved"}]

--- a/plots/violin-grouped-swarm/implementations/python/highcharts.py
+++ b/plots/violin-grouped-swarm/implementations/python/highcharts.py
@@ -28,14 +28,14 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Response times (ms) across task types and expertise levels
 np.random.seed(42)
 
 categories = ["Pattern Match", "Memory Recall", "Calculation"]
 groups = ["Novice", "Expert"]
-colors = {"Novice": "#009E73", "Expert": "#D55E00"}
+colors = {"Novice": "#009E73", "Expert": "#C475FD"}
 
 # Generate realistic response time data
 raw_data = {}
@@ -131,7 +131,7 @@ chart = Chart(container="container")
 chart.options = HighchartsOptions()
 
 # Set color palette
-chart.options.colors = OKABE_ITO
+chart.options.colors = IMPRINT
 
 # Chart configuration
 chart.options.chart = {

--- a/plots/violin-split/implementations/python/highcharts.py
+++ b/plots/violin-split/implementations/python/highcharts.py
@@ -26,7 +26,7 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Data - Employee satisfaction scores by department, comparing Remote vs Office workers
 np.random.seed(42)

--- a/plots/violin-swarm/implementations/python/highcharts.py
+++ b/plots/violin-swarm/implementations/python/highcharts.py
@@ -30,7 +30,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Reaction times (ms) across 4 experimental conditions
 np.random.seed(42)
@@ -70,7 +70,7 @@ for i, cat in enumerate(categories):
             "y_grid": y_grid,
             "density": density_norm,
             "raw_data": data,
-            "color": OKABE_ITO[i],
+            "color": IMPRINT[i],
         }
     )
 

--- a/plots/volcano-basic/implementations/python/highcharts.py
+++ b/plots/volcano-basic/implementations/python/highcharts.py
@@ -25,7 +25,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 COLOR_NEUTRAL = "#1A1A1A" if THEME == "light" else "#E8E8E0"
 
 np.random.seed(42)
@@ -124,14 +124,14 @@ chart.add_series(series_ns)
 series_down = ScatterSeries()
 series_down.name = f"Down-regulated ({np.sum(sig_down)})"
 series_down.data = [[float(x), float(y)] for x, y in zip(log2_fc[sig_down], neg_log10_p[sig_down], strict=True)]
-series_down.color = OKABE_ITO[2]
+series_down.color = IMPRINT[2]
 series_down.marker = {"radius": 10, "symbol": "circle"}
 chart.add_series(series_down)
 
 series_up = ScatterSeries()
 series_up.name = f"Up-regulated ({np.sum(sig_up)})"
 series_up.data = [[float(x), float(y)] for x, y in zip(log2_fc[sig_up], neg_log10_p[sig_up], strict=True)]
-series_up.color = OKABE_ITO[1]
+series_up.color = IMPRINT[1]
 series_up.marker = {"radius": 10, "symbol": "circle"}
 chart.add_series(series_up)
 

--- a/plots/voronoi-basic/implementations/python/highcharts.py
+++ b/plots/voronoi-basic/implementations/python/highcharts.py
@@ -26,14 +26,14 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette - first color is always brand green
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
-    "#E69F00",  # orange
-    "#56B4E9",  # sky blue
-    "#F0E442",  # yellow
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
+    "#AE3030",  # orange
+    "#2ABCCD",  # sky blue
+    "#954477",  # yellow
 ]
 
 # Data - Generate seed points for Voronoi diagram
@@ -142,7 +142,7 @@ for idx in range(n_points):
     # Close the polygon
     clipped.append(clipped[0])
 
-    color = OKABE_ITO[idx % len(OKABE_ITO)]
+    color = IMPRINT[idx % len(IMPRINT)]
 
     polygon_series.append(
         {

--- a/plots/waterfall-basic/implementations/python/highcharts.py
+++ b/plots/waterfall-basic/implementations/python/highcharts.py
@@ -26,8 +26,8 @@ GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette: positive = brand green, negative = vermillion
 POSITIVE_COLOR = "#009E73"  # Okabe-Ito position 1 (brand green)
-NEGATIVE_COLOR = "#D55E00"  # Okabe-Ito position 2 (vermillion)
-TOTAL_COLOR = "#0072B2"  # Okabe-Ito position 3 (blue) for start/end totals
+NEGATIVE_COLOR = "#AE3030"  # imprint red — negative
+TOTAL_COLOR = "#4467A3"  # Okabe-Ito position 3 (blue) for start/end totals
 
 # Data - Quarterly financial breakdown from revenue to net income
 categories = [

--- a/plots/wordcloud-basic/implementations/python/highcharts.py
+++ b/plots/wordcloud-basic/implementations/python/highcharts.py
@@ -22,7 +22,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Technology terms and their frequency from a developer survey
 words_data = [
@@ -97,7 +97,7 @@ chart.options.series = [
         "spiral": "rectangular",
         "rotation": {"from": 0, "to": 60, "orientations": 4},
         "style": {"fontFamily": "Arial, sans-serif", "fontWeight": "normal"},
-        "colors": OKABE_ITO,
+        "colors": IMPRINT,
     }
 ]
 


### PR DESCRIPTION
## Summary

- Positional hex + rgba replacement across **146 highcharts impls** with light+dark renders.
- Proactive semantic-anchor fixes for 11 highcharts impls (red/amber/green where slot-1 lavender broke meaning, plus span-basic's "Financial Crisis" band restored to semantic red).

## Test plan

- [x] `ruff check .` + format green
- [ ] CI green
- [ ] Copilot triage
- [ ] After merge: Stage B for 146 highcharts impls → GCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)