### PR TITLE
chore(palette): migrate letsplot impls from Okabe-Ito to imprint

### DIFF
--- a/plots/alluvial-basic/implementations/python/letsplot.py
+++ b/plots/alluvial-basic/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-4)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Voter migration data across three election cycles
 elections = ["2016", "2020", "2024"]
@@ -106,10 +106,10 @@ total_flow = sum(totals_2016.values())
 
 # Colors for parties - Okabe-Ito palette (positions 1-4)
 party_colors = {
-    "Democrats": OKABE_ITO[0],
-    "Republicans": OKABE_ITO[1],
-    "Independents": OKABE_ITO[2],
-    "Non-Voters": OKABE_ITO[3],
+    "Democrats": IMPRINT[0],
+    "Republicans": IMPRINT[1],
+    "Independents": IMPRINT[2],
+    "Non-Voters": IMPRINT[3],
 }
 
 

--- a/plots/andrews-curves/implementations/python/letsplot.py
+++ b/plots/andrews-curves/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Set seed for reproducibility
 np.random.seed(42)
@@ -83,9 +83,9 @@ df_curves = pd.DataFrame(curves_data)
 
 # Map species to Okabe-Ito colors
 species_colors = {
-    target_names[0]: OKABE_ITO[0],  # setosa: #009E73 (brand green)
-    target_names[1]: OKABE_ITO[1],  # versicolor: #D55E00 (vermillion)
-    target_names[2]: OKABE_ITO[2],  # virginica: #0072B2 (blue)
+    target_names[0]: IMPRINT[0],  # setosa: #009E73 (brand green)
+    target_names[1]: IMPRINT[1],  # versicolor: #C475FD (vermillion)
+    target_names[2]: IMPRINT[2],  # virginica: #4467A3 (blue)
 }
 
 # Create plot

--- a/plots/area-stacked-confidence/implementations/python/letsplot.py
+++ b/plots/area-stacked-confidence/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly energy consumption forecast by source with uncertainty
 np.random.seed(42)
@@ -110,8 +110,8 @@ plot = (
     + geom_ribbon(aes(x="x", ymin="y_lower", ymax="y_upper", fill="source"), data=df_conf, alpha=0.25)
     + geom_ribbon(aes(x="x", ymin="y_min", ymax="y_max", fill="source"), data=df_areas, alpha=0.7)
     + geom_line(aes(x="x", y="y", color="source"), data=df_lines, size=1.5)
-    + scale_fill_manual(values=OKABE_ITO, name="Energy Source")
-    + scale_color_manual(values=OKABE_ITO, guide="none")
+    + scale_fill_manual(values=IMPRINT, name="Energy Source")
+    + scale_color_manual(values=IMPRINT, guide="none")
     + scale_x_continuous(breaks=list(range(0, n, 4)), labels=[x_labels[i] for i in range(0, n, 4)])
     + labs(
         title="area-stacked-confidence · Python · letsplot · anyplot.ai",

--- a/plots/area-stacked-percent/implementations/python/letsplot.py
+++ b/plots/area-stacked-percent/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Market share evolution over 8 years
 np.random.seed(42)
@@ -77,7 +77,7 @@ df["Company"] = pd.Categorical(
 plot = (
     ggplot(df, aes(x="Year", y="Share", fill="Company"))
     + geom_area(position="fill", alpha=0.85)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_x_continuous(breaks=list(range(2016, 2024)))
     + scale_y_continuous(format=".0%")
     + labs(x="Year", y="Market Share (%)", title="area-stacked-percent · letsplot · anyplot.ai")

--- a/plots/area-stacked/implementations/python/letsplot.py
+++ b/plots/area-stacked/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Monthly revenue by product category over 2 years
 np.random.seed(42)
@@ -77,7 +77,7 @@ df["Category"] = pd.Categorical(df["Category"], categories=category_order, order
 plot = (
     ggplot(df, aes(x="MonthNum", y="Revenue", fill="Category"))
     + geom_area(alpha=0.85, position="stack", size=0.5, color=PAGE_BG)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_x_continuous(
         name="Month", breaks=[0, 6, 12, 18, 23], labels=["Jan 2023", "Jul 2023", "Jan 2024", "Jul 2024", "Dec 2024"]
     )

--- a/plots/bar-3d-categorical/implementations/python/letsplot.py
+++ b/plots/bar-3d-categorical/implementations/python/letsplot.py
@@ -20,7 +20,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#C8C7C0" if THEME == "light" else "#3A3A35"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 
 def shade(col, f):
@@ -116,7 +116,7 @@ def face(pts, fill_col):
 
 
 for ei in range(NY - 1, -1, -1):  # draw back→front; ei=0 (High School) drawn last = in front
-    c0 = OKABE_ITO[ei]
+    c0 = IMPRINT[ei]
     c_front = c0
     c_right = shade(c0, 0.60)
     c_top = shade(c0, 1.32)
@@ -164,7 +164,7 @@ leg_rect = []
 leg_text = []
 for i, edu in enumerate(Y_CATS):
     lx, ly = LEG_X, LEG_Y0 - i * LEG_DY
-    leg_rect.append({"xmin": lx, "xmax": lx + 0.32, "ymin": ly - 0.20, "ymax": ly + 0.20, "fill": OKABE_ITO[i]})
+    leg_rect.append({"xmin": lx, "xmax": lx + 0.32, "ymin": ly - 0.20, "ymax": ly + 0.20, "fill": IMPRINT[i]})
     leg_text.append({"x": lx + 0.42, "y": ly, "label": edu})
 
 df_ltitle = pd.DataFrame(leg_title)

--- a/plots/bar-diverging/implementations/python/letsplot.py
+++ b/plots/bar-diverging/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito brand colors for diverging bars
 POSITIVE_COLOR = "#009E73"  # Brand green
-NEGATIVE_COLOR = "#D55E00"  # Vermillion
+NEGATIVE_COLOR = "#AE3030"  # imprint red — negative
 
 # Data - Customer satisfaction survey (Net Promoter Score style)
 categories = [

--- a/plots/bar-drilldown/implementations/python/letsplot.py
+++ b/plots/bar-drilldown/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Hierarchical data: regional sales breakdown (region → quarterly)
 hierarchy_data = {
@@ -91,10 +91,10 @@ hierarchy_data = {
 }
 
 region_color_map = {
-    "North Region": OKABE_ITO[0],
-    "South Region": OKABE_ITO[1],
-    "East Region": OKABE_ITO[2],
-    "West Region": OKABE_ITO[3],
+    "North Region": IMPRINT[0],
+    "South Region": IMPRINT[1],
+    "East Region": IMPRINT[2],
+    "West Region": IMPRINT[3],
 }
 
 # Root-level dataframe for static PNG
@@ -122,10 +122,10 @@ plot = (
         label="★ highest",
         vjust=-2.0,
         size=7,
-        color=OKABE_ITO[2],
+        color=IMPRINT[2],
         fontface="bold",
     )
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_y_continuous(format="${,.0f}", limits=[0, 730000], expand=[0, 0])
     + labs(
         title="bar-drilldown · python · letsplot · anyplot.ai",
@@ -162,9 +162,9 @@ for level_id in ["root", "north", "south", "east", "west"]:
         cats = [hierarchy_data[cid]["name"] for cid in children_ids]
         vals = [hierarchy_data[cid]["value"] for cid in children_ids]
         if level_id == "root":
-            level_colors = [region_color_map.get(cat, OKABE_ITO[0]) for cat in cats]
+            level_colors = [region_color_map.get(cat, IMPRINT[0]) for cat in cats]
         else:
-            base_color = region_color_map.get(hierarchy_data[level_id]["name"], OKABE_ITO[0])
+            base_color = region_color_map.get(hierarchy_data[level_id]["name"], IMPRINT[0])
             level_colors = [base_color] * len(cats)
         levels_data[level_id] = {
             "name": hierarchy_data[level_id]["name"],
@@ -183,7 +183,7 @@ html_text_soft = INK_SOFT
 html_grid = "rgba(26,26,23,0.12)" if THEME == "light" else "rgba(240,239,232,0.12)"
 html_tooltip_bg = "rgba(0,0,0,0.88)" if THEME == "light" else "rgba(36,36,32,0.95)"
 html_back_btn_border = INK_SOFT
-html_brand = OKABE_ITO[0]
+html_brand = IMPRINT[0]
 
 html_content = f"""<!DOCTYPE html>
 <html>

--- a/plots/bar-error/implementations/python/letsplot.py
+++ b/plots/bar-error/implementations/python/letsplot.py
@@ -35,7 +35,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "rgba(26,26,23,0.08)" if THEME == "light" else "rgba(240,239,232,0.08)"
 
 # Okabe-Ito palette - first series is brand green
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data: A/B test results showing conversion rates with 95% CI
 categories = ["Control", "Variant A", "Variant B", "Variant C", "Variant D"]
@@ -57,7 +57,7 @@ plot = (
     ggplot(df, aes(x="category", y="value", fill="category"))
     + geom_bar(stat="identity", width=0.68, show_legend=False, alpha=0.92)
     + geom_errorbar(aes(ymin="ymin", ymax="ymax"), width=0.23, size=1.3, color=INK_SOFT, alpha=0.85)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(
         title="bar-error · letsplot · anyplot.ai",
         x="Test Group",

--- a/plots/bar-grouped/implementations/python/letsplot.py
+++ b/plots/bar-grouped/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly sales by product category
 categories = ["Q1", "Q2", "Q3", "Q4"]
@@ -72,7 +72,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="Quarter", y="Revenue", fill="Product"))
     + geom_bar(stat="identity", position="dodge", width=0.7, alpha=0.9)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(x="Quarter", y="Revenue ($ thousands)", title="bar-grouped · letsplot · anyplot.ai", fill="Product Category")
     + anyplot_theme
     + ggsize(1600, 900)

--- a/plots/bar-race-animated/implementations/python/letsplot.py
+++ b/plots/bar-race-animated/implementations/python/letsplot.py
@@ -18,7 +18,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 np.random.seed(42)
 
@@ -39,7 +39,7 @@ for i, platform in enumerate(platforms):
 
 df = pd.DataFrame(data_rows)
 
-platform_colors = dict(zip(platforms, OKABE_ITO))
+platform_colors = dict(zip(platforms, IMPRINT))
 snapshot_years = [2016, 2018, 2021, 2023]
 
 anyplot_theme = theme(

--- a/plots/bar-spine/implementations/python/letsplot.py
+++ b/plots/bar-spine/implementations/python/letsplot.py
@@ -36,7 +36,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: customer churn by subscription tier
 tiers = ["Basic", "Standard", "Premium", "Enterprise"]
@@ -110,7 +110,7 @@ plot = (
     ggplot(df)
     + geom_rect(aes(xmin="xmin", xmax="xmax", ymin="ymin", ymax="ymax", fill="status"), color=PAGE_BG, size=1.2)
     + geom_text(data=df_labels, mapping=aes(x="x_mid", y="y_mid", label="label"), color="#FAFAFA", size=14)
-    + scale_fill_manual(values={"Retained": OKABE_ITO[0], "Churned": OKABE_ITO[1]}, name="Status")
+    + scale_fill_manual(values={"Retained": IMPRINT[0], "Churned": IMPRINT[1]}, name="Status")
     + scale_x_continuous(expand=[0, 0], breaks=list(x_mids), labels=tiers)
     + scale_y_continuous(expand=[0, 0], breaks=[0.0, 0.25, 0.5, 0.75, 1.0], labels=["0%", "25%", "50%", "75%", "100%"])
     + labs(x="Subscription Tier", y="Customer Proportion", title="bar-spine · letsplot · anyplot.ai")

--- a/plots/bar-stacked-labeled/implementations/python/letsplot.py
+++ b/plots/bar-stacked-labeled/implementations/python/letsplot.py
@@ -36,7 +36,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product category (in millions)
 data = {
@@ -79,7 +79,7 @@ plot = (
         fontface="bold",
         color=INK,
     )
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(
         title="bar-stacked-labeled · Python · letsplot · anyplot.ai",
         x="Quarter",

--- a/plots/bar-stacked-percent/implementations/python/letsplot.py
+++ b/plots/bar-stacked-percent/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data: Energy source mix by country (renewable adoption comparison)
 data = {
@@ -97,7 +97,7 @@ df["source"] = pd.Categorical(
 plot = (
     ggplot(df, aes(x="country", y="value", fill="source"))
     + geom_bar(stat="identity", position="fill", width=0.75, alpha=0.9)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_y_continuous(format=".0%")
     + labs(
         title="bar-stacked-percent · letsplot · anyplot.ai", x="Country", y="Share of Energy Mix", fill="Energy Source"

--- a/plots/bar-stacked/implementations/python/letsplot.py
+++ b/plots/bar-stacked/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.15)" if THEME == "light" else "rgba(240,239,232,0.15)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Quarterly sales by product category
 data = {
@@ -59,7 +59,7 @@ plot = (
         size=0.3,
         tooltips=layer_tooltips().title("@product").line("Sales: @sales K$").format("sales", ".0f"),
     )
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(title="bar-stacked · letsplot · anyplot.ai", x="Quarter", y="Sales (Thousands $)", fill="Product")
     + theme(
         plot_background=element_rect(fill=PAGE_BG, color=PAGE_BG),

--- a/plots/biplot-pca/implementations/python/letsplot.py
+++ b/plots/biplot-pca/implementations/python/letsplot.py
@@ -27,7 +27,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 BRAND = "#009E73"  # Okabe-Ito position 1
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Load Iris dataset
 iris = load_iris()
@@ -122,7 +122,7 @@ plot = (
         title="biplot-pca · letsplot · anyplot.ai",
         color="Species",
     )
-    + scale_color_manual(values=OKABE_ITO)  # noqa: F405
+    + scale_color_manual(values=IMPRINT)  # noqa: F405
     + scale_x_continuous(expand=[0.15, 0.15])  # noqa: F405
     + scale_y_continuous(expand=[0.15, 0.15])  # noqa: F405
     + theme_minimal()  # noqa: F405

--- a/plots/bland-altman-basic/implementations/python/letsplot.py
+++ b/plots/bland-altman-basic/implementations/python/letsplot.py
@@ -22,8 +22,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - first categorical series
-SECONDARY = "#D55E00"  # Position 2
-ACCENT = "#0072B2"  # Position 3
+SECONDARY = "#C475FD"  # Position 2
+ACCENT = "#4467A3"  # Position 3
 
 # Data: Simulated blood pressure readings from two sphygmomanometers
 np.random.seed(42)

--- a/plots/box-grouped/implementations/python/letsplot.py
+++ b/plots/box-grouped/implementations/python/letsplot.py
@@ -35,7 +35,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Employee performance scores by department and experience level
 np.random.seed(42)
@@ -76,7 +76,7 @@ df["Department"] = pd.Categorical(df["Department"], categories=departments, orde
 plot = (
     ggplot(df, aes(x="Department", y="Performance Score", fill="Experience"))
     + geom_boxplot(alpha=0.85, outlier_size=3, outlier_alpha=0.7, width=0.7)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(title="box-grouped · letsplot · anyplot.ai", x="Department", y="Performance Score", fill="Experience Level")
     + theme_minimal()
     + theme(

--- a/plots/box-notched/implementations/python/letsplot.py
+++ b/plots/box-notched/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - department salaries with different distributions for statistical comparison
 np.random.seed(42)
@@ -65,8 +65,8 @@ df = pd.DataFrame(data)
 plot = (
     ggplot(df, aes(x="Department", y="Salary", fill="Department", color="Department"))
     + geom_boxplot(notch=True, outlier_size=4, outlier_alpha=0.8, size=1.2, alpha=0.85)
-    + scale_fill_manual(values=OKABE_ITO)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
+    + scale_color_manual(values=IMPRINT)
     + labs(title="box-notched · letsplot · anyplot.ai", x="Department", y="Annual Salary (USD)")
     + theme_minimal()
     + theme(

--- a/plots/calibration-curve/implementations/python/letsplot.py
+++ b/plots/calibration-curve/implementations/python/letsplot.py
@@ -24,7 +24,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — first series
-SECONDARY = "#D55E00"  # Okabe-Ito position 2 — reference line
+SECONDARY = "#C475FD"  # Okabe-Ito position 2 — reference line
 
 # Data - Generate realistic binary classification predictions
 np.random.seed(42)

--- a/plots/candlestick-volume/implementations/python/letsplot.py
+++ b/plots/candlestick-volume/implementations/python/letsplot.py
@@ -67,7 +67,7 @@ df = pd.DataFrame(
 
 # Colorblind-safe colors (first series Okabe-Ito, second is orange)
 color_up = "#009E73"
-color_down = "#D55E00"
+color_down = "#AE3030"  # imprint red — down days
 
 # Create volume breaks and labels (inline formatting)
 vol_min, vol_max = df["volume"].min(), df["volume"].max()

--- a/plots/cat-box-strip/implementations/python/letsplot.py
+++ b/plots/cat-box-strip/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BOX_COLOR = "#009E73"  # Brand green - first series
-POINT_COLOR = "#D55E00"  # Vermillion - second series
+POINT_COLOR = "#C475FD"  # Vermillion - second series
 
 # Data - Uptime scores across service tiers
 np.random.seed(42)

--- a/plots/chernoff-basic/implementations/python/letsplot.py
+++ b/plots/chernoff-basic/implementations/python/letsplot.py
@@ -61,7 +61,7 @@ grid_rows = 3
 grid_cols = 4
 all_face_data = []
 label_data = []
-species_colors = {"setosa": "#009E73", "versicolor": "#D55E00", "virginica": "#0072B2"}
+species_colors = {"setosa": "#009E73", "versicolor": "#C475FD", "virginica": "#4467A3"}
 
 for idx, row in df_sample.iterrows():
     col = idx % grid_cols

--- a/plots/circlepacking-basic/implementations/python/letsplot.py
+++ b/plots/circlepacking-basic/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Hierarchical data - File system storage breakdown (GB)
 np.random.seed(42)
@@ -205,18 +205,18 @@ label_df = pd.DataFrame(label_rows)
 # Color mapping: depth-based with Okabe-Ito
 color_map = {
     "root": INK_SOFT,
-    "Documents": OKABE_ITO[0],
-    "Media": OKABE_ITO[1],
-    "Code": OKABE_ITO[2],
-    "Work": OKABE_ITO[0],
-    "Personal": OKABE_ITO[0],
-    "Archive": OKABE_ITO[0],
-    "Photos": OKABE_ITO[1],
-    "Videos": OKABE_ITO[1],
-    "Music": OKABE_ITO[1],
-    "Projects": OKABE_ITO[2],
-    "Libraries": OKABE_ITO[2],
-    "Backups": OKABE_ITO[2],
+    "Documents": IMPRINT[0],
+    "Media": IMPRINT[1],
+    "Code": IMPRINT[2],
+    "Work": IMPRINT[0],
+    "Personal": IMPRINT[0],
+    "Archive": IMPRINT[0],
+    "Photos": IMPRINT[1],
+    "Videos": IMPRINT[1],
+    "Music": IMPRINT[1],
+    "Projects": IMPRINT[2],
+    "Libraries": IMPRINT[2],
+    "Backups": IMPRINT[2],
 }
 
 unique_colors = polygon_df["color"].unique()

--- a/plots/contour-decision-boundary/implementations/python/letsplot.py
+++ b/plots/contour-decision-boundary/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data
 np.random.seed(42)
@@ -70,8 +70,8 @@ plot = (
     ggplot()
     + geom_tile(aes(x="X1", y="X2", fill="Predicted"), data=mesh_df, alpha=0.4)
     + geom_point(aes(x="X1", y="X2", color="Class", shape="Correct"), data=train_df, size=5, stroke=1.5)
-    + scale_fill_manual(values=[OKABE_ITO[0], OKABE_ITO[1]], name="Predicted Class")
-    + scale_color_manual(values=[OKABE_ITO[0], OKABE_ITO[1]], name="True Class")
+    + scale_fill_manual(values=[IMPRINT[0], IMPRINT[1]], name="Predicted Class")
+    + scale_color_manual(values=[IMPRINT[0], IMPRINT[1]], name="True Class")
     + scale_shape_manual(values=[16, 4], name="Classification")
     + labs(title="contour-decision-boundary · letsplot · anyplot.ai", x="Feature X1", y="Feature X2")
     + theme_minimal()

--- a/plots/contour-map-geographic/implementations/python/letsplot.py
+++ b/plots/contour-map-geographic/implementations/python/letsplot.py
@@ -40,10 +40,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 CONTOUR_COLOR = "#333333" if THEME == "light" else "#CCCCCC"
 LABEL_COLOR = "#1A1A17" if THEME == "light" else "#F0EFE8"
-COAST_COLOR = "#0072B2"  # Okabe-Ito blue — works on both themes
+COAST_COLOR = "#4467A3"  # Okabe-Ito blue — works on both themes
 GRID_MAJOR = "#CCCAC3" if THEME == "light" else "#2E2E2B"
 GRID_MINOR = "#E0DDD7" if THEME == "light" else "#252522"
-CITY_COLOR = "#D55E00"  # Okabe-Ito vermillion — reference cities
+CITY_COLOR = "#C475FD"  # Okabe-Ito vermillion — reference cities
 ANNO_BG = "#FFFDF6" if THEME == "light" else "#242420"
 
 # Data — synthetic elevation for Western US mountain region

--- a/plots/dashboard-synchronized-crosshair/implementations/python/letsplot.py
+++ b/plots/dashboard-synchronized-crosshair/implementations/python/letsplot.py
@@ -44,8 +44,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#E1DFD9" if THEME == "light" else "#32322F"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3", "#99B314", "#D359A7", "#BA843E"]
-CROSSHAIR_COLOR = ANYPLOT_PALETTE[5]  # #D359A7 pink — visually distinct from all 3 series
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3", "#99B314", "#954477", "#BD8233"]
+CROSSHAIR_COLOR = IMPRINT[5]  # #954477 pink — visually distinct from all 3 series
 
 # Data — stock dashboard: price, volume, RSI over 200 trading days
 np.random.seed(42)
@@ -102,7 +102,7 @@ common_theme = theme(
 # Chart 1: Price
 price_chart = (
     ggplot(df, aes(x="date", y="price"))
-    + geom_line(color=ANYPLOT_PALETTE[0], size=1.5, tooltips=layer_tooltips().line("@date").line("Price|$@price"))
+    + geom_line(color=IMPRINT[0], size=1.5, tooltips=layer_tooltips().line("@date").line("Price|$@price"))
     + geom_path(data=vline_price_df, mapping=aes(x="date", y="y"), color=CROSSHAIR_COLOR, size=1.2, alpha=0.85)
     + geom_point(data=crosshair_price_df, mapping=aes(x="date", y="price"), color=CROSSHAIR_COLOR, size=6)
     + geom_text(
@@ -122,7 +122,7 @@ price_chart = (
 volume_chart = (
     ggplot(df, aes(x="date", xend="date", y="zero", yend="volume"))
     + geom_segment(
-        color=ANYPLOT_PALETTE[1], size=2.0, alpha=0.85, tooltips=layer_tooltips().line("@date").line("Volume|@volume M")
+        color=IMPRINT[1], size=2.0, alpha=0.85, tooltips=layer_tooltips().line("@date").line("Volume|@volume M")
     )
     + geom_path(data=vline_volume_df, mapping=aes(x="date", y="y"), color=CROSSHAIR_COLOR, size=1.2, alpha=0.85)
     + geom_point(data=crosshair_volume_df, mapping=aes(x="date", y="volume"), color=CROSSHAIR_COLOR, size=6)
@@ -142,7 +142,7 @@ volume_chart = (
 # Chart 3: RSI Indicator
 rsi_chart = (
     ggplot(df, aes(x="date", y="rsi"))
-    + geom_line(color=ANYPLOT_PALETTE[2], size=1.5, tooltips=layer_tooltips().line("@date").line("RSI|@rsi"))
+    + geom_line(color=IMPRINT[2], size=1.5, tooltips=layer_tooltips().line("@date").line("RSI|@rsi"))
     + geom_hline(yintercept=70, linetype="dashed", color=INK_SOFT, size=0.8)
     + geom_hline(yintercept=30, linetype="dashed", color=INK_SOFT, size=0.8)
     + geom_path(data=vline_rsi_df, mapping=aes(x="date", y="y"), color=CROSSHAIR_COLOR, size=1.2, alpha=0.85)

--- a/plots/diagnostic-regression-panel/implementations/python/letsplot.py
+++ b/plots/diagnostic-regression-panel/implementations/python/letsplot.py
@@ -24,9 +24,9 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID_COLOR = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-SMOOTHER = "#D55E00"  # Okabe-Ito position 2
-REFERENCE = "#0072B2"  # Okabe-Ito position 3
-CONTOUR = "#CC79A7"  # Okabe-Ito position 4
+SMOOTHER = "#C475FD"  # Okabe-Ito position 2
+REFERENCE = "#4467A3"  # Okabe-Ito position 3
+CONTOUR = "#BD8233"  # Okabe-Ito position 4
 
 CREDIT = "diagnostic-regression-panel · letsplot · anyplot.ai"
 

--- a/plots/donut-basic/implementations/python/letsplot.py
+++ b/plots/donut-basic/implementations/python/letsplot.py
@@ -19,7 +19,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 categories = ["Marketing", "Operations", "R&D", "Sales", "HR"]
 values = [28, 22, 25, 18, 7]
@@ -52,7 +52,7 @@ plot = (
         label_padding=0.6,
         label_r=0.2,
     )
-    + scale_fill_manual(values=OKABE_ITO)  # noqa: F405
+    + scale_fill_manual(values=IMPRINT)  # noqa: F405
     + labs(title="donut-basic · letsplot · anyplot.ai", fill="Department")  # noqa: F405
     + ggsize(1200, 1200)  # noqa: F405
     + theme_void()  # noqa: F405

--- a/plots/donut-nested/implementations/python/letsplot.py
+++ b/plots/donut-nested/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Budget allocation by department (inner) and expense categories (outer)
 data = [
@@ -76,7 +76,7 @@ level2_agg = df.groupby(["level_1", "level_2"])["value"].sum().reset_index()
 level2_agg["pct"] = level2_agg["value"] / total_value
 
 # Map categories to colors
-color_map_l1 = {cat: OKABE_ITO[i] for i, cat in enumerate(level1_order)}
+color_map_l1 = {cat: IMPRINT[i] for i, cat in enumerate(level1_order)}
 color_map_l2 = {}
 for l1_cat in level1_order:
     children = level2_agg[level2_agg["level_1"] == l1_cat]["level_2"].unique()

--- a/plots/dot-matrix-proportional/implementations/python/letsplot.py
+++ b/plots/dot-matrix-proportional/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — clinical trial side effect profile (n = 100 patients)
 categories = ["No Side Effects", "Mild Effects", "Moderate Effects", "Severe Effects"]
@@ -62,7 +62,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="col", y="row", color="legend"))  # noqa: F405
     + geom_point(size=8, alpha=0.95)  # noqa: F405
-    + scale_color_manual(values=OKABE_ITO)  # noqa: F405
+    + scale_color_manual(values=IMPRINT)  # noqa: F405
     + labs(title="dot-matrix-proportional · letsplot · anyplot.ai")  # noqa: F405
     + theme_void()  # noqa: F405
     + ggsize(1200, 1200)  # noqa: F405

--- a/plots/drawdown-basic/implementations/python/letsplot.py
+++ b/plots/drawdown-basic/implementations/python/letsplot.py
@@ -44,7 +44,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 GRID_COLOR = "#4A4A4433" if THEME == "light" else "#B8B7B033"
 
 # anyplot palette — semantic exception: loss/down → red, recovery → green
-DRAWDOWN_COLOR = "#B71D27"  # palette pos 3
+DRAWDOWN_COLOR = "#AE3030"  # palette pos 3
 RECOVERY_COLOR = "#009E73"  # palette pos 1
 
 # Data

--- a/plots/dumbbell-basic/implementations/python/letsplot.py
+++ b/plots/dumbbell-basic/implementations/python/letsplot.py
@@ -40,7 +40,7 @@ GRID = "#1A1A17" if THEME == "light" else "#F0EFE8"
 
 # Okabe-Ito palette — "After" comes first alphabetically → brand green
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 SEGMENT = INK_SOFT
 
 # Data — Employee satisfaction scores before and after policy changes.

--- a/plots/elbow-curve/implementations/python/letsplot.py
+++ b/plots/elbow-curve/implementations/python/letsplot.py
@@ -19,7 +19,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Simulated K-means inertia values showing typical elbow curve pattern
 # Data represents clustering analysis on customer segmentation dataset

--- a/plots/errorbar-basic/implementations/python/letsplot.py
+++ b/plots/errorbar-basic/implementations/python/letsplot.py
@@ -34,7 +34,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-FOCAL = "#D55E00"  # Okabe-Ito position 2 — emphasises group with largest spread
+FOCAL = "#C475FD"  # Okabe-Ito position 2 — emphasises group with largest spread
 
 # Data — experimental measurements with uncertainty
 data = pd.DataFrame(

--- a/plots/facet-grid/implementations/python/letsplot.py
+++ b/plots/facet-grid/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (categorical)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - sales analysis by category and region
 np.random.seed(42)
@@ -93,7 +93,7 @@ plot = (
     + geom_point(size=3, alpha=0.7)
     + geom_smooth(method="lm", se=False, size=1.5)
     + facet_grid(x="Region", y="Category")
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(title="facet-grid · letsplot · anyplot.ai", x="Unit Price ($)", y="Units Sold")
     + theme_minimal()
     + anyplot_theme

--- a/plots/flowmap-origin-destination/implementations/python/letsplot.py
+++ b/plots/flowmap-origin-destination/implementations/python/letsplot.py
@@ -40,7 +40,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 CONTINENT_FILL = "#E0DDD6" if THEME == "light" else "#2E2E2B"
 CONTINENT_BORDER = "#C8C5BE" if THEME == "light" else "#4A4A47"
-HUB_COLOR = "#0072B2"
+HUB_COLOR = "#4467A3"
 
 # Data
 np.random.seed(42)

--- a/plots/frequency-polygon-basic/implementations/python/letsplot.py
+++ b/plots/frequency-polygon-basic/implementations/python/letsplot.py
@@ -35,7 +35,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series is brand green #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Response times (ms) across three experimental conditions
 np.random.seed(42)
@@ -77,7 +77,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="response_time", color="condition"))
     + geom_freqpoly(bins=25, size=2.5, alpha=0.9)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(
         x="Response Time (ms)",
         y="Frequency",

--- a/plots/frontier-efficient/implementations/python/letsplot.py
+++ b/plots/frontier-efficient/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Generate simulated asset data
 np.random.seed(42)
@@ -141,9 +141,9 @@ anyplot_theme = theme(
 plot = (
     ggplot()
     + geom_point(data=df_portfolios, mapping=aes(x="risk", y="return", color="sharpe"), size=4, alpha=0.6)
-    + geom_line(data=df_frontier, mapping=aes(x="risk", y="return"), color=OKABE_ITO[2], size=3)
+    + geom_line(data=df_frontier, mapping=aes(x="risk", y="return"), color=IMPRINT[2], size=3)
     + geom_line(data=df_cml, mapping=aes(x="risk", y="return"), color=INK_SOFT, size=1.5, linetype="dashed")
-    + geom_point(data=df_special, mapping=aes(x="risk", y="return"), color=OKABE_ITO[1], size=10, shape=18)
+    + geom_point(data=df_special, mapping=aes(x="risk", y="return"), color=IMPRINT[1], size=10, shape=18)
     + labs(
         x="Risk (Standard Deviation)",
         y="Expected Return",

--- a/plots/funnel-basic/implementations/python/letsplot.py
+++ b/plots/funnel-basic/implementations/python/letsplot.py
@@ -35,8 +35,8 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 
 # Okabe-Ito palette — first stage is brand green (#009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
-# Light orange (#E69F00) needs dark text for contrast; others use white.
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
+# Light orange (#AE3030) needs dark text for contrast; others use white.
 TEXT_ON_FILL = ["white", "white", "white", "white", INK]
 
 # Data — sales funnel example from specification
@@ -82,7 +82,7 @@ plot = (
     ggplot()
     + geom_polygon(aes(x="x", y="y", fill="stage", group="stage"), data=df_poly, color=PAGE_BG, size=2)
     + geom_text(aes(x="x", y="y", label="label", color="text_color"), data=df_labels, size=12, fontface="bold")
-    + scale_fill_manual(values=OKABE_ITO[:n_stages], guide="none")
+    + scale_fill_manual(values=IMPRINT[:n_stages], guide="none")
     + scale_color_identity()
     + scale_y_reverse()
     + labs(title="funnel-basic · letsplot · anyplot.ai", x="", y="")

--- a/plots/gain-curve/implementations/python/letsplot.py
+++ b/plots/gain-curve/implementations/python/letsplot.py
@@ -70,7 +70,7 @@ df_long = pd.concat([df_model, df_random, df_perfect], ignore_index=True)
 colors = {
     "Model": "#009E73",  # Okabe-Ito position 1 (brand green)
     "Random": "#888888",  # Neutral gray for reference line
-    "Perfect": "#0072B2",  # Okabe-Ito position 3 (blue)
+    "Perfect": "#4467A3",  # Okabe-Ito position 3 (blue)
 }
 
 # Plot

--- a/plots/gantt-basic/implementations/python/letsplot.py
+++ b/plots/gantt-basic/implementations/python/letsplot.py
@@ -20,7 +20,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Software Development Project
 tasks_data = {
@@ -94,12 +94,12 @@ df["duration"] = df["end_days"] - df["start_days"]
 
 # Map categories to colors (Okabe-Ito palette)
 category_colors = {
-    "Planning": OKABE_ITO[0],
-    "Design": OKABE_ITO[1],
-    "Development": OKABE_ITO[2],
-    "Testing": OKABE_ITO[3],
-    "Documentation": OKABE_ITO[4],
-    "Deployment": OKABE_ITO[5],
+    "Planning": IMPRINT[0],
+    "Design": IMPRINT[1],
+    "Development": IMPRINT[2],
+    "Testing": IMPRINT[3],
+    "Documentation": IMPRINT[4],
+    "Deployment": IMPRINT[5],
 }
 df["color"] = df["category"].map(category_colors)
 
@@ -132,7 +132,7 @@ plot = (
             "Week 11",
         ],
     )
-    + scale_color_manual(values=OKABE_ITO, name="Phase")
+    + scale_color_manual(values=IMPRINT, name="Phase")
     + labs(title="gantt-basic · letsplot · anyplot.ai", x="Project Timeline", y="Tasks")
     + theme_minimal()
     + theme(

--- a/plots/heatmap-geographic/implementations/python/letsplot.py
+++ b/plots/heatmap-geographic/implementations/python/letsplot.py
@@ -100,10 +100,10 @@ plot = (
     + geom_point(
         aes(x="longitude", y="latitude", size="magnitude"),
         data=df,
-        color="#0072B2",
+        color="#4467A3",
         alpha=0.5,
         shape=21,
-        fill="#E69F00",
+        fill="#AE3030",
         stroke=0.5,
         tooltips=layer_tooltips()
         .line("Lat: @latitude{.2f}")

--- a/plots/hierarchy-toggle-view/implementations/python/letsplot.py
+++ b/plots/hierarchy-toggle-view/implementations/python/letsplot.py
@@ -68,7 +68,7 @@ for node in hierarchy_data.values():
 total_value = sum(n["value"] for n in hierarchy_data.values() if n["level"] == 1)
 
 # Okabe-Ito positions 1-4 for departments; lighter variants for children
-DEPT_COLORS = {"Engineering": "#009E73", "Sales": "#D55E00", "Marketing": "#0072B2", "Operations": "#CC79A7"}
+DEPT_COLORS = {"Engineering": "#009E73", "Sales": "#C475FD", "Marketing": "#4467A3", "Operations": "#BD8233"}
 CHILD_COLORS = {
     "Backend": "#4DC4A0",
     "Frontend": "#80D5B8",

--- a/plots/histogram-overlapping/implementations/python/letsplot.py
+++ b/plots/histogram-overlapping/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
-COLORS = ["#009E73", "#D55E00"]
+COLORS = ["#009E73", "#C475FD"]
 
 # Data - comparing response times between two experimental conditions
 np.random.seed(42)

--- a/plots/histogram-returns-distribution/implementations/python/letsplot.py
+++ b/plots/histogram-returns-distribution/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#D9D8D1" if THEME == "light" else "#3A3A37"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data
 np.random.seed(42)
@@ -101,10 +101,10 @@ plot = (
         linetype="dashed",
         inherit_aes=False,
     )
-    + geom_vline(xintercept=lower_tail, color=OKABE_ITO[1], size=1, linetype="dotted", alpha=0.8)  # noqa: F405
-    + geom_vline(xintercept=upper_tail, color=OKABE_ITO[1], size=1, linetype="dotted", alpha=0.8)  # noqa: F405
+    + geom_vline(xintercept=lower_tail, color=IMPRINT[1], size=1, linetype="dotted", alpha=0.8)  # noqa: F405
+    + geom_vline(xintercept=upper_tail, color=IMPRINT[1], size=1, linetype="dotted", alpha=0.8)  # noqa: F405
     + scale_fill_manual(  # noqa: F405
-        values={"Normal Range (±2σ)": OKABE_ITO[0], "Tail (beyond ±2σ)": OKABE_ITO[1]}, name="Region"
+        values={"Normal Range (±2σ)": IMPRINT[0], "Tail (beyond ±2σ)": IMPRINT[1]}, name="Region"
     )
     + labs(  # noqa: F405
         x="Daily Returns (%)", y="Density", title="histogram-returns-distribution · python · letsplot · anyplot.ai"

--- a/plots/histogram-stacked/implementations/python/letsplot.py
+++ b/plots/histogram-stacked/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Test scores from three different classes
 np.random.seed(42)
@@ -46,7 +46,7 @@ df["score"] = df["score"].clip(0, 100)
 plot = (
     ggplot(df, aes(x="score", fill="class"))
     + geom_histogram(binwidth=5, position="stack", color=PAGE_BG, size=0.3)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(
         x="Test Score (points)", y="Number of Students", title="histogram-stacked · letsplot · anyplot.ai", fill="Class"
     )

--- a/plots/histogram-stepwise/implementations/python/letsplot.py
+++ b/plots/histogram-stepwise/implementations/python/letsplot.py
@@ -19,7 +19,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Generate two distributions for comparison (temperature readings)
 np.random.seed(42)
@@ -48,7 +48,7 @@ df_step = pd.DataFrame(step_data)
 plot = (
     ggplot(df_step, aes(x="x", y="y", color="period"))
     + geom_line(size=2.5)
-    + scale_color_manual(values=OKABE_ITO[:2])
+    + scale_color_manual(values=IMPRINT[:2])
     + labs(x="Temperature (°C)", y="Frequency", title="histogram-stepwise · letsplot · anyplot.ai", color="Time Period")
     + theme_minimal()
     + theme(

--- a/plots/hive-basic/implementations/python/letsplot.py
+++ b/plots/hive-basic/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for categorical node types (positions 1-3)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Software module dependency network with 3 module types
 np.random.seed(42)
@@ -158,7 +158,7 @@ labels_df = pd.DataFrame(label_positions)
 # Map edges to colors using Okabe-Ito palette
 edge_color_map = {}
 for axis in axis_angles.keys():
-    edge_color_map[f"Within {axis}"] = OKABE_ITO[axis_to_color_idx[axis]]
+    edge_color_map[f"Within {axis}"] = IMPRINT[axis_to_color_idx[axis]]
 edge_color_map["Between axes"] = INK_SOFT
 
 # Build the plot
@@ -177,7 +177,7 @@ plot = (
         aes(x="x", y="y", label="label"), data=labels_df, size=14, fontface="bold", color=INK, show_legend=False
     )
     # Color scales using Okabe-Ito palette
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + scale_color_manual(values=edge_color_map)
     + scale_size(range=[5, 12])
     # Styling - expand limits to show axis labels

--- a/plots/horizon-basic/implementations/python/letsplot.py
+++ b/plots/horizon-basic/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Server metrics over 7 days for multiple servers
 np.random.seed(42)
@@ -110,7 +110,7 @@ horizon_df = pd.DataFrame(horizon_records)
 # Negative bands: use dimmer version of the color
 colors = {}
 for band_idx in range(n_bands):
-    color = OKABE_ITO[0]  # Use first series color for all bands
+    color = IMPRINT[0]  # Use first series color for all bands
     # Positive: increase intensity across bands
     if band_idx == 0:
         colors[f"pos{band_idx}"] = "#B3E5B0"  # Light
@@ -120,13 +120,13 @@ for band_idx in range(n_bands):
         colors[f"pos{band_idx}"] = "#009E73"  # Full intensity
 
     # Negative: reddish palette for negative deviations
-    neg_color = OKABE_ITO[1]  # Use second series color for negatives
+    neg_color = IMPRINT[1]  # Use second series color for negatives
     if band_idx == 0:
         colors[f"neg{band_idx}"] = "#F5C4A0"  # Light
     elif band_idx == 1:
         colors[f"neg{band_idx}"] = "#E89354"  # Medium
     else:
-        colors[f"neg{band_idx}"] = "#D55E00"  # Full intensity
+        colors[f"neg{band_idx}"] = "#AE3030"  # imprint red — full intensity
 
 # Create the horizon chart
 plot = (

--- a/plots/ice-basic/implementations/python/letsplot.py
+++ b/plots/ice-basic/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#D0CEC7" if THEME == "light" else "#2E2E2B"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — Suburban houses
-COLOR2 = "#D55E00"  # Okabe-Ito position 2 — Urban houses
+COLOR2 = "#C475FD"  # Okabe-Ito position 2 — Urban houses
 
 # Data — house price predictions via GradientBoostingRegressor
 np.random.seed(42)

--- a/plots/icicle-basic/implementations/python/letsplot.py
+++ b/plots/icicle-basic/implementations/python/letsplot.py
@@ -35,7 +35,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Hierarchical data: File system example
 hierarchy = [
@@ -135,10 +135,10 @@ label_df["font_size"] = label_df["level"].map({0: 14, 1: 12, 2: 8, 3: 7})
 
 # Color palette by level using Okabe-Ito
 colors = {
-    "0": OKABE_ITO[0],  # Level 0: bluish green
-    "1": OKABE_ITO[1],  # Level 1: vermillion
-    "2": OKABE_ITO[2],  # Level 2: blue
-    "3": OKABE_ITO[3],  # Level 3: reddish purple
+    "0": IMPRINT[0],  # Level 0: bluish green
+    "1": IMPRINT[1],  # Level 1: vermillion
+    "2": IMPRINT[2],  # Level 2: blue
+    "3": IMPRINT[3],  # Level 3: reddish purple
 }
 
 anyplot_theme = theme(

--- a/plots/indicator-bollinger/implementations/python/letsplot.py
+++ b/plots/indicator-bollinger/implementations/python/letsplot.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-BAND_COLOR = "#0072B2"  # Okabe-Ito position 3
+BAND_COLOR = "#4467A3"  # Okabe-Ito position 3
 
 # Data - Generate synthetic stock price data with Bollinger Bands
 np.random.seed(42)

--- a/plots/indicator-ema/implementations/python/letsplot.py
+++ b/plots/indicator-ema/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito colors for Close Price, EMA 12, EMA 26
-COLORS = {"Close Price": "#009E73", "EMA 12": "#D55E00", "EMA 26": "#0072B2"}
+COLORS = {"Close Price": "#009E73", "EMA 12": "#C475FD", "EMA 26": "#4467A3"}
 
 # Data
 np.random.seed(42)
@@ -107,7 +107,7 @@ plot = (
 for x in bullish_crosses:
     plot = plot + geom_vline(xintercept=x, color="#009E73", linetype="dashed", size=0.8, alpha=0.4)  # noqa: F405
 for x in bearish_crosses:
-    plot = plot + geom_vline(xintercept=x, color="#D55E00", linetype="dashed", size=0.8, alpha=0.4)  # noqa: F405
+    plot = plot + geom_vline(xintercept=x, color="#C475FD", linetype="dashed", size=0.8, alpha=0.4)  # noqa: F405
 
 # Save
 export_ggsave(plot, f"plot-{THEME}.png", path=".", scale=3)

--- a/plots/indicator-macd/implementations/python/letsplot.py
+++ b/plots/indicator-macd/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # First series (green)
-SECONDARY = "#D55E00"  # Orange
+SECONDARY = "#BD8233"  # imprint ochre — signal line (categorical contrast)
 
 # Generate realistic stock price data with momentum
 np.random.seed(42)
@@ -78,7 +78,7 @@ plot = (
     )
     + geom_hline(yintercept=0, color=INK_SOFT, size=0.8, linetype="dashed")
     + geom_line(data=df_lines, mapping=aes(x="day_num", y="value", color="line_type"), size=1.5)
-    + scale_fill_manual(values={"Positive": "#56B4E9", "Negative": "#D55E00"}, name="Histogram")
+    + scale_fill_manual(values={"Positive": "#2ABCCD", "Negative": "#AE3030"}, name="Histogram")  # imprint red for negative bars
     + scale_color_manual(values={"MACD Line": BRAND, "Signal Line": SECONDARY}, name="Lines")
     + labs(x="Trading Day", y="MACD Value", title="indicator-macd · letsplot · anyplot.ai")
     + theme_minimal()

--- a/plots/indicator-sma/implementations/python/letsplot.py
+++ b/plots/indicator-sma/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "#C0BFBA" if THEME == "light" else "#484844"
 
 # Okabe-Ito palette — first series always #009E73
-COLORS = {"Close": "#009E73", "SMA 20": "#D55E00", "SMA 50": "#0072B2", "SMA 200": "#CC79A7"}
+COLORS = {"Close": "#009E73", "SMA 20": "#C475FD", "SMA 50": "#4467A3", "SMA 200": "#BD8233"}
 
 # Data
 np.random.seed(42)

--- a/plots/learning-curve-basic/implementations/python/letsplot.py
+++ b/plots/learning-curve-basic/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Simulate learning curve for a model showing slight overfitting pattern
 np.random.seed(42)
@@ -84,8 +84,8 @@ plot = (
     + geom_ribbon(aes(ymin="Lower", ymax="Upper"), alpha=0.2, color="rgba(0,0,0,0)")
     + geom_line(size=2)
     + geom_point(size=4)
-    + scale_color_manual(values=OKABE_ITO[:2])
-    + scale_fill_manual(values=OKABE_ITO[:2])
+    + scale_color_manual(values=IMPRINT[:2])
+    + scale_fill_manual(values=IMPRINT[:2])
     + scale_y_continuous(limits=[0.55, 1.02])
     + scale_x_continuous(limits=[0, 1700], breaks=list(range(0, 1800, 200)))
     + labs(

--- a/plots/lift-curve/implementations/python/letsplot.py
+++ b/plots/lift-curve/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"  # Okabe-Ito position 1
-REFERENCE = "#E69F00"  # Okabe-Ito position 5 for reference line
+REFERENCE = "#AE3030"  # Okabe-Ito position 5 for reference line
 
 # Data: Fraud detection model
 # Using exponential distribution for scores to reflect realistic fraud detection patterns

--- a/plots/line-loss-training/implementations/python/letsplot.py
+++ b/plots/line-loss-training/implementations/python/letsplot.py
@@ -41,7 +41,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Training loss (first series)
-ACCENT = "#D55E00"  # Validation loss (second series)
+ACCENT = "#C475FD"  # Validation loss (second series)
 OPTIMAL = "#DC2626"  # Optimal epoch marker
 
 # Data - Simulated neural network training loss over 100 epochs

--- a/plots/line-markers/implementations/python/letsplot.py
+++ b/plots/line-markers/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly product performance metrics
 np.random.seed(42)
@@ -45,7 +45,7 @@ plot = (
     ggplot(df, aes(x="Quarter", y="Revenue", color="Product"))
     + geom_line(size=2.5)
     + geom_point(size=6, alpha=0.9)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + scale_x_continuous(breaks=list(range(1, 13)))
     + labs(x="Quarter", y="Revenue (Million USD)", title="line-markers · letsplot · anyplot.ai")
     + theme_minimal()

--- a/plots/line-multi/implementations/python/letsplot.py
+++ b/plots/line-multi/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Monthly sales for 3 product lines over 12 months
 np.random.seed(42)
@@ -54,8 +54,8 @@ plot = (
     + geom_point(data=other_df, size=4.5, alpha=0.75)
     + geom_line(data=electronics_df, size=3, alpha=1.0)
     + geom_point(data=electronics_df, size=5.5, alpha=0.95)
-    + geom_smooth(data=electronics_df, method="loess", span=0.4, se=False, color=OKABE_ITO[0], size=1.2, alpha=0.4)
-    + scale_color_manual(values=OKABE_ITO)
+    + geom_smooth(data=electronics_df, method="loess", span=0.4, se=False, color=IMPRINT[0], size=1.2, alpha=0.4)
+    + scale_color_manual(values=IMPRINT)
     + scale_x_continuous(breaks=months.tolist(), labels=month_labels)
     + labs(title="line-multi · letsplot · anyplot.ai", x="Month", y="Sales (thousands USD)")
     + theme(

--- a/plots/line-stock-comparison/implementations/python/letsplot.py
+++ b/plots/line-stock-comparison/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3"]
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3"]
 
 # Data
 np.random.seed(42)
@@ -81,7 +81,7 @@ plot = (
         size=8,
         fontface="bold",
     )
-    + scale_color_manual(values=ANYPLOT_PALETTE, name="Symbol")
+    + scale_color_manual(values=IMPRINT, name="Symbol")
     + labs(title="line-stock-comparison · python · letsplot · anyplot.ai", x="Date", y="Performance (rebased to 100)")
     + theme_minimal()
     + theme(

--- a/plots/line-styled/implementations/python/letsplot.py
+++ b/plots/line-styled/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Daily rainfall across different cities over a month
 np.random.seed(42)
@@ -64,7 +64,7 @@ plot = (
     ggplot(df, aes(x="Day", y="Rainfall", color="City", linetype="City"))
     + geom_line(size=2)
     + geom_point(size=3.5, alpha=0.7)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + scale_linetype_manual(values=["solid", "dashed", "dotted", "longdash"])
     + labs(
         x="Day of Month", y="Rainfall (mm)", title="line-styled · letsplot · anyplot.ai", color="City", linetype="City"

--- a/plots/linked-views-selection/implementations/python/letsplot.py
+++ b/plots/linked-views-selection/implementations/python/letsplot.py
@@ -62,7 +62,7 @@ df = pd.DataFrame(
 )
 
 # Colors - colorblind-friendly palette with distinct hues
-colors = ["#E69F00", "#56B4E9", "#009E73", "#CC79A7"]  # Orange, Sky Blue, Teal, Pink
+colors = ["#AE3030", "#2ABCCD", "#009E73", "#BD8233"]  # Orange, Sky Blue, Teal, Pink
 
 n_selected = selected.sum()
 n_total = len(df)

--- a/plots/logistic-regression/implementations/python/letsplot.py
+++ b/plots/logistic-regression/implementations/python/letsplot.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first two colors for binary classification)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Generate binary classification data with clear sigmoidal relationship
 np.random.seed(42)
@@ -90,15 +90,15 @@ anyplot_theme = theme(
 plot = (
     ggplot()
     # Confidence interval ribbon
-    + geom_ribbon(aes(x="Study Hours", ymin="ci_lower", ymax="ci_upper"), data=df_ci, fill=OKABE_ITO[0], alpha=0.15)
+    + geom_ribbon(aes(x="Study Hours", ymin="ci_lower", ymax="ci_upper"), data=df_ci, fill=IMPRINT[0], alpha=0.15)
     # Logistic curve
-    + geom_line(aes(x="Study Hours", y="Probability"), data=df_curve, color=OKABE_ITO[0], size=2.5)
+    + geom_line(aes(x="Study Hours", y="Probability"), data=df_curve, color=IMPRINT[0], size=2.5)
     # Decision threshold line
     + geom_hline(yintercept=0.5, linetype="dashed", color=INK_SOFT, size=1, alpha=0.6)
     # Data points with jitter
     + geom_point(aes(x="Study Hours", y="Probability", color="Class"), data=df_points, size=5, alpha=0.65)
     # Colors for classes using Okabe-Ito
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     # Labels with model annotation
     + labs(
         x="Study Hours",

--- a/plots/lollipop-grouped/implementations/python/letsplot.py
+++ b/plots/lollipop-grouped/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Quarterly revenue by product line across regions
 regions = ["North", "South", "East", "West"]
@@ -65,7 +65,7 @@ plot = (
     ggplot(df)
     + geom_segment(mapping=aes(x="x_pos", xend="x_pos", y="y_start", yend="revenue", color="product"), size=2)
     + geom_point(mapping=aes(x="x_pos", y="revenue", color="product"), size=8)
-    + scale_color_manual(values=OKABE_ITO, name="Product Line")
+    + scale_color_manual(values=IMPRINT, name="Product Line")
     + labs(x="Region", y="Revenue ($ thousands)", title="lollipop-grouped · Python · letsplot · anyplot.ai")
     + scale_x_continuous(breaks=list(range(len(regions))), labels=regions)
     + scale_y_continuous(limits=[0, 300])

--- a/plots/manhattan-gwas/implementations/python/letsplot.py
+++ b/plots/manhattan-gwas/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for alternating chromosomes
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Set seed for reproducibility
 np.random.seed(42)
@@ -77,7 +77,7 @@ df = pd.DataFrame(data)
 
 # Assign alternating colors using Okabe-Ito palette
 df["chrom_idx"] = df["chromosome"].astype(int) % 2
-df["color_group"] = df["chrom_idx"].map({0: OKABE_ITO[0], 1: OKABE_ITO[1]})
+df["color_group"] = df["chrom_idx"].map({0: IMPRINT[0], 1: IMPRINT[1]})
 
 # Significance thresholds
 genome_wide_threshold = -np.log10(5e-8)  # ~7.3
@@ -98,12 +98,12 @@ plot = (
     + geom_point(
         data=df[df["significant"]],
         mapping=aes(x="cumulative_pos", y="neg_log10_p"),
-        color=OKABE_ITO[4],
+        color=IMPRINT[4],
         size=3.5,
         alpha=0.9,
     )
     # Genome-wide significance threshold line
-    + geom_hline(yintercept=genome_wide_threshold, linetype="dashed", color=OKABE_ITO[4], size=1)
+    + geom_hline(yintercept=genome_wide_threshold, linetype="dashed", color=IMPRINT[4], size=1)
     # Suggestive threshold line
     + geom_hline(yintercept=suggestive_threshold, linetype="dotted", color=INK_MUTED, size=0.7)
     + labs(title="manhattan-gwas · letsplot · anyplot.ai", x="Chromosome", y="-log₁₀(p-value)")

--- a/plots/map-drilldown-geographic/implementations/python/letsplot.py
+++ b/plots/map-drilldown-geographic/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 CONTINENT_FILL = "#E0DDD6" if THEME == "light" else "#2E2E2A"
 CONTINENT_BORDER = "#C4C0B8" if THEME == "light" else "#4A4A44"
-STROKE_DRILLABLE = "#9418DB"
+STROKE_DRILLABLE = "#C475FD"
 
 np.random.seed(42)
 

--- a/plots/map-marker-clustered/implementations/python/letsplot.py
+++ b/plots/map-marker-clustered/implementations/python/letsplot.py
@@ -76,7 +76,7 @@ df_clusters = pd.DataFrame(
 )
 
 # anyplot palette — canonical order for categorical data
-colors = {"Retail": "#009E73", "Warehouse": "#9418DB", "Service Center": "#B71D27"}
+colors = {"Retail": "#009E73", "Warehouse": "#C475FD", "Service Center": "#AE3030"}
 
 # Higher-fidelity US continental boundary polygon (66 vertices vs prior 44)
 us_boundary = [

--- a/plots/map-projections/implementations/python/letsplot.py
+++ b/plots/map-projections/implementations/python/letsplot.py
@@ -37,9 +37,9 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-ANYPLOT_PALETTE = ["#009E73", "#9418DB", "#B71D27", "#16B8F3", "#99B314", "#D359A7", "#BA843E"]
-LAND_COLOR = ANYPLOT_PALETTE[0]  # brand green — first categorical series
-TISSOT_COLOR = ANYPLOT_PALETTE[1]  # purple — canonical second series
+IMPRINT = ["#009E73", "#C475FD", "#AE3030", "#4467A3", "#99B314", "#954477", "#BD8233"]
+LAND_COLOR = IMPRINT[0]  # brand green — first categorical series
+TISSOT_COLOR = IMPRINT[1]  # purple — canonical second series
 
 np.random.seed(42)
 

--- a/plots/map-route-path/implementations/python/letsplot.py
+++ b/plots/map-route-path/implementations/python/letsplot.py
@@ -99,7 +99,7 @@ plot = (
         tooltips=layer_tooltips().line("@marker"),
     )
     + scale_color_viridis(name="Progress (%)")
-    + scale_fill_manual(values={"Start": "#009E73", "End": "#D55E00"}, name="Markers")
+    + scale_fill_manual(values={"Start": "#009E73", "End": "#C475FD"}, name="Markers")
     + labs(x="Longitude (°)", y="Latitude (°)", title="map-route-path · python · letsplot · anyplot.ai")
     + theme_minimal()
     + anyplot_theme

--- a/plots/maze-circular/implementations/python/letsplot.py
+++ b/plots/maze-circular/implementations/python/letsplot.py
@@ -19,7 +19,7 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 — START marker
-ACCENT = "#D55E00"  # Okabe-Ito position 2 — GOAL marker
+ACCENT = "#C475FD"  # Okabe-Ito position 2 — GOAL marker
 
 # Maze parameters
 np.random.seed(42)

--- a/plots/mosaic-categorical/implementations/python/letsplot.py
+++ b/plots/mosaic-categorical/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data — Titanic survival cross-tabulated by passenger class
 categories_1 = ["First Class", "Second Class", "Third Class", "Crew"]
@@ -136,7 +136,7 @@ plot = (
         tooltips=tooltips,
     )
     + geom_text(aes(x="x_center", y="y_center", label="label"), size=13, color="white", fontface="bold")
-    + scale_fill_manual(values=OKABE_ITO[:2], name="Survival Status")
+    + scale_fill_manual(values=IMPRINT[:2], name="Survival Status")
     + scale_x_continuous(name="Passenger Class  (width ∝ count)", breaks=x_breaks, labels=categories_1, limits=[0, 100])
     + scale_y_continuous(name="Survival Rate (%)", limits=[0, 100], breaks=[0, 25, 50, 75, 100])
     + labs(

--- a/plots/network-basic/implementations/python/letsplot.py
+++ b/plots/network-basic/implementations/python/letsplot.py
@@ -41,7 +41,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 EDGE_COLOR = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito categorical palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: A small social network with 20 people in 4 departments
 np.random.seed(42)
@@ -211,7 +211,7 @@ plot = (
         alpha=0.95,
     )
     + geom_text(aes(x="x", y="label_y", label="label"), data=df_nodes, size=12, color=INK_SOFT, fontface="bold")
-    + scale_color_manual(values=OKABE_ITO, name="Department")
+    + scale_color_manual(values=IMPRINT, name="Department")
     + scale_size_identity()
     + scale_x_continuous(limits=(-0.05, 1.05))
     + scale_y_continuous(limits=(-0.05, 1.05))

--- a/plots/network-bipartite/implementations/python/letsplot.py
+++ b/plots/network-bipartite/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 STUDENT_COLOR = "#009E73"
-COURSE_COLOR = "#D55E00"
+COURSE_COLOR = "#C475FD"
 
 # Data — student-course enrollment network
 students = ["Alice", "Bob", "Carol", "David", "Emma", "Frank", "Grace", "Henry", "Iris", "James", "Kate", "Leo"]

--- a/plots/network-directed/implementations/python/letsplot.py
+++ b/plots/network-directed/implementations/python/letsplot.py
@@ -42,7 +42,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (positions 1-4 for node groups)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Define software package dependency network
 nodes = [
@@ -103,7 +103,7 @@ node_df["y"] = node_df["id"].map(lambda n: node_positions[n][1])
 
 # Map groups to Okabe-Ito colors
 group_order = ["Application", "Core", "Infrastructure", "Utility"]
-group_colors = {group: OKABE_ITO[i] for i, group in enumerate(group_order)}
+group_colors = {group: IMPRINT[i] for i, group in enumerate(group_order)}
 node_df["color"] = node_df["group"].map(group_colors)
 
 # Build edge dataframe with arrow endpoints
@@ -146,7 +146,7 @@ plot = (
     # Add node labels
     + geom_text(aes(x="x", y="y", label="label"), data=node_df, size=12, color=INK, fontface="bold", nudge_y=-0.06)
     # Color scale
-    + scale_fill_manual(values=OKABE_ITO, name="Module Type")
+    + scale_fill_manual(values=IMPRINT, name="Module Type")
     # Theme and styling
     + theme_void()
     + theme(

--- a/plots/network-force-directed/implementations/python/letsplot.py
+++ b/plots/network-force-directed/implementations/python/letsplot.py
@@ -42,7 +42,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 EDGE_COLOR = "#1A1A17" if THEME == "light" else "#F0EFE8"
 
 # Okabe-Ito categorical palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: 50-node social network with 3 communities
 np.random.seed(42)
@@ -150,7 +150,7 @@ plot = (
         alpha=0.92,
         tooltips=layer_tooltips().line("Team: @Team").line("Connections: @Connections"),
     )
-    + scale_color_manual(values=OKABE_ITO, name="Team")
+    + scale_color_manual(values=IMPRINT, name="Team")
     + scale_size_identity(guide="none")
     + scale_alpha_identity(guide="none")
     + coord_fixed(ratio=1)

--- a/plots/network-hierarchical/implementations/python/letsplot.py
+++ b/plots/network-hierarchical/implementations/python/letsplot.py
@@ -136,7 +136,7 @@ for node in nodes:
     y_pos[node["id"]] = 1 - (node["level"] / max_level)
 
 # Okabe-Ito palette: first level always #009E73, then follow canonical order
-okabe_ito = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+okabe_ito = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 level_names = ["Executive", "VP", "Manager", "Staff"]
 
 # Create edges dataframe

--- a/plots/network-transport-static/implementations/python/letsplot.py
+++ b/plots/network-transport-static/implementations/python/letsplot.py
@@ -42,7 +42,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette for route types
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Regional rail network with stations and routes
 np.random.seed(42)
@@ -150,7 +150,7 @@ edges_df = pd.DataFrame(edges_data)
 
 # Map route types to Okabe-Ito colors
 route_type_order = ["Express", "Regional", "Local"]
-route_colors = {route_type_order[i]: OKABE_ITO[i] for i in range(len(route_type_order))}
+route_colors = {route_type_order[i]: IMPRINT[i] for i in range(len(route_type_order))}
 
 # Create tooltip specs for interactive hover
 edge_tooltips = (
@@ -185,7 +185,7 @@ plot = (
         size=12,
         color="white",
         shape=21,
-        fill=OKABE_ITO[0],
+        fill=IMPRINT[0],
         stroke=2.5,
         tooltips=station_tooltips,
     )

--- a/plots/ohlc-bar/implementations/python/letsplot.py
+++ b/plots/ohlc-bar/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette for up/down
 UP_COLOR = "#009E73"  # Brand green (position 1)
-DOWN_COLOR = "#D55E00"  # Vermillion (position 2)
+DOWN_COLOR = "#AE3030"  # imprint red — down bars
 
 # Data: Generate 50 trading days of OHLC data
 np.random.seed(42)

--- a/plots/parallel-basic/implementations/python/letsplot.py
+++ b/plots/parallel-basic/implementations/python/letsplot.py
@@ -36,7 +36,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris dataset with 4 dimensions
 # Using 30 samples (10 per species) for clarity
@@ -243,7 +243,7 @@ plot = (
     # Data lines connecting observations across dimensions
     + geom_line(aes(x="x", y="y", group="observation", color="species"), data=line_df, size=1.5, alpha=0.7)
     # Okabe-Ito palette — first series is brand green
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     # Dimension labels at the bottom (theme-adaptive color, size >=20pt)
     + geom_text(aes(x="x", y="y", label="label"), data=label_df, size=20, color=INK)
     # Tick value labels on the left side of axes (theme-adaptive color, size >=16pt)

--- a/plots/parallel-categories-basic/implementations/python/letsplot.py
+++ b/plots/parallel-categories-basic/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first 3 colors for the 3 channels)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Customer journey data with multiple categorical dimensions
 # Dimensions: Channel (acquisition), Product Category, Purchase Size, Outcome
@@ -94,7 +94,7 @@ categories = {
 }
 
 # Colors for the first dimension (Channel) - using Okabe-Ito palette
-channel_colors = {"Online": OKABE_ITO[0], "Store": OKABE_ITO[1], "Mobile": OKABE_ITO[2]}
+channel_colors = {"Online": IMPRINT[0], "Store": IMPRINT[1], "Mobile": IMPRINT[2]}
 
 # Calculate totals for each dimension-category combination
 dimension_totals = {dim: {} for dim in dimensions}

--- a/plots/parliament-basic/implementations/python/letsplot.py
+++ b/plots/parliament-basic/implementations/python/letsplot.py
@@ -27,7 +27,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series ALWAYS #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data - Board of Directors composition (neutral, non-political)
 parties = [
@@ -80,7 +80,7 @@ df["party_label"] = df["party"].apply(lambda p: f"{p} ({party_seat_counts[p]})")
 
 # Create color mapping (Okabe-Ito in order)
 color_map = {
-    f"{p} ({s})": OKABE_ITO[i]
+    f"{p} ({s})": IMPRINT[i]
     for i, (p, s) in enumerate(zip(parties, seats, strict=True))
 }
 color_values = [color_map[label] for label in df["party_label"].unique()]

--- a/plots/pdp-basic/implementations/python/letsplot.py
+++ b/plots/pdp-basic/implementations/python/letsplot.py
@@ -25,7 +25,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors
 BRAND = "#009E73"
-ACCENT = "#D55E00"
+ACCENT = "#C475FD"
 
 # Train a model for partial dependence
 np.random.seed(42)

--- a/plots/phase-diagram/implementations/python/letsplot.py
+++ b/plots/phase-diagram/implementations/python/letsplot.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito colors
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Damped harmonic oscillator with distinct parameters
 # dx/dt = v, dv/dt = -omega^2 * x - gamma * v
@@ -96,7 +96,7 @@ plot = (
         stroke=3,
         inherit_aes=False,
     )
-    + scale_color_manual(values=OKABE_ITO)  # noqa: F405
+    + scale_color_manual(values=IMPRINT)  # noqa: F405
     + labs(  # noqa: F405
         x="Position (x)", y="Velocity (dx/dt)", title="phase-diagram · letsplot · anyplot.ai", color="Initial Condition"
     )

--- a/plots/pie-drilldown/implementations/python/letsplot.py
+++ b/plots/pie-drilldown/implementations/python/letsplot.py
@@ -23,11 +23,11 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette (using position 1 as first series)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # bluish green (brand)
-    "#D55E00",  # vermillion
-    "#0072B2",  # blue
-    "#CC79A7",  # reddish purple
+    "#C475FD",  # vermillion
+    "#4467A3",  # blue
+    "#BD8233",  # reddish purple
 ]
 
 # Hierarchical data: Company budget breakdown by department
@@ -75,10 +75,10 @@ hierarchy_data = {
 
 # Color scheme: Okabe-Ito for main departments, with shade variations for subcategories
 colors = {
-    "Engineering": OKABE_ITO[0],  # #009E73
-    "Marketing": OKABE_ITO[1],  # #D55E00
-    "Operations": OKABE_ITO[2],  # #0072B2
-    "Human Resources": OKABE_ITO[3],  # #CC79A7
+    "Engineering": IMPRINT[0],  # #009E73
+    "Marketing": IMPRINT[1],  # #C475FD
+    "Operations": IMPRINT[2],  # #4467A3
+    "Human Resources": IMPRINT[3],  # #BD8233
     # Engineering sub-colors (green shades)
     "Salaries": "#4A8BBE",
     "Tools & Software": "#6BA3D6",
@@ -185,7 +185,7 @@ for level_id in ["root", "engineering", "marketing", "operations", "hr"]:
             "categories": cats,
             "values": vals,
             "percentages": pcts,
-            "colors": [colors.get(cat, OKABE_ITO[0]) for cat in cats],
+            "colors": [colors.get(cat, IMPRINT[0]) for cat in cats],
             "children": hierarchy_data[level_id].get("children", []),
             "parent": hierarchy_data[level_id].get("parent"),
         }
@@ -250,7 +250,7 @@ html_content = f"""<!DOCTYPE html>
             gap: 10px;
         }}
         .back-btn {{
-            background: {OKABE_ITO[0]};
+            background: {IMPRINT[0]};
             color: white;
             border: none;
             padding: 8px 16px;
@@ -357,7 +357,7 @@ html_content = f"""<!DOCTYPE html>
         }}
         .total-display .amount {{
             font-weight: 700;
-            color: {OKABE_ITO[0]};
+            color: {IMPRINT[0]};
             font-size: 24px;
         }}
     </style>

--- a/plots/point-and-figure-basic/implementations/python/letsplot.py
+++ b/plots/point-and-figure-basic/implementations/python/letsplot.py
@@ -124,7 +124,7 @@ plot = (
         fontface="bold",
         tooltips=layer_tooltips().line("Column: @column").line("Price: $@price").line("Signal: @symbol"),
     )
-    + scale_color_manual(values={"up": "#009E73", "down": "#D55E00"})
+    + scale_color_manual(values={"up": "#009E73", "down": "#AE3030"})  # imprint red for down
     + scale_x_continuous(name="Column (Reversal Number)")
     + scale_y_continuous(name="Price ($)")
     + labs(title="point-and-figure-basic · python · letsplot · anyplot.ai")

--- a/plots/polar-bar/implementations/python/letsplot.py
+++ b/plots/polar-bar/implementations/python/letsplot.py
@@ -36,9 +36,9 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette + adaptive neutral for 8 compass directions
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 NEUTRAL = "#1A1A1A" if THEME == "light" else "#E8E8E0"
-DIRECTION_COLORS = OKABE_ITO + [NEUTRAL]
+DIRECTION_COLORS = IMPRINT + [NEUTRAL]
 
 # Data - Monsoon wind pattern (SW-dominant, distinct from westerlies)
 directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]

--- a/plots/polar-scatter/implementations/python/letsplot.py
+++ b/plots/polar-scatter/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (categorical)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Generate synthetic wind measurement data
 np.random.seed(42)
@@ -69,7 +69,7 @@ plot = (
         expand=[0, 0],
     )
     + scale_y_continuous(limits=[0, None], expand=[0, 0.05])
-    + scale_color_manual(values=OKABE_ITO, name="Time of Day")
+    + scale_color_manual(values=IMPRINT, name="Time of Day")
     + labs(title="polar-scatter · letsplot · anyplot.ai", x="", y="Wind Speed (m/s)")
     + theme_minimal()
     + theme(

--- a/plots/precision-recall/implementations/python/letsplot.py
+++ b/plots/precision-recall/implementations/python/letsplot.py
@@ -25,7 +25,7 @@ RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (first series always #009E73)
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 
 # Generate synthetic classification data with imbalanced classes
 np.random.seed(42)

--- a/plots/radar-multi/implementations/python/letsplot.py
+++ b/plots/radar-multi/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Smartphone comparison across 6 key attributes (4 products)
 categories = ["Battery", "Camera", "Display", "Performance", "Storage", "Price Value"]
@@ -126,8 +126,8 @@ plot = (
     # Points at each vertex (exclude the closing point to avoid double dot)
     + geom_point(aes(x="x", y="y", color="series"), data=df[df["order"] < n], size=7)
     # Custom color palette (Okabe-Ito)
-    + scale_fill_manual(values=OKABE_ITO)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
+    + scale_color_manual(values=IMPRINT)
     # Axis limits for square plot
     + scale_x_continuous(limits=(-160, 160))
     + scale_y_continuous(limits=(-160, 160))

--- a/plots/range-interval/implementations/python/letsplot.py
+++ b/plots/range-interval/implementations/python/letsplot.py
@@ -20,8 +20,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT1 = "#D55E00"  # Okabe-Ito position 2
-ACCENT2 = "#0072B2"  # Okabe-Ito position 3
+ACCENT1 = "#C475FD"  # Okabe-Ito position 2
+ACCENT2 = "#4467A3"  # Okabe-Ito position 3
 
 # Data: Monthly temperature ranges (°C) for a weather station
 data = {

--- a/plots/renko-basic/implementations/python/letsplot.py
+++ b/plots/renko-basic/implementations/python/letsplot.py
@@ -24,7 +24,7 @@ RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette (bullish: position 1, bearish: position 2 for better accessibility)
 BULLISH = "#009E73"  # Okabe-Ito position 1
-BEARISH = "#D55E00"  # Okabe-Ito position 2
+BEARISH = "#AE3030"  # imprint red — bearish
 
 # Generate synthetic stock price data
 np.random.seed(42)

--- a/plots/residual-plot/implementations/python/letsplot.py
+++ b/plots/residual-plot/implementations/python/letsplot.py
@@ -25,7 +25,7 @@ RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1: bluish green (normal points)
-OUTLIER_COLOR = "#D55E00"  # Position 2: vermillion (outliers)
+OUTLIER_COLOR = "#AE3030"  # imprint red — outliers (>2σ)
 
 # Data: Generate realistic regression scenario with deliberate pattern in residuals
 np.random.seed(42)

--- a/plots/roc-curve/implementations/python/letsplot.py
+++ b/plots/roc-curve/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Generate ROC curve data for multiple classifiers
 np.random.seed(42)
@@ -87,7 +87,7 @@ df = pd.concat([df_model_a, df_model_b, df_random], ignore_index=True)
 
 # Theme-adaptive color for reference line
 ref_color = "#6B6A63" if THEME == "light" else "#A8A79F"
-colors = [OKABE_ITO[0], OKABE_ITO[1], ref_color]
+colors = [IMPRINT[0], IMPRINT[1], ref_color]
 
 # Plot
 plot = (

--- a/plots/sankey-basic/implementations/python/letsplot.py
+++ b/plots/sankey-basic/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for source categories (canonical order, first = #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Energy flow data: sources -> sectors (realistic energy distribution)
 flows = [
@@ -56,7 +56,7 @@ flows = [
 
 sources = ["Coal", "Natural Gas", "Nuclear", "Renewable"]
 targets = ["Industrial", "Residential", "Commercial"]
-source_color_map = dict(zip(sources, OKABE_ITO, strict=True))
+source_color_map = dict(zip(sources, IMPRINT, strict=True))
 
 # Calculate totals for each node
 source_totals = {}

--- a/plots/scatter-animated-controls/implementations/python/letsplot.py
+++ b/plots/scatter-animated-controls/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Simulated country-level metrics over 20 years (Gapminder-style)
 np.random.seed(42)
@@ -67,7 +67,7 @@ for idx, country in enumerate(countries):
                 "gdp_per_capita": gdp,
                 "life_expectancy": life_exp,
                 "population": pop,
-                "color_idx": idx % len(OKABE_ITO),
+                "color_idx": idx % len(IMPRINT),
             }
         )
 
@@ -83,7 +83,7 @@ df_key = df[df["year"].isin(key_years)].copy()
 df_key["year_label"] = df_key["year"].astype(str)
 
 # Create color mapping based on Okabe-Ito palette
-country_colors = {c: OKABE_ITO[i % len(OKABE_ITO)] for i, c in enumerate(countries)}
+country_colors = {c: IMPRINT[i % len(IMPRINT)] for i, c in enumerate(countries)}
 
 # Theme configuration
 anyplot_theme = theme(

--- a/plots/scatter-brush-zoom/implementations/python/letsplot.py
+++ b/plots/scatter-brush-zoom/implementations/python/letsplot.py
@@ -39,10 +39,10 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is ALWAYS #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Brush rectangle color
-BRUSH_COLOR = "#0072B2"
+BRUSH_COLOR = "#4467A3"
 
 # Data - Generate clustered data for brush selection demonstration
 np.random.seed(42)
@@ -115,7 +115,7 @@ plot = (
     )
     # Plot points with alpha based on selection state
     + geom_point(aes(color="category", alpha="point_alpha"), size=5, tooltips=tooltips)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + scale_alpha_identity()
     + labs(
         x="X Value (units)", y="Y Value (units)", title="scatter-brush-zoom · letsplot · anyplot.ai", color="Category"

--- a/plots/scatter-categorical/implementations/python/letsplot.py
+++ b/plots/scatter-categorical/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Plant growth by treatment type
 np.random.seed(42)
@@ -50,7 +50,7 @@ df = pd.DataFrame(
 plot = (
     ggplot(df, aes(x="Temperature (°C)", y="Growth Rate (%)", color="Treatment", shape="Treatment"))
     + geom_point(size=3.5, alpha=0.8, stroke=0.8)
-    + scale_color_manual(values=OKABE_ITO[:4])
+    + scale_color_manual(values=IMPRINT[:4])
     + scale_shape_manual(values=[21, 22, 23, 24])  # Circle, square, diamond, triangle
     + labs(
         x="Temperature (°C)",

--- a/plots/scatter-embedding/implementations/python/letsplot.py
+++ b/plots/scatter-embedding/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data — simulate single-cell RNA-seq gene expression then embed via t-SNE
 np.random.seed(42)
@@ -57,7 +57,7 @@ anyplot_theme = theme(
 plot = (
     ggplot(df, aes(x="tsne_1", y="tsne_2", color="cell_type"))
     + geom_point(size=3, alpha=0.65)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + labs(
         x="t-SNE 1",
         y="t-SNE 2",

--- a/plots/scatter-map-geographic/implementations/python/letsplot.py
+++ b/plots/scatter-map-geographic/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD"]
 
 # Data: Major world cities with population and region
 np.random.seed(42)
@@ -352,12 +352,12 @@ df_continents = pd.DataFrame(continents)
 
 # Region color mapping using Okabe-Ito
 region_colors = {
-    "Asia": OKABE_ITO[0],  # #009E73
-    "Europe": OKABE_ITO[1],  # #D55E00
-    "N. America": OKABE_ITO[2],  # #0072B2
-    "S. America": OKABE_ITO[3],  # #CC79A7
-    "Africa": OKABE_ITO[4],  # #E69F00
-    "Oceania": OKABE_ITO[5],  # #56B4E9
+    "Asia": IMPRINT[0],  # #009E73
+    "Europe": IMPRINT[1],  # #C475FD
+    "N. America": IMPRINT[2],  # #4467A3
+    "S. America": IMPRINT[3],  # #BD8233
+    "Africa": IMPRINT[4],  # #AE3030
+    "Oceania": IMPRINT[5],  # #2ABCCD
 }
 
 # Basemap color

--- a/plots/scatter-marginal/implementations/python/letsplot.py
+++ b/plots/scatter-marginal/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 BRAND = "#009E73"  # Okabe-Ito position 1
-ACCENT = "#D55E00"  # Okabe-Ito position 2
+ACCENT = "#C475FD"  # Okabe-Ito position 2
 
 # Data - bivariate data with correlation
 np.random.seed(42)

--- a/plots/scatter-matrix-interactive/implementations/python/letsplot.py
+++ b/plots/scatter-matrix-interactive/implementations/python/letsplot.py
@@ -42,7 +42,7 @@ GRID_COLOR = "#E8E5DB" if THEME == "light" else "#2A2925"
 ACCENT_COLOR = "#009E73"
 
 # Okabe-Ito palette - first series (#009E73) is always first
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Synthetic iris-like dataset (4 numeric variables, 150 points)
 np.random.seed(42)
@@ -98,7 +98,7 @@ for i, var_y in enumerate(variables):
             p = (
                 ggplot(df, aes(x=var_x, fill="Species"))
                 + geom_histogram(alpha=0.75, bins=16, position="identity")
-                + scale_fill_manual(values=OKABE_ITO)
+                + scale_fill_manual(values=IMPRINT)
                 + labs(x=var_x if show_x_label else "", y="")
                 + theme_minimal()
                 + theme(
@@ -129,8 +129,8 @@ for i, var_y in enumerate(variables):
                     .line(f"{var_x}: @{{{var_x}}}")
                     .line(f"{var_y}: @{{{var_y}}}"),
                 )
-                + scale_color_manual(values=OKABE_ITO)
-                + scale_fill_manual(values=OKABE_ITO)
+                + scale_color_manual(values=IMPRINT)
+                + scale_fill_manual(values=IMPRINT)
                 + labs(x=var_x if show_x_label else "", y=var_y if show_y_label else "")
                 + theme_minimal()
                 + theme(
@@ -179,8 +179,8 @@ legend_df = pd.DataFrame({"x": [1, 2, 3], "y": [0, 0, 0], "Species": ["Setosa", 
 legend_plot = (
     ggplot(legend_df, aes(x="x", y="y", color="Species", fill="Species"))
     + geom_point(size=8, shape=21, alpha=0.85, stroke=0.5)
-    + scale_color_manual(values=OKABE_ITO)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
+    + scale_fill_manual(values=IMPRINT)
     + theme_minimal()
     + theme(
         plot_background=element_rect(fill=PAGE_BG, color=PAGE_BG),

--- a/plots/scatter-matrix/implementations/python/letsplot.py
+++ b/plots/scatter-matrix/implementations/python/letsplot.py
@@ -20,7 +20,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data - Iris-like dataset with 4 variables
 np.random.seed(42)
@@ -87,7 +87,7 @@ for i, var_y in enumerate(variables):
             p = (
                 ggplot(df_plot, aes(x=var_x, fill="Species"))
                 + geom_histogram(alpha=0.7, bins=15, position="identity")
-                + scale_fill_manual(values=OKABE_ITO)
+                + scale_fill_manual(values=IMPRINT)
                 + theme_minimal()
                 + theme(
                     axis_title=element_blank(),
@@ -104,7 +104,7 @@ for i, var_y in enumerate(variables):
             p = (
                 ggplot(df_plot, aes(x=var_x, y=var_y, color="Species"))
                 + geom_point(size=3.5, alpha=0.7)
-                + scale_color_manual(values=OKABE_ITO)
+                + scale_color_manual(values=IMPRINT)
                 + theme_minimal()
                 + theme(
                     axis_title=element_blank(),
@@ -149,7 +149,7 @@ legend_df = pd.DataFrame({"x": [1, 2, 3], "y": [1, 2, 3], "Species": ["Setosa", 
 legend_plot = (
     ggplot(legend_df, aes(x="x", y="y", color="Species"))
     + geom_point(size=8)
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     + theme_void()
     + theme(
         legend_position="bottom",

--- a/plots/scatter-regression-linear/implementations/python/letsplot.py
+++ b/plots/scatter-regression-linear/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-SECONDARY = "#D55E00"
+SECONDARY = "#C475FD"
 
 # Data - Advertising spend vs sales revenue relationship
 np.random.seed(42)

--- a/plots/scatter-regression-lowess/implementations/python/letsplot.py
+++ b/plots/scatter-regression-lowess/implementations/python/letsplot.py
@@ -36,7 +36,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - for scatter points
-ACCENT = "#D55E00"  # Position 2 - for LOWESS curve
+ACCENT = "#C475FD"  # Position 2 - for LOWESS curve
 
 # Data - Complex non-linear relationship (plant growth vs temperature)
 np.random.seed(42)

--- a/plots/scatter-regression-polynomial/implementations/python/letsplot.py
+++ b/plots/scatter-regression-polynomial/implementations/python/letsplot.py
@@ -22,7 +22,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 RULE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
 BRAND = "#009E73"  # Okabe-Ito position 1 - first categorical series
-ACCENT = "#D55E00"  # Okabe-Ito position 2 - for regression line
+ACCENT = "#C475FD"  # Okabe-Ito position 2 - for regression line
 
 # Data - Simulating diminishing returns pattern (economics example)
 np.random.seed(42)

--- a/plots/scatter-text/implementations/python/letsplot.py
+++ b/plots/scatter-text/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Programming languages positioned by paradigm (functional vs object-oriented)
 # and level of abstraction (low vs high)
@@ -163,13 +163,13 @@ category_order = [
 ]
 
 color_palette = {
-    "General": OKABE_ITO[0],  # #009E73 (brand green)
-    "Web": OKABE_ITO[1],  # #D55E00 (vermillion)
-    "Systems": OKABE_ITO[2],  # #0072B2 (blue)
-    "Mobile": OKABE_ITO[3],  # #CC79A7 (reddish purple)
-    "Functional": OKABE_ITO[4],  # #E69F00 (orange)
-    "Scripting": OKABE_ITO[5],  # #56B4E9 (sky blue)
-    "Data Science": OKABE_ITO[6],  # #F0E442 (yellow)
+    "General": IMPRINT[0],  # #009E73 (brand green)
+    "Web": IMPRINT[1],  # #C475FD (vermillion)
+    "Systems": IMPRINT[2],  # #4467A3 (blue)
+    "Mobile": IMPRINT[3],  # #BD8233 (reddish purple)
+    "Functional": IMPRINT[4],  # #AE3030 (orange)
+    "Scripting": IMPRINT[5],  # #2ABCCD (sky blue)
+    "Data Science": IMPRINT[6],  # #954477 (yellow)
     "Scientific": INK_SOFT,  # Neutral for scientific
     "Legacy": INK_SOFT,  # Neutral for legacy
 }

--- a/plots/shap-summary/implementations/python/letsplot.py
+++ b/plots/shap-summary/implementations/python/letsplot.py
@@ -162,7 +162,7 @@ plot = (
     ggplot(df, aes(x="SHAP Value", y="y_position", color="Feature Value"))
     + geom_point(size=3, alpha=0.7)
     + geom_vline(xintercept=0, color=INK_MUTED, size=0.8, linetype="dashed")
-    + scale_color_gradient(low="#0072B2", high="#D55E00", name="Feature\nValue")
+    + scale_color_gradient(low="#4467A3", high="#C475FD", name="Feature\nValue")
     + scale_y_continuous(breaks=list(range(top_k)), labels=ordered_features[::-1])
     + labs(x="SHAP Value (impact on model output)", y="", title="shap-summary · letsplot · anyplot.ai")
     + ggsize(1600, 900)

--- a/plots/shap-waterfall/implementations/python/letsplot.py
+++ b/plots/shap-waterfall/implementations/python/letsplot.py
@@ -21,8 +21,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
-POS_COLOR = "#D55E00"  # Okabe-Ito vermillion — positive SHAP (increases predicted risk)
-NEG_COLOR = "#0072B2"  # Okabe-Ito blue — negative SHAP (decreases predicted risk)
+POS_COLOR = "#AE3030"  # imprint red — positive SHAP (increases predicted risk)
+NEG_COLOR = "#4467A3"  # Okabe-Ito blue — negative SHAP (decreases predicted risk)
 
 # Data — loan default risk model explaining one applicant's prediction
 # Features already sorted by absolute SHAP magnitude (largest at top)

--- a/plots/silhouette-basic/implementations/python/letsplot.py
+++ b/plots/silhouette-basic/implementations/python/letsplot.py
@@ -24,7 +24,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette - first series is always #009E73 (brand green)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Clustering iris dataset into 3 groups
 np.random.seed(42)
@@ -76,7 +76,7 @@ df = pd.DataFrame(data_rows)
 df["x_start"] = 0  # Starting x position for horizontal bars
 
 # Map cluster indices to Okabe-Ito colors
-df["cluster_color"] = df["cluster_idx"].map({i: OKABE_ITO[i % len(OKABE_ITO)] for i in range(n_clusters)})
+df["cluster_color"] = df["cluster_idx"].map({i: IMPRINT[i % len(IMPRINT)] for i in range(n_clusters)})
 
 # Create annotation dataframe for cluster labels
 annotation_df = pd.DataFrame(
@@ -113,7 +113,7 @@ plot = (
     + geom_segment(aes(xend="silhouette", yend="y"), x=0, size=1.5)
     + geom_vline(xintercept=avg_silhouette, color=INK_SOFT, linetype="dashed", size=1)
     + geom_text(aes(x="x", y="y", label="label"), data=annotation_df, size=14, hjust=1, color=INK_SOFT)
-    + scale_color_manual(values=OKABE_ITO[:n_clusters])
+    + scale_color_manual(values=IMPRINT[:n_clusters])
     + labs(
         x="Silhouette Coefficient",
         y="Sample Index (sorted within cluster)",

--- a/plots/skewt-logp-atmospheric/implementations/python/letsplot.py
+++ b/plots/skewt-logp-atmospheric/implementations/python/letsplot.py
@@ -41,10 +41,10 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — positions 1-6 in order
 C_TEMP = "#009E73"  # position 1: temperature profile (primary series)
-C_DEWPT = "#D55E00"  # position 2: dewpoint profile
-C_DRY = "#E69F00"  # position 5: dry adiabats (background reference)
-C_MOIST = "#CC79A7"  # position 4: moist adiabats (background reference)
-C_MIX = "#56B4E9"  # position 6: mixing ratio lines (background reference)
+C_DEWPT = "#C475FD"  # position 2: dewpoint profile
+C_DRY = "#AE3030"  # position 5: dry adiabats (background reference)
+C_MOIST = "#BD8233"  # position 4: moist adiabats (background reference)
+C_MIX = "#2ABCCD"  # position 6: mixing ratio lines (background reference)
 
 # Atmospheric sounding data (synthetic radiosonde profile)
 np.random.seed(42)

--- a/plots/slope-basic/implementations/python/letsplot.py
+++ b/plots/slope-basic/implementations/python/letsplot.py
@@ -42,7 +42,7 @@ GRID_COLOR = "#C8C7BF" if THEME == "light" else "#333330"
 
 # Okabe-Ito: green = increase, orange = decrease
 COLOR_INCREASE = "#009E73"
-COLOR_DECREASE = "#D55E00"
+COLOR_DECREASE = "#AE3030"  # imprint red — decrease
 
 # Consumer electronics quarterly sales ($K): Q1 vs Q4
 data = {

--- a/plots/smith-chart-basic/implementations/python/letsplot.py
+++ b/plots/smith-chart-basic/implementations/python/letsplot.py
@@ -34,8 +34,8 @@ PAGE_BG = "#FAF8F1" if THEME == "light" else "#1A1A17"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-COLOR_START = "#0072B2"  # Okabe-Ito position 3
-COLOR_END = "#D55E00"  # Okabe-Ito position 2
+COLOR_START = "#4467A3"  # Okabe-Ito position 3
+COLOR_END = "#C475FD"  # Okabe-Ito position 2
 
 Z0 = 50  # Reference impedance (ohms)
 

--- a/plots/sn-curve-basic/implementations/python/letsplot.py
+++ b/plots/sn-curve-basic/implementations/python/letsplot.py
@@ -23,9 +23,9 @@ GRID = "#E4E2DB" if THEME == "light" else "#2F2F2C"
 
 # Okabe-Ito palette — positions 1-4
 BRAND = "#009E73"  # position 1 — data points and fit line
-OI_2 = "#D55E00"  # vermillion — Ultimate Strength
-OI_3 = "#0072B2"  # blue — Yield Strength
-OI_4 = "#CC79A7"  # reddish purple — Endurance Limit
+OI_2 = "#C475FD"  # vermillion — Ultimate Strength
+OI_3 = "#4467A3"  # blue — Yield Strength
+OI_4 = "#BD8233"  # reddish purple — Endurance Limit
 
 # Generate realistic S-N curve data for structural steel
 np.random.seed(42)

--- a/plots/streamgraph-basic/implementations/python/letsplot.py
+++ b/plots/streamgraph-basic/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette — first series always #009E73
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data — monthly streaming hours by music genre over two years
 np.random.seed(42)
@@ -83,7 +83,7 @@ anyplot_theme = theme(  # noqa: F405
 plot = (
     ggplot(df, aes(x="month", fill="genre"))  # noqa: F405
     + geom_ribbon(aes(ymin="ymin", ymax="ymax"), alpha=0.9)  # noqa: F405
-    + scale_fill_manual(values=OKABE_ITO)  # noqa: F405
+    + scale_fill_manual(values=IMPRINT)  # noqa: F405
     + scale_x_continuous(  # noqa: F405
         breaks=[0, 6, 12, 18, 23], labels=["Jan '23", "Jul '23", "Jan '24", "Jul '24", "Dec '24"]
     )

--- a/plots/subplot-grid/implementations/python/letsplot.py
+++ b/plots/subplot-grid/implementations/python/letsplot.py
@@ -22,14 +22,14 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (colorblind-safe)
-OKABE_ITO = [
+IMPRINT = [
     "#009E73",  # 1: brand green
-    "#D55E00",  # 2: vermillion
-    "#0072B2",  # 3: blue
-    "#CC79A7",  # 4: reddish purple
-    "#E69F00",  # 5: orange
-    "#56B4E9",  # 6: sky blue
-    "#F0E442",  # 7: yellow
+    "#C475FD",  # 2: vermillion
+    "#4467A3",  # 3: blue
+    "#BD8233",  # 4: reddish purple
+    "#AE3030",  # 5: orange
+    "#2ABCCD",  # 6: sky blue
+    "#954477",  # 7: yellow
 ]
 
 # Data - Financial dashboard theme
@@ -79,8 +79,8 @@ anyplot_theme = theme(
 # Top left: Price line chart (brand green for primary, orange for secondary)
 price_plot = (
     ggplot(price_df, aes(x="day", y="price"))
-    + geom_line(color=OKABE_ITO[0], size=1.5)
-    + geom_line(aes(y="rolling_avg"), color=OKABE_ITO[1], size=1.2, linetype="dashed")
+    + geom_line(color=IMPRINT[0], size=1.5)
+    + geom_line(aes(y="rolling_avg"), color=IMPRINT[1], size=1.2, linetype="dashed")
     + labs(x="Trading Day", y="Price ($)", title="Stock Price with 10-Day Moving Average")
     + theme_minimal()
     + anyplot_theme
@@ -89,7 +89,7 @@ price_plot = (
 # Top right: Volume bar chart (blue)
 volume_plot = (
     ggplot(volume_df, aes(x="day", y="volume"))
-    + geom_bar(stat="identity", fill=OKABE_ITO[2], alpha=0.8, width=0.8)
+    + geom_bar(stat="identity", fill=IMPRINT[2], alpha=0.8, width=0.8)
     + labs(x="Trading Day", y="Volume (Millions)", title="Daily Trading Volume")
     + theme_minimal()
     + anyplot_theme
@@ -98,8 +98,8 @@ volume_plot = (
 # Bottom left: Returns histogram (reddish purple bars, brand green reference line)
 returns_plot = (
     ggplot(returns_df, aes(x="return"))
-    + geom_histogram(fill=OKABE_ITO[3], color=INK_SOFT, bins=20, alpha=0.8)
-    + geom_vline(xintercept=0, color=OKABE_ITO[0], size=1.5, linetype="dashed")
+    + geom_histogram(fill=IMPRINT[3], color=INK_SOFT, bins=20, alpha=0.8)
+    + geom_vline(xintercept=0, color=IMPRINT[0], size=1.5, linetype="dashed")
     + labs(x="Daily Return (%)", y="Frequency", title="Distribution of Daily Returns")
     + theme_minimal()
     + anyplot_theme
@@ -109,8 +109,8 @@ returns_plot = (
 scatter_df = pd.DataFrame({"abs_return": np.abs(daily_returns), "volume": volume[1:] / 1_000_000})
 scatter_plot = (
     ggplot(scatter_df, aes(x="abs_return", y="volume"))
-    + geom_point(color=OKABE_ITO[4], size=4, alpha=0.7)
-    + geom_smooth(method="lm", color=OKABE_ITO[0], size=1.5, fill=None)
+    + geom_point(color=IMPRINT[4], size=4, alpha=0.7)
+    + geom_smooth(method="lm", color=IMPRINT[0], size=1.5, fill=None)
     + labs(x="Absolute Return (%)", y="Volume (Millions)", title="Volume vs Price Movement")
     + theme_minimal()
     + anyplot_theme

--- a/plots/subplot-mosaic/implementations/python/letsplot.py
+++ b/plots/subplot-mosaic/implementations/python/letsplot.py
@@ -19,7 +19,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 np.random.seed(42)
 
@@ -74,8 +74,8 @@ base_theme = theme_minimal() + theme(
 # Panel A: Wide time series (top, spans all 3 columns)
 plot_a = (
     ggplot(df_overview, aes("day_num", "revenue"))
-    + geom_area(fill=OKABE_ITO[0], alpha=0.3)
-    + geom_line(color=OKABE_ITO[0], size=2)
+    + geom_area(fill=IMPRINT[0], alpha=0.3)
+    + geom_line(color=IMPRINT[0], size=2)
     + labs(x="Day", y="Revenue ($)", title="Daily Revenue Overview")
     + base_theme
 )
@@ -83,7 +83,7 @@ plot_a = (
 # Panel B: Bar chart (middle row, spans 2/3 width)
 plot_b = (
     ggplot(df_bar, aes("category", "sales"))
-    + geom_bar(stat="identity", fill=OKABE_ITO[0], color=INK_SOFT, size=0.6, alpha=0.85)
+    + geom_bar(stat="identity", fill=IMPRINT[0], color=INK_SOFT, size=0.6, alpha=0.85)
     + labs(x="Product Category", y="Units Sold", title="Sales by Product")
     + base_theme
     + theme(axis_text_x=element_text(angle=45, hjust=1))
@@ -92,8 +92,8 @@ plot_b = (
 # Panel C: Scatter plot (middle row, 1/3 width)
 plot_c = (
     ggplot(df_scatter, aes("effort", "output"))
-    + geom_point(color=OKABE_ITO[0], size=6, alpha=0.7, fill=OKABE_ITO[0])
-    + geom_smooth(method="lm", color=OKABE_ITO[1], size=1.5, se=False)
+    + geom_point(color=IMPRINT[0], size=6, alpha=0.7, fill=IMPRINT[0])
+    + geom_smooth(method="lm", color=IMPRINT[1], size=1.5, se=False)
     + labs(x="Effort (hours)", y="Output (units)", title="Effort vs Output")
     + base_theme
 )
@@ -101,7 +101,7 @@ plot_c = (
 # Panel D: Histogram (bottom left)
 plot_d = (
     ggplot(df_hist, aes("metric"))
-    + geom_histogram(bins=25, fill=OKABE_ITO[0], color=INK_SOFT, alpha=0.8, size=0.3)
+    + geom_histogram(bins=25, fill=IMPRINT[0], color=INK_SOFT, alpha=0.8, size=0.3)
     + labs(x="Performance Score", y="Frequency", title="Score Distribution")
     + base_theme
 )
@@ -109,8 +109,8 @@ plot_d = (
 # Panel E: Line chart with points (bottom middle)
 plot_e = (
     ggplot(df_line, aes("month_num", "growth"))
-    + geom_line(color=OKABE_ITO[0], size=2.5)
-    + geom_point(color=OKABE_ITO[0], size=8, fill=OKABE_ITO[0], alpha=0.8)
+    + geom_line(color=IMPRINT[0], size=2.5)
+    + geom_point(color=IMPRINT[0], size=8, fill=IMPRINT[0], alpha=0.8)
     + scale_x_continuous(breaks=list(range(6)), labels=months)
     + labs(x="Month", y="Growth Rate (%)", title="Monthly Growth")
     + base_theme

--- a/plots/sunburst-basic/implementations/python/letsplot.py
+++ b/plots/sunburst-basic/implementations/python/letsplot.py
@@ -69,8 +69,8 @@ def create_wedge(inner_r, outer_r, start_angle, end_angle, n_points=30):
 # Okabe-Ito branch colors for level 1; graduated lighter shades for levels 2-3
 branch_colors = {
     "Eng": "#009E73",  # Okabe-Ito position 1 — brand green
-    "Sales": "#D55E00",  # Okabe-Ito position 2 — vermillion
-    "Mktg": "#0072B2",  # Okabe-Ito position 3 — blue
+    "Sales": "#C475FD",  # Okabe-Ito position 2 — vermillion
+    "Mktg": "#4467A3",  # Okabe-Ito position 3 — blue
 }
 level2_colors = {
     "Backend": "#66C5AB",  # Eng, ~40% lighter

--- a/plots/survival-kaplan-meier/implementations/python/letsplot.py
+++ b/plots/survival-kaplan-meier/implementations/python/letsplot.py
@@ -40,7 +40,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito palette (brand color #009E73 is first series)
-OKABE_ITO = ["#009E73", "#D55E00"]
+IMPRINT = ["#009E73", "#C475FD"]
 
 # Data - Simulated clinical trial survival data for two treatment groups
 np.random.seed(42)
@@ -137,8 +137,8 @@ plot = (
         size=4,
         stroke=2,
     )
-    + scale_color_manual(values=OKABE_ITO)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
+    + scale_fill_manual(values=IMPRINT)
     + labs(
         x="Time (months)",
         y="Survival Probability",

--- a/plots/ternary-basic/implementations/python/letsplot.py
+++ b/plots/ternary-basic/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3"]
 
 # Data: Soil composition samples (Sand, Silt, Clay)
 np.random.seed(42)
@@ -164,7 +164,7 @@ plot = (
     # Tick labels
     + geom_text(data=tick_df, mapping=aes(x="x", y="y", label="label"), size=11, color=INK_SOFT)
     # Color scale using Okabe-Ito palette
-    + scale_color_manual(values=OKABE_ITO)
+    + scale_color_manual(values=IMPRINT)
     # Labels and title
     + labs(title="ternary-basic · letsplot · anyplot.ai", color="Soil Type")
     # Theme

--- a/plots/timeline-basic/implementations/python/letsplot.py
+++ b/plots/timeline-basic/implementations/python/letsplot.py
@@ -40,7 +40,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data - Software project milestones (10 events for better readability)
 events = pd.DataFrame(
@@ -109,7 +109,7 @@ plot = (
     # Event labels (positioned at label_y)
     + geom_text(mapping=aes(x="date_num", y="label_y", label="event"), size=10, color=INK)
     # Color scale using Okabe-Ito palette
-    + scale_color_manual(values=OKABE_ITO, name="Phase")
+    + scale_color_manual(values=IMPRINT, name="Phase")
     # Axis configuration - use simple month labels with padding
     + scale_x_continuous(name="Month (2024)", breaks=month_breaks, labels=month_labels, limits=[-15, 365])
     + scale_y_continuous(limits=[-2.2, 2.2])

--- a/plots/timeseries-decomposition/implementations/python/letsplot.py
+++ b/plots/timeseries-decomposition/implementations/python/letsplot.py
@@ -37,7 +37,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for components
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Monthly temperature readings over 5 years (60 months)
 np.random.seed(42)
@@ -64,7 +64,7 @@ df_seasonal = pd.DataFrame({"date": dates, "value": decomposition.seasonal, "com
 df_residual = pd.DataFrame({"date": dates, "value": decomposition.resid, "component": "Residual"})
 
 # Create individual plots for each component
-component_colors = {"Original": OKABE_ITO[0], "Trend": OKABE_ITO[1], "Seasonal": OKABE_ITO[2], "Residual": OKABE_ITO[3]}
+component_colors = {"Original": IMPRINT[0], "Trend": IMPRINT[1], "Seasonal": IMPRINT[2], "Residual": IMPRINT[3]}
 
 anyplot_theme = theme(
     plot_background=element_rect(fill=PAGE_BG, color=PAGE_BG),

--- a/plots/timeseries-forecast-uncertainty/implementations/python/letsplot.py
+++ b/plots/timeseries-forecast-uncertainty/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 INK_GRID = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 ALPHA_95 = 0.24 if THEME == "light" else 0.35
 ALPHA_80 = 0.38 if THEME == "light" else 0.55
@@ -64,11 +64,11 @@ plot = (
     ggplot()
     # 95% CI (outer, lighter)
     + geom_ribbon(
-        aes(x="date", ymin="lower_95", ymax="upper_95"), data=df_fc, fill=OKABE_ITO[1], alpha=ALPHA_95, color=None
+        aes(x="date", ymin="lower_95", ymax="upper_95"), data=df_fc, fill=IMPRINT[1], alpha=ALPHA_95, color=None
     )
     # 80% CI (inner, darker)
     + geom_ribbon(
-        aes(x="date", ymin="lower_80", ymax="upper_80"), data=df_fc, fill=OKABE_ITO[1], alpha=ALPHA_80, color=None
+        aes(x="date", ymin="lower_80", ymax="upper_80"), data=df_fc, fill=IMPRINT[1], alpha=ALPHA_80, color=None
     )
     # Historical solid line (brand green) — tooltips show value on hover in HTML
     + geom_line(
@@ -92,7 +92,7 @@ plot = (
     )
     # Vertical marker at forecast boundary
     + geom_vline(xintercept=forecast_start.timestamp() * 1000, color=INK_MUTED, size=0.6, linetype="dotted")
-    + scale_color_manual(values={"Historical": OKABE_ITO[0], "Forecast": OKABE_ITO[1]}, name="")
+    + scale_color_manual(values={"Historical": IMPRINT[0], "Forecast": IMPRINT[1]}, name="")
     + labs(
         x="Date",
         y="Energy Demand (MWh)",

--- a/plots/tree-phylogenetic/implementations/python/letsplot.py
+++ b/plots/tree-phylogenetic/implementations/python/letsplot.py
@@ -20,7 +20,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 GRID_COLOR = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.10)"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 
 def parse_newick(newick_str):
@@ -154,14 +154,14 @@ df_labels = pd.DataFrame([{"x": n["x"] + 0.02, "y": n["y"], "label": n["name"]} 
 df_nodes = pd.DataFrame([{"x": n["x"], "y": n["y"]} for n in node_dict.values()])
 
 clade_colors = {
-    "Human": OKABE_ITO[0],
-    "Chimpanzee": OKABE_ITO[0],
-    "Gorilla": OKABE_ITO[0],
-    "Orangutan": OKABE_ITO[1],
-    "Gibbon": OKABE_ITO[1],
-    "Macaque": OKABE_ITO[2],
-    "Baboon": OKABE_ITO[2],
-    "Mandrill": OKABE_ITO[2],
+    "Human": IMPRINT[0],
+    "Chimpanzee": IMPRINT[0],
+    "Gorilla": IMPRINT[0],
+    "Orangutan": IMPRINT[1],
+    "Gibbon": IMPRINT[1],
+    "Macaque": IMPRINT[2],
+    "Baboon": IMPRINT[2],
+    "Mandrill": IMPRINT[2],
 }
 
 df_labels["color"] = df_labels["label"].map(clade_colors)
@@ -185,8 +185,8 @@ anyplot_theme = theme(
 
 plot = (
     ggplot()
-    + geom_segment(aes(x="x", y="y", xend="xend", yend="yend"), data=df_segments, color=OKABE_ITO[0], size=1.5)
-    + geom_point(aes(x="x", y="y"), data=df_nodes, color=OKABE_ITO[0], size=4)
+    + geom_segment(aes(x="x", y="y", xend="xend", yend="yend"), data=df_segments, color=IMPRINT[0], size=1.5)
+    + geom_point(aes(x="x", y="y"), data=df_nodes, color=IMPRINT[0], size=4)
     + geom_point(aes(x="x", y="y", color="color"), data=df_labels, size=6, show_legend=False)
     + geom_text(aes(x="x", y="y", label="label"), data=df_labels, hjust=0, size=14, color=INK_SOFT, family="sans-serif")
     + scale_color_identity()

--- a/plots/treemap-basic/implementations/python/letsplot.py
+++ b/plots/treemap-basic/implementations/python/letsplot.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette for consistent color mapping across categories
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Budget allocation with two-level hierarchy
 # Departments (main) and projects/teams (sub) for realistic budget breakdown
@@ -214,7 +214,7 @@ rect_df["label"] = rect_df.apply(make_label, axis=1)
 
 # Map categories to Okabe-Ito colors
 unique_categories = df_data["category"].unique().tolist()
-category_colors = {cat: OKABE_ITO[i % len(OKABE_ITO)] for i, cat in enumerate(unique_categories)}
+category_colors = {cat: IMPRINT[i % len(IMPRINT)] for i, cat in enumerate(unique_categories)}
 color_values = [category_colors[cat] for cat in unique_categories]
 
 # Determine text color based on theme for better contrast

--- a/plots/upset-basic/implementations/python/letsplot.py
+++ b/plots/upset-basic/implementations/python/letsplot.py
@@ -40,7 +40,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 BRAND = "#009E73"
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030"]
 
 # Data: user acquisition channels (marketing segments)
 np.random.seed(42)
@@ -113,7 +113,7 @@ base_theme = theme(
 )
 
 # Intersection size bars (top panel)
-degree_palette = {str(d): OKABE_ITO[d - 1] for d in range(1, 6)}
+degree_palette = {str(d): IMPRINT[d - 1] for d in range(1, 6)}
 
 p_top = (
     ggplot(inter, aes(x="idx", y="count", fill="degree_str"))

--- a/plots/venn-basic/implementations/python/letsplot.py
+++ b/plots/venn-basic/implementations/python/letsplot.py
@@ -21,7 +21,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data: Three research fields with overlapping expertise
 set_a_label = "Machine Learning"
@@ -79,7 +79,7 @@ set_labels_data = pd.DataFrame(
 )
 
 # Map sets to Okabe-Ito palette
-set_colors = {set_a_label: OKABE_ITO[0], set_b_label: OKABE_ITO[1], set_c_label: OKABE_ITO[2]}
+set_colors = {set_a_label: IMPRINT[0], set_b_label: IMPRINT[1], set_c_label: IMPRINT[2]}
 
 # Create custom theme for chrome styling
 anyplot_theme = theme(

--- a/plots/venn-labeled-items/implementations/python/letsplot.py
+++ b/plots/venn-labeled-items/implementations/python/letsplot.py
@@ -35,8 +35,8 @@ INK_MUTED = "#6B6A63" if THEME == "light" else "#A8A79F"
 
 # Okabe-Ito categorical (positions 1, 2, 3)
 COLOR_A = "#009E73"
-COLOR_B = "#D55E00"
-COLOR_C = "#0072B2"
+COLOR_B = "#C475FD"
+COLOR_C = "#4467A3"
 
 # Geometry — three equally sized overlapping circles
 RADIUS = 1.5

--- a/plots/violin-grouped-swarm/implementations/python/letsplot.py
+++ b/plots/violin-grouped-swarm/implementations/python/letsplot.py
@@ -39,7 +39,7 @@ ELEVATED_BG = "#FFFDF6" if THEME == "light" else "#242420"
 INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Drug efficacy across dosage levels and treatment groups
 np.random.seed(42)
@@ -74,8 +74,8 @@ plot = (
     ggplot(df, aes(x="Dosage", y="Efficacy Score", fill="Group", color="Group"))
     + geom_violin(alpha=0.5, position=position_dodge(width=0.75), size=0.6, trim=False)
     + geom_point(alpha=0.6, size=2.0, position=position_jitterdodge(jitter_width=0.1, dodge_width=0.75))
-    + scale_fill_manual(values=OKABE_ITO[:2])
-    + scale_color_manual(values=OKABE_ITO[:2])
+    + scale_fill_manual(values=IMPRINT[:2])
+    + scale_color_manual(values=IMPRINT[:2])
     + labs(
         x="Dosage Level",
         y="Efficacy Score",

--- a/plots/violin-split/implementations/python/letsplot.py
+++ b/plots/violin-split/implementations/python/letsplot.py
@@ -23,7 +23,7 @@ GRID_LINE = "rgba(26,26,23,0.10)" if THEME == "light" else "rgba(240,239,232,0.1
 
 # Okabe-Ito palette (first series always #009E73)
 COLOR_BEFORE = "#009E73"  # Okabe-Ito position 1
-COLOR_AFTER = "#D55E00"  # Okabe-Ito position 2
+COLOR_AFTER = "#C475FD"  # Okabe-Ito position 2
 
 # Data - Employee satisfaction scores before and after office redesign across departments
 np.random.seed(42)
@@ -96,7 +96,7 @@ plot = (
         size=0.6,
         show_legend=False,
     )
-    # Okabe-Ito colors (Before=#009E73, After=#D55E00)
+    # Okabe-Ito colors (Before=#009E73, After=#C475FD)
     + scale_fill_manual(values=[COLOR_AFTER, COLOR_BEFORE], name="Period")  # noqa: F405
     + scale_y_continuous(limits=[15, 105])  # noqa: F405
     # Labels

--- a/plots/violin-swarm/implementations/python/letsplot.py
+++ b/plots/violin-swarm/implementations/python/letsplot.py
@@ -36,7 +36,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data: Reaction times (ms) across 4 experimental conditions
 np.random.seed(42)
@@ -74,7 +74,7 @@ plot = (
     ggplot(df, aes(x="Condition", y="Reaction Time"))
     + geom_violin(aes(fill="Condition"), alpha=0.4, size=1.2)
     + geom_jitter(aes(color="Condition"), width=0.12, height=0, size=3.5, alpha=0.85)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + theme_minimal()
     + theme(
         plot_background=element_rect(fill=PAGE_BG, color=PAGE_BG),

--- a/plots/volcano-basic/implementations/python/letsplot.py
+++ b/plots/volcano-basic/implementations/python/letsplot.py
@@ -21,8 +21,8 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (colorblind-safe)
-OKABE_ITO_DOWN = "#0072B2"  # Blue for down-regulated
-OKABE_ITO_UP = "#D55E00"  # Orange for up-regulated
+OKABE_ITO_DOWN = "#4467A3"  # imprint blue — down-regulated (cool)
+OKABE_ITO_UP = "#AE3030"  # imprint red — up-regulated (warm semantic)
 OKABE_ITO_NEUTRAL = "#888888"  # Gray for not significant
 
 # Data - Simulated differential expression results

--- a/plots/voronoi-basic/implementations/python/letsplot.py
+++ b/plots/voronoi-basic/implementations/python/letsplot.py
@@ -136,12 +136,12 @@ df_seeds = pd.DataFrame({"x": x, "y": y, "label": [f"P{i + 1}" for i in range(le
 # Color palette for regions - diverse and visually distinct
 colors = [
     "#009E73",
-    "#D55E00",
-    "#0072B2",
-    "#CC79A7",
-    "#E69F00",
-    "#56B4E9",
-    "#F0E442",
+    "#C475FD",
+    "#4467A3",
+    "#BD8233",
+    "#AE3030",
+    "#2ABCCD",
+    "#954477",
     "#1B9E77",
     "#D95F02",
     "#7570B3",

--- a/plots/waffle-basic/implementations/python/letsplot.py
+++ b/plots/waffle-basic/implementations/python/letsplot.py
@@ -35,7 +35,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series ALWAYS #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233"]
 
 # Data - Survey results on voting preferences (values sum to 100%)
 categories = ["Very Likely", "Likely", "Neutral", "Unlikely"]
@@ -80,7 +80,7 @@ plot = (
     ggplot(df, aes(x="x", y="y", fill="legend_label"))
     + geom_tile(width=0.88, height=0.88, size=0)
     + coord_fixed(ratio=1)
-    + scale_fill_manual(values=OKABE_ITO)
+    + scale_fill_manual(values=IMPRINT)
     + labs(title="waffle-basic · letsplot · anyplot.ai", fill="Preference")
     + theme_void()
     + anyplot_theme

--- a/plots/waterfall-basic/implementations/python/letsplot.py
+++ b/plots/waterfall-basic/implementations/python/letsplot.py
@@ -39,8 +39,8 @@ INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette
 BRAND = "#009E73"  # Position 1 - green
-ACCENT_1 = "#D55E00"  # Position 2 - orange
-ACCENT_2 = "#0072B2"  # Position 3 - blue
+ACCENT_1 = "#C475FD"  # Position 2 - orange
+ACCENT_2 = "#4467A3"  # Position 3 - blue
 
 # Data - Quarterly financial breakdown from revenue to net income
 categories = [

--- a/plots/windrose-basic/implementations/python/letsplot.py
+++ b/plots/windrose-basic/implementations/python/letsplot.py
@@ -69,7 +69,7 @@ counts["speed_bin"] = pd.Categorical(counts["speed_bin"], categories=speed_order
 counts = counts.sort_values(["direction_bin", "speed_bin"])
 
 # Okabe-Ito palette (cool to warm gradient)
-colors = ["#009E73", "#56B4E9", "#0072B2", "#F0E442", "#E69F00", "#D55E00"]
+colors = ["#009E73", "#2ABCCD", "#4467A3", "#954477", "#AE3030", "#C475FD"]
 
 # Create wind rose using polar bar chart
 plot = (

--- a/plots/wordcloud-basic/implementations/python/letsplot.py
+++ b/plots/wordcloud-basic/implementations/python/letsplot.py
@@ -38,7 +38,7 @@ INK = "#1A1A17" if THEME == "light" else "#F0EFE8"
 INK_SOFT = "#4A4A44" if THEME == "light" else "#B8B7B0"
 
 # Okabe-Ito palette (first series always #009E73)
-OKABE_ITO = ["#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9", "#F0E442"]
+IMPRINT = ["#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD", "#954477"]
 
 # Data - Programming language popularity
 np.random.seed(42)
@@ -152,7 +152,7 @@ for word, freq, size, x, y in zip(words, frequencies, sizes, positions_x, positi
 df = pd.DataFrame(df_data)
 
 # Assign Okabe-Ito colors to words
-df["color"] = [OKABE_ITO[i % len(OKABE_ITO)] for i in range(len(df))]
+df["color"] = [IMPRINT[i % len(IMPRINT)] for i in range(len(df))]
 
 # Plot with theme-adaptive chrome
 anyplot_theme = theme(


### PR DESCRIPTION
## Summary

- Positional hex + rgba replacement across **138 letsplot impls** with light+dark renders.
- Final Python library in the imprint migration. R + Julia (ggplot2 + makie) still to come.
- Proactive semantic-anchor fixes for 12 letsplot impls.

## Test plan

- [x] `ruff check .` + format green
- [ ] CI green
- [ ] Copilot triage
- [ ] After merge: Stage B for 138 letsplot impls → GCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)