### PR TITLE
chore(palette): migrate R + Julia impls from Okabe-Ito to imprint

### DIFF
--- a/plots/area-stacked-confidence/implementations/r/ggplot2.R
+++ b/plots/area-stacked-confidence/implementations/r/ggplot2.R
@@ -17,8 +17,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Quarterly energy consumption forecast by source with confidence bands
@@ -88,8 +88,8 @@ p <- ggplot(df_plot, aes(x = quarter, fill = source, color = source)) +
   geom_ribbon(aes(ymin = y_lower, ymax = y_upper), alpha = 0.2, color = NA) +
   # Central stacked areas
   geom_area(aes(y = y_center), alpha = 0.7, color = NA) +
-  scale_fill_manual(values = OKABE_ITO[1:4]) +
-  scale_color_manual(values = OKABE_ITO[1:4]) +
+  scale_fill_manual(values = IMPRINT[1:4]) +
+  scale_color_manual(values = IMPRINT[1:4]) +
   labs(
     title = "area-stacked-confidence · R · ggplot2 · anyplot.ai",
     x = "Quarter",

--- a/plots/bar-drilldown/implementations/r/ggplot2.R
+++ b/plots/bar-drilldown/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 GRID_COLOR  <- if (THEME == "light") "#D0CFC8" else "#2C2C29"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: company annual budget hierarchy (department -> expense category) ---
 departments <- c("Engineering", "Sales", "Marketing", "Operations")
@@ -73,7 +73,7 @@ df <- df %>%
     )
   )
 
-dept_colors <- setNames(OKABE_ITO[1:4], departments)
+dept_colors <- setNames(IMPRINT[1:4], departments)
 
 # --- Plot ---
 p <- ggplot(df, aes(x = unique_item, y = budget_m, fill = department, alpha = bar_emphasis)) +

--- a/plots/bar-permutation-importance/implementations/r/ggplot2.R
+++ b/plots/bar-permutation-importance/implementations/r/ggplot2.R
@@ -18,8 +18,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Simulate permutation importance from a machine learning model
@@ -88,8 +88,8 @@ p <- ggplot(df, aes(x = importance_mean, y = reorder(feature, importance_mean)))
   ) +
   # Continuous color gradient for importance
   scale_fill_gradient(
-    low = OKABE_ITO[1],
-    high = OKABE_ITO[2],
+    low = IMPRINT[1],
+    high = IMPRINT[2],
     name = "Mean Importance",
     labels = label_number(accuracy = 0.001)
   ) +

--- a/plots/bar-race-animated/implementations/r/ggplot2.R
+++ b/plots/bar-race-animated/implementations/r/ggplot2.R
@@ -17,8 +17,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # Data — top 10 countries by GDP per capita at 6 key snapshots
 years_snap <- c(1952, 1967, 1977, 1987, 1997, 2007)
@@ -34,7 +34,7 @@ df_snap <- gapminder::gapminder |>
   )
 
 continent_colors <- setNames(
-  OKABE_ITO[1:5],
+  IMPRINT[1:5],
   c("Africa", "Americas", "Asia", "Europe", "Oceania")
 )
 

--- a/plots/bar-stacked-labeled/implementations/r/ggplot2.R
+++ b/plots/bar-stacked-labeled/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Quarterly revenue by product category
@@ -47,7 +47,7 @@ p <- ggplot(df, aes(x = quarter, y = revenue, fill = product)) +
     color = INK,
     inherit.aes = FALSE
   ) +
-  scale_fill_manual(values = OKABE_ITO[1:3], name = "Product") +
+  scale_fill_manual(values = IMPRINT[1:3], name = "Product") +
   labs(
     title = "bar-stacked-labeled · R · ggplot2 · anyplot.ai",
     x = "Quarter",

--- a/plots/biplot-pca/implementations/r/ggplot2.R
+++ b/plots/biplot-pca/implementations/r/ggplot2.R
@@ -17,8 +17,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Perform PCA on iris dataset ----
 pca_result <- prcomp(iris[, 1:4], scale. = TRUE)
@@ -94,9 +94,9 @@ p <- ggplot() +
   # Color scale: species (first group uses #009E73)
   scale_color_manual(
     values = c(
-      "setosa" = OKABE_ITO[1],
-      "versicolor" = OKABE_ITO[2],
-      "virginica" = OKABE_ITO[3]
+      "setosa" = IMPRINT[1],
+      "versicolor" = IMPRINT[2],
+      "virginica" = IMPRINT[3]
     ),
     name = "Species"
   ) +

--- a/plots/boxen-basic/implementations/r/ggplot2.R
+++ b/plots/boxen-basic/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Simulate response time distributions across three server endpoints
@@ -129,7 +129,7 @@ p <- ggplot() +
   ) +
   scale_fill_manual(
     name = "Endpoint",
-    values = OKABE_ITO[1:3],
+    values = IMPRINT[1:3],
     breaks = endpoints
   ) +
   scale_alpha_identity() +

--- a/plots/bubble-map-geographic/implementations/r/ggplot2.R
+++ b/plots/bubble-map-geographic/implementations/r/ggplot2.R
@@ -17,7 +17,7 @@ INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 OCEAN_BG    <- if (THEME == "light") "#D6E8F2" else "#182530"
 GRID_COLOR  <- if (THEME == "light") "#AACCDC" else "#2C4455"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7", "#E69F00", "#56B4E9")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233", "#AE3030", "#2ABCCD")
 
 # Data: Major world cities with population (millions, 2023 estimates)
 cities <- tibble(
@@ -82,12 +82,12 @@ region_labels <- tibble(
 
 # Color mapping by continent (Okabe-Ito order, Asia first = #009E73)
 continent_colors <- c(
-  "Asia"       = OKABE_ITO[1],
-  "Africa"     = OKABE_ITO[2],
-  "N. America" = OKABE_ITO[3],
-  "S. America" = OKABE_ITO[4],
-  "Europe"     = OKABE_ITO[5],
-  "Oceania"    = OKABE_ITO[6]
+  "Asia"       = IMPRINT[1],
+  "Africa"     = IMPRINT[2],
+  "N. America" = IMPRINT[3],
+  "S. America" = IMPRINT[4],
+  "Europe"     = IMPRINT[5],
+  "Oceania"    = IMPRINT[6]
 )
 
 LABEL_COLOR <- if (THEME == "light") "#7A8C96" else "#4A6070"

--- a/plots/chessboard-pieces/implementations/r/ggplot2.R
+++ b/plots/chessboard-pieces/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Chess board setup ------------------------------------------------
 

--- a/plots/coefficient-confidence/implementations/r/ggplot2.R
+++ b/plots/coefficient-confidence/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Simulated housing price regression coefficients with confidence intervals
@@ -46,12 +46,12 @@ p <- ggplot(coefficients, aes(x = coefficient, y = variable,
   # Color scale: significant vs non-significant
   scale_color_manual(
     name = "Statistically Significant",
-    values = c("TRUE" = OKABE_ITO[1], "FALSE" = INK_SOFT),
+    values = c("TRUE" = IMPRINT[1], "FALSE" = INK_SOFT),
     labels = c("TRUE" = "Yes", "FALSE" = "No")
   ) +
   scale_fill_manual(
     name = "Statistically Significant",
-    values = c("TRUE" = OKABE_ITO[1], "FALSE" = INK_SOFT),
+    values = c("TRUE" = IMPRINT[1], "FALSE" = INK_SOFT),
     labels = c("TRUE" = "Yes", "FALSE" = "No")
   ) +
   labs(

--- a/plots/dashboard-metrics-tiles/implementations/r/ggplot2.R
+++ b/plots/dashboard-metrics-tiles/implementations/r/ggplot2.R
@@ -18,8 +18,8 @@ INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
 COL_GOOD     <- "#009E73"  # Okabe-Ito 1 — good / brand
-COL_WARNING  <- "#E69F00"  # Okabe-Ito 5 — warning
-COL_CRITICAL <- "#D55E00"  # Okabe-Ito 2 — critical / bad
+COL_WARNING  <- "#DDCC77"  # imprint amber — warning
+COL_CRITICAL <- "#AE3030"  # imprint red — critical / bad
 
 # --- Data -------------------------------------------------------------------
 # Server health metrics snapshot (6 tiles in 3x2 grid)

--- a/plots/dashboard-synchronized-crosshair/implementations/julia/makie.jl
+++ b/plots/dashboard-synchronized-crosshair/implementations/julia/makie.jl
@@ -17,14 +17,14 @@ const INK       = THEME == "light" ? colorant"#1A1A17" : colorant"#F0EFE8"
 const INK_SOFT  = THEME == "light" ? colorant"#4A4A44" : colorant"#B8B7B0"
 const INK_MUTED = THEME == "light" ? colorant"#6B6A63" : colorant"#A8A79F"
 
-const ANYPLOT_PALETTE = [
+const IMPRINT = [
     colorant"#009E73",
-    colorant"#9418DB",
-    colorant"#B71D27",
-    colorant"#16B8F3",
+    colorant"#C475FD",
+    colorant"#AE3030",
+    colorant"#4467A3",
     colorant"#99B314",
-    colorant"#D359A7",
-    colorant"#BA843E",
+    colorant"#954477",
+    colorant"#BD8233",
 ]
 
 # Data: 200 simulated trading days (stock price, volume, RSI)
@@ -70,8 +70,8 @@ vol_hi = maximum(volume)
 grid_col = RGBAf(INK.r, INK.g, INK.b, 0.10)
 
 # Zone fill colors — very low alpha so data is not obscured
-overbought_fill = RGBAf(ANYPLOT_PALETTE[3].r, ANYPLOT_PALETTE[3].g, ANYPLOT_PALETTE[3].b, 0.10)
-oversold_fill   = RGBAf(ANYPLOT_PALETTE[1].r, ANYPLOT_PALETTE[1].g, ANYPLOT_PALETTE[1].b, 0.10)
+overbought_fill = RGBAf(IMPRINT[3].r, IMPRINT[3].g, IMPRINT[3].b, 0.10)
+oversold_fill   = RGBAf(IMPRINT[1].r, IMPRINT[1].g, IMPRINT[1].b, 0.10)
 
 # Figure
 fig = Figure(
@@ -156,17 +156,17 @@ ax3 = Axis(
 linkxaxes!(ax1, ax2, ax3)
 
 # Price line — palette position 1
-lines!(ax1, days, price; color = ANYPLOT_PALETTE[1], linewidth = 2.0)
+lines!(ax1, days, price; color = IMPRINT[1], linewidth = 2.0)
 
 # Volume bars — palette position 2 (canonical order)
-barplot!(ax2, days, volume; color = ANYPLOT_PALETTE[2], strokewidth = 0, width = 0.9)
+barplot!(ax2, days, volume; color = IMPRINT[2], strokewidth = 0, width = 0.9)
 
 # RSI overbought/oversold zone fills using band! — highlights the threshold regions
 band!(ax3, days, fill(70.0, n), fill(100.0, n); color = overbought_fill)
 band!(ax3, days, fill(0.0, n), fill(30.0, n);  color = oversold_fill)
 
 # RSI line — palette position 3 (canonical order)
-lines!(ax3, rsi_days, rsi_vals; color = ANYPLOT_PALETTE[3], linewidth = 2.0)
+lines!(ax3, rsi_days, rsi_vals; color = IMPRINT[3], linewidth = 2.0)
 
 # RSI overbought / oversold reference lines
 hlines!(ax3, [30.0, 70.0];
@@ -197,13 +197,13 @@ vlines!(ax3, [Float64(cx)]; color = cx_line_col, linewidth = 1.5, linestyle = :d
 
 # Value markers at the crosshair position
 scatter!(ax1, [Float64(cx)], [cx_price];
-    color = ANYPLOT_PALETTE[1], markersize = 10,
+    color = IMPRINT[1], markersize = 10,
     strokewidth = 1.5, strokecolor = PAGE_BG)
 scatter!(ax2, [Float64(cx)], [cx_volume];
-    color = ANYPLOT_PALETTE[2], markersize = 10,
+    color = IMPRINT[2], markersize = 10,
     strokewidth = 1.5, strokecolor = PAGE_BG)
 scatter!(ax3, [Float64(cx)], [cx_rsi];
-    color = ANYPLOT_PALETTE[3], markersize = 10,
+    color = IMPRINT[3], markersize = 10,
     strokewidth = 1.5, strokecolor = PAGE_BG)
 
 # Value annotations at crosshair — offset right; for RSI clamp downward when near ceiling

--- a/plots/dashboard-synchronized-crosshair/implementations/r/ggplot2.R
+++ b/plots/dashboard-synchronized-crosshair/implementations/r/ggplot2.R
@@ -17,9 +17,9 @@ INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
 
-ANYPLOT_PALETTE <- c(
-    "#009E73", "#9418DB", "#B71D27", "#16B8F3",
-    "#99B314", "#D359A7", "#BA843E"
+IMPRINT <- c(
+    "#009E73", "#C475FD", "#AE3030", "#4467A3",
+    "#99B314", "#954477", "#BD8233"
 )
 
 # 200 trading days of synthetic stock data
@@ -52,9 +52,9 @@ df <- tibble::tibble(
 )
 
 metric_colors <- c(
-    "Price (USD)" = ANYPLOT_PALETTE[1],
-    "Volume (M)"  = ANYPLOT_PALETTE[2],
-    "RSI (14)"    = ANYPLOT_PALETTE[3]
+    "Price (USD)" = IMPRINT[1],
+    "Volume (M)"  = IMPRINT[2],
+    "RSI (14)"    = IMPRINT[3]
 )
 
 event_date <- dates[120]

--- a/plots/density-rug/implementations/r/ggplot2.R
+++ b/plots/density-rug/implementations/r/ggplot2.R
@@ -13,8 +13,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Response times (in milliseconds) from a web application
@@ -29,8 +29,8 @@ df <- data.frame(value = response_times)
 p <- ggplot(df, aes(x = value)) +
   geom_density(
     stat = "density",
-    fill = OKABE_ITO[1],
-    color = OKABE_ITO[1],
+    fill = IMPRINT[1],
+    color = IMPRINT[1],
     alpha = 0.35,
     linewidth = 1.4,
     bw = 20
@@ -38,28 +38,28 @@ p <- ggplot(df, aes(x = value)) +
   geom_density(
     stat = "density",
     fill = NA,
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     alpha = 1,
     linewidth = 2,
     bw = 20,
     key_glyph = "blank"
   ) +
   geom_rug(
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     alpha = 0.7,
     linewidth = 0.9,
     length = unit(0.035, "npc")
   ) +
   geom_vline(
     xintercept = 150,
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     linewidth = 0.6,
     alpha = 0.5,
     linetype = "dashed"
   ) +
   geom_vline(
     xintercept = 250,
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     linewidth = 0.6,
     alpha = 0.5,
     linetype = "dashed"

--- a/plots/drawdown-basic/implementations/julia/makie.jl
+++ b/plots/drawdown-basic/implementations/julia/makie.jl
@@ -16,7 +16,7 @@ const ELEVATED_BG = THEME == "light" ? colorant"#FFFDF6" : colorant"#242420"
 const INK = THEME == "light" ? colorant"#1A1A17" : colorant"#F0EFE8"
 const INK_SOFT = THEME == "light" ? colorant"#4A4A44" : colorant"#B8B7B0"
 # Drawdown = loss → semantic red (anyplot palette position 3)
-const DRAW_RED = colorant"#B71D27"
+const DRAW_RED = colorant"#AE3030"
 # Recovery = new high → anyplot green (palette position 1)
 const RECOVER_GREEN = colorant"#009E73"
 

--- a/plots/drawdown-basic/implementations/r/ggplot2.R
+++ b/plots/drawdown-basic/implementations/r/ggplot2.R
@@ -15,7 +15,7 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
-DD_COLOR    <- "#B71D27"  # red — semantic: loss / drawdown
+DD_COLOR    <- "#AE3030"  # red — semantic: loss / drawdown
 DD_ALPHA    <- if (THEME == "light") 0.25 else 0.45  # more visible in dark mode
 
 # Data: synthetic portfolio NAV, Jan 2021 – Dec 2023

--- a/plots/flowmap-origin-destination/implementations/r/ggplot2.R
+++ b/plots/flowmap-origin-destination/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # World basemap polygons for geographic context
 world <- map_data("world")
@@ -60,10 +60,10 @@ flows <- flows_raw |>
   rename(dest_lat = lat, dest_lon = lon)
 
 region_colors <- c(
-  "Americas"     = OKABE_ITO[1],
-  "Europe"       = OKABE_ITO[2],
-  "Middle East"  = OKABE_ITO[3],
-  "Asia Pacific" = OKABE_ITO[4]
+  "Americas"     = IMPRINT[1],
+  "Europe"       = IMPRINT[2],
+  "Middle East"  = IMPRINT[3],
+  "Asia Pacific" = IMPRINT[4]
 )
 
 # Manual label nudges to spread the dense European cluster

--- a/plots/frequency-polygon-basic/implementations/r/ggplot2.R
+++ b/plots/frequency-polygon-basic/implementations/r/ggplot2.R
@@ -13,8 +13,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 df <- data.frame(
@@ -40,8 +40,8 @@ p <- ggplot(df, aes(x = score, color = group, fill = group)) +
     alpha = 0.6,
     show.legend = FALSE
   ) +
-  scale_color_manual(values = OKABE_ITO[1:3]) +
-  scale_fill_manual(values = OKABE_ITO[1:3]) +
+  scale_color_manual(values = IMPRINT[1:3]) +
+  scale_fill_manual(values = IMPRINT[1:3]) +
   labs(
     title = "frequency-polygon-basic · ggplot2 · anyplot.ai",
     x = "Test Score",

--- a/plots/frontier-efficient/implementations/r/ggplot2.R
+++ b/plots/frontier-efficient/implementations/r/ggplot2.R
@@ -17,8 +17,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Generate random portfolios and efficient frontier ----------------
 
@@ -129,28 +129,28 @@ p <- ggplot() +
   geom_line(
     data = frontier_curve,
     aes(x = risk, y = return),
-    color = OKABE_ITO[1], linewidth = 1.2, alpha = 0.9
+    color = IMPRINT[1], linewidth = 1.2, alpha = 0.9
   ) +
   # Capital market line
   geom_line(
     data = cml_df,
     aes(x = risk, y = return),
-    color = OKABE_ITO[2], linewidth = 1.0, linetype = "dashed", alpha = 0.7
+    color = IMPRINT[2], linewidth = 1.0, linetype = "dashed", alpha = 0.7
   ) +
   # Key points
   geom_point(
     data = min_var_port,
     aes(x = risk, y = return),
-    color = OKABE_ITO[3], size = 5.5, shape = 23, fill = OKABE_ITO[3]
+    color = IMPRINT[3], size = 5.5, shape = 23, fill = IMPRINT[3]
   ) +
   geom_point(
     data = max_sharpe_port,
     aes(x = risk, y = return),
-    color = OKABE_ITO[4], size = 5.5, shape = 21, fill = OKABE_ITO[4]
+    color = IMPRINT[4], size = 5.5, shape = 21, fill = IMPRINT[4]
   ) +
   # Scale for Sharpe coloring
   scale_color_gradient(
-    low = INK_SOFT, high = OKABE_ITO[1],
+    low = INK_SOFT, high = IMPRINT[1],
     name = "Sharpe\nRatio",
     breaks = scales::pretty_breaks(n = 3),
     guide = guide_colorbar(barwidth = 0.8, barheight = 6)

--- a/plots/histogram-returns-distribution/implementations/r/ggplot2.R
+++ b/plots/histogram-returns-distribution/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # Data - 2 years of daily returns for a diversified equity portfolio
 n     <- 504
@@ -58,17 +58,17 @@ ann_y <- max(h$density) * 0.93
 p <- ggplot(df_hist, aes(x = mid, y = density, fill = tail)) +
   geom_col(width = bin_w * 0.90, color = PAGE_BG, linewidth = 0.2, alpha = 0.85) +
   scale_fill_manual(
-    values = c("FALSE" = OKABE_ITO[1], "TRUE" = OKABE_ITO[2]),
+    values = c("FALSE" = IMPRINT[1], "TRUE" = IMPRINT[2]),
     labels = c("FALSE" = "Within ±2σ", "TRUE" = "Beyond ±2σ"),
     name   = NULL
   ) +
   geom_line(
     data = df_norm, aes(x = x, y = y), inherit.aes = FALSE,
-    color = OKABE_ITO[3], linewidth = 1.2
+    color = IMPRINT[3], linewidth = 1.2
   ) +
   geom_vline(
     xintercept = c(mean_ret - 2 * sd_ret, mean_ret + 2 * sd_ret),
-    color      = OKABE_ITO[2], linewidth = 0.7, linetype = "dashed", alpha = 0.7
+    color      = IMPRINT[2], linewidth = 0.7, linetype = "dashed", alpha = 0.7
   ) +
   annotate("label",
     x = ann_x, y = ann_y,

--- a/plots/indicator-bollinger/implementations/r/ggplot2.R
+++ b/plots/indicator-bollinger/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 n_periods <- 150
@@ -57,14 +57,14 @@ df <- data.frame(
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(df, aes(x = date)) +
   geom_ribbon(aes(ymin = lower_band, ymax = upper_band),
-              fill = OKABE_ITO[1], alpha = 0.15) +
-  geom_line(aes(y = upper_band), color = OKABE_ITO[1], linewidth = 0.6,
+              fill = IMPRINT[1], alpha = 0.15) +
+  geom_line(aes(y = upper_band), color = IMPRINT[1], linewidth = 0.6,
             linetype = "solid", alpha = 0.6) +
-  geom_line(aes(y = lower_band), color = OKABE_ITO[1], linewidth = 0.6,
+  geom_line(aes(y = lower_band), color = IMPRINT[1], linewidth = 0.6,
             linetype = "solid", alpha = 0.6) +
-  geom_line(aes(y = sma), color = OKABE_ITO[1], linewidth = 0.8,
+  geom_line(aes(y = sma), color = IMPRINT[1], linewidth = 0.8,
             linetype = "dashed", alpha = 0.7) +
-  geom_line(aes(y = close), color = OKABE_ITO[1], linewidth = 1.2) +
+  geom_line(aes(y = close), color = IMPRINT[1], linewidth = 1.2) +
   labs(
     title = "indicator-bollinger · ggplot2 · anyplot.ai",
     x = "Date",

--- a/plots/indicator-ema/implementations/r/ggplot2.R
+++ b/plots/indicator-ema/implementations/r/ggplot2.R
@@ -17,10 +17,10 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
-OKABE_ITO <- c(
+IMPRINT <- c(
     "Price"    = "#009E73",
-    "EMA (12)" = "#D55E00",
-    "EMA (26)" = "#0072B2"
+    "EMA (12)" = "#C475FD",
+    "EMA (26)" = "#4467A3"
 )
 
 # Data
@@ -56,9 +56,9 @@ p <- ggplot(df_long, aes(x = date, y = price, color = series)) +
     geom_line(aes(linewidth = series, alpha = series)) +
     geom_point(data = crossovers, aes(x = date, y = ema12),
                shape = 21, size = 4, fill = PAGE_BG,
-               color = OKABE_ITO[["EMA (12)"]], stroke = 1.5,
+               color = IMPRINT[["EMA (12)"]], stroke = 1.5,
                inherit.aes = FALSE) +
-    scale_color_manual(name = NULL, values = OKABE_ITO,
+    scale_color_manual(name = NULL, values = IMPRINT,
                        breaks = c("Price", "EMA (12)", "EMA (26)")) +
     scale_linewidth_manual(
         values = c("Price" = 1.5, "EMA (12)" = 1.1, "EMA (26)" = 1.1),

--- a/plots/indicator-sma/implementations/r/ggplot2.R
+++ b/plots/indicator-sma/implementations/r/ggplot2.R
@@ -18,8 +18,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
-OKABE_ITO <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-               "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+               "#AE3030", "#2ABCCD", "#954477")
 
 # Data: 500 trading days of simulated stock prices
 n_days <- 700L
@@ -51,7 +51,7 @@ df <- data.frame(
 df_long <- tidyr::pivot_longer(df, cols = -date, names_to = "series", values_to = "value")
 df_long$series <- factor(df_long$series, levels = c("Price", "SMA 20", "SMA 50", "SMA 200"))
 
-series_colors <- setNames(OKABE_ITO[1:4], c("Price", "SMA 20", "SMA 50", "SMA 200"))
+series_colors <- setNames(IMPRINT[1:4], c("Price", "SMA 20", "SMA 50", "SMA 200"))
 series_widths <- c("Price" = 1.4, "SMA 20" = 1.0, "SMA 50" = 1.0, "SMA 200" = 1.0)
 
 # Plot

--- a/plots/kagi-basic/implementations/r/ggplot2.R
+++ b/plots/kagi-basic/implementations/r/ggplot2.R
@@ -18,7 +18,7 @@ INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
 # Kagi-specific colors: yang (uptrend) uses brand green, yin (downtrend) uses vermillion
 COLOR_YANG  <- "#009E73"  # Okabe-Ito position 1 — uptrend
-COLOR_YIN   <- "#D55E00"  # Okabe-Ito position 2 — downtrend
+COLOR_YIN   <- "#AE3030"  # imprint red — downtrend
 
 # --- Generate price data -----------------------------------------------------
 # Daily closing prices over ~6 months with realistic volatility

--- a/plots/line-stock-comparison/implementations/julia/makie.jl
+++ b/plots/line-stock-comparison/implementations/julia/makie.jl
@@ -16,11 +16,11 @@ const ELEVATED_BG = THEME == "light" ? colorant"#FFFDF6" : colorant"#242420"
 const INK         = THEME == "light" ? colorant"#1A1A17" : colorant"#F0EFE8"
 const INK_SOFT    = THEME == "light" ? colorant"#4A4A44" : colorant"#B8B7B0"
 
-const ANYPLOT_PALETTE = [
+const IMPRINT = [
     colorant"#009E73",  # 1 — brand green  (NVDA)
-    colorant"#9418DB",  # 2 — purple       (AAPL)
-    colorant"#B71D27",  # 3 — red          (AMZN)
-    colorant"#16B8F3",  # 4 — sky blue     (SPY)
+    colorant"#C475FD",  # 2 — purple       (AAPL)
+    colorant"#AE3030",  # 3 — red          (AMZN)
+    colorant"#4467A3",  # 4 — sky blue     (SPY)
 ]
 
 # Data: 252 trading days (~1 year) for 4 assets, normalized to 100
@@ -100,7 +100,7 @@ hlines!(ax, [100.0]; color = ref_col, linewidth = 1.2, linestyle = :dash)
 # Stock series lines
 for j in 1:4
     lines!(ax, days, prices[:, j];
-        color     = ANYPLOT_PALETTE[j],
+        color     = IMPRINT[j],
         linewidth = 2.5,
         label     = TICKERS[j],
     )
@@ -112,7 +112,7 @@ for j in 1:4
     final_val = prices[end, j]
     text!(ax, N_DAYS + 3, final_val;
         text     = string(round(Int, final_val)),
-        color    = ANYPLOT_PALETTE[j],
+        color    = IMPRINT[j],
         fontsize = 11,
         align    = (:left, :center),
     )

--- a/plots/line-stock-comparison/implementations/r/ggplot2.R
+++ b/plots/line-stock-comparison/implementations/r/ggplot2.R
@@ -17,7 +17,7 @@ INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 # embed alpha into hex — ggplot2 element_line lacks alpha parameter
 GRID_COLOR  <- adjustcolor(INK_SOFT, alpha.f = if (THEME == "dark") 0.22 else 0.35)
 
-ANYPLOT_PALETTE <- c("#009E73", "#9418DB", "#B71D27", "#16B8F3")
+IMPRINT <- c("#009E73", "#C475FD", "#AE3030", "#4467A3")
 
 # Data — approximately 1 year of trading days starting Jan 2023
 all_dates     <- seq(as.Date("2023-01-03"), by = "day", length.out = 400)
@@ -86,14 +86,14 @@ p <- ggplot(df, aes(x = date, y = rebased, color = symbol)) +
     geom_rect(
         data = svb_region,
         aes(xmin = xmin, xmax = xmax, ymin = ymin, ymax = ymax),
-        fill = "#B71D27", alpha = 0.07,
+        fill = "#AE3030", alpha = 0.07,
         inherit.aes = FALSE
     ) +
     # Subtle fill ribbon under NVDA to emphasize outperformance
     geom_ribbon(
         data = nvda_df,
         aes(x = date, ymin = 100, ymax = rebased),
-        fill = ANYPLOT_PALETTE[1], alpha = 0.12, inherit.aes = FALSE
+        fill = IMPRINT[1], alpha = 0.12, inherit.aes = FALSE
     ) +
     # Reference line at 100
     geom_hline(yintercept = 100, color = INK_SOFT, linewidth = 0.5,
@@ -113,11 +113,11 @@ p <- ggplot(df, aes(x = date, y = rebased, color = symbol)) +
     # Styled callout boxes using annotate(geom="label") — distinctively ggplot2
     # SVB label at y=145 clears the stock cluster; color-coded to match the shaded region
     annotate("label", x = as.Date("2023-03-11"), y = 145,
-             label = "SVB Collapse", color = "#B71D27",
+             label = "SVB Collapse", color = "#AE3030",
              fill = ELEVATED_BG, label.size = 0.15, size = 3.0,
              angle = 90, hjust = 0, vjust = 0.4, fontface = "italic") +
     annotate("label", x = ai_surge_date, y = 102,
-             label = "NVDA AI Surge", color = ANYPLOT_PALETTE[1],
+             label = "NVDA AI Surge", color = IMPRINT[1],
              fill = ELEVATED_BG, label.size = 0.15, size = 3.0,
              angle = 90, hjust = 0, vjust = 0.4, fontface = "italic") +
     annotate("label", x = rate_peak_date, y = 102,
@@ -126,7 +126,7 @@ p <- ggplot(df, aes(x = date, y = rebased, color = symbol)) +
              angle = 90, hjust = 0, vjust = 0.4, fontface = "italic") +
     # clip="off" enables end-of-line labels and off-axis annotations outside the panel
     coord_cartesian(clip = "off") +
-    scale_color_manual(values = setNames(ANYPLOT_PALETTE, tickers), name = NULL) +
+    scale_color_manual(values = setNames(IMPRINT, tickers), name = NULL) +
     scale_x_date(date_labels = "%b '%y", date_breaks = "2 months") +
     labs(
         title    = "line-stock-comparison · r · ggplot2 · anyplot.ai",

--- a/plots/linked-views-selection/implementations/r/ggplot2.R
+++ b/plots/linked-views-selection/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 GRID        <- if (THEME == "light") "#D4D4D0" else "#3A3A36"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Create coordinated dataset: multivariate iris with clear groupings
@@ -77,7 +77,7 @@ df_views <- rbind(
 # --- Main plot: Multiple linked views ----------------------------------------
 p <- ggplot(df_views, aes(x = x_val, y = y_val, color = Species)) +
   geom_point(size = 5, alpha = 0.75) +
-  scale_color_manual(values = OKABE_ITO[1:3]) +
+  scale_color_manual(values = IMPRINT[1:3]) +
   facet_wrap(~view_name, scales = "free", ncol = 3) +
   labs(
     title = "linked-views-selection · ggplot2 · anyplot.ai",

--- a/plots/logistic-regression/implementations/r/ggplot2.R
+++ b/plots/logistic-regression/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Medical diagnostic context: biomarker level predicts disease probability
@@ -50,10 +50,10 @@ plot_data <- data.frame(
 p <- ggplot() +
   # Confidence interval band
   geom_ribbon(data = pred_data, aes(x = biomarker, ymin = lower, ymax = upper),
-              fill = OKABE_ITO[1], alpha = 0.15) +
+              fill = IMPRINT[1], alpha = 0.15) +
   # Fitted curve
   geom_line(data = pred_data, aes(x = biomarker, y = probability),
-            color = OKABE_ITO[1], linewidth = 1.2) +
+            color = IMPRINT[1], linewidth = 1.2) +
   # Data points colored by class
   geom_point(data = plot_data, aes(x = biomarker, y = y_jittered, color = disease),
              size = 3, alpha = 0.65) +
@@ -61,7 +61,7 @@ p <- ggplot() +
   geom_hline(yintercept = 0.5, linetype = "dashed", color = INK_SOFT,
              linewidth = 0.7) +
   # Scales
-  scale_color_manual(values = c(OKABE_ITO[1], OKABE_ITO[2])) +
+  scale_color_manual(values = c(IMPRINT[1], IMPRINT[2])) +
   scale_y_continuous(limits = c(-0.15, 1.15), breaks = seq(0, 1, 0.25)) +
   # Labels
   labs(

--- a/plots/lollipop-grouped/implementations/r/ggplot2.R
+++ b/plots/lollipop-grouped/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Sales revenue (millions) by product line across regions
@@ -60,9 +60,9 @@ p <- ggplot(data, aes(x = region, y = revenue, color = product)) +
   ) +
   scale_color_manual(
     name = "Product",
-    values = c("Product A" = OKABE_ITO[1],
-               "Product B" = OKABE_ITO[2],
-               "Product C" = OKABE_ITO[3])
+    values = c("Product A" = IMPRINT[1],
+               "Product B" = IMPRINT[2],
+               "Product C" = IMPRINT[3])
   ) +
   labs(
     title = "lollipop-grouped · R · ggplot2 · anyplot.ai",

--- a/plots/map-marker-clustered/implementations/julia/makie.jl
+++ b/plots/map-marker-clustered/implementations/julia/makie.jl
@@ -23,14 +23,14 @@ const WATER_COLOR  = THEME == "light" ? RGBAf(0.63f0, 0.77f0, 0.87f0, 0.95f0) : 
 const STREET_COLOR = THEME == "light" ? RGBAf(1.0f0, 0.99f0, 0.97f0, 0.85f0) : RGBAf(0.10f0, 0.10f0, 0.08f0, 0.70f0)
 const WATER_LABEL  = THEME == "light" ? RGBAf(0.25f0, 0.45f0, 0.65f0, 0.65f0) : RGBAf(0.50f0, 0.70f0, 0.90f0, 0.65f0)
 
-const ANYPLOT_PALETTE = [
+const IMPRINT = [
     colorant"#009E73",
-    colorant"#9418DB",
-    colorant"#B71D27",
-    colorant"#16B8F3",
+    colorant"#C475FD",
+    colorant"#AE3030",
+    colorant"#4467A3",
     colorant"#99B314",
-    colorant"#D359A7",
-    colorant"#BA843E",
+    colorant"#954477",
+    colorant"#BD8233",
 ]
 
 # Data: specialty venues (coffee shops, bakeries, tea houses) across lower Manhattan, NYC
@@ -154,7 +154,7 @@ for (i, cat_name) in enumerate(CAT_NAMES)
     idx = filter(j -> cat_ids[j] == i, solo_idx)
     isempty(idx) && continue
     scatter!(ax, lons[idx], lats[idx];
-        color       = ANYPLOT_PALETTE[i],
+        color       = IMPRINT[i],
         markersize  = 15,
         strokewidth = 1.5,
         strokecolor = PAGE_BG,
@@ -166,10 +166,10 @@ end
 for (clat, clon, npts, dom_cat) in cluster_rows
     bubble_sz = clamp(npts * 2.8 + 18, 28, 72)
     scatter!(ax, [clon], [clat];
-        color       = (ANYPLOT_PALETTE[dom_cat], 0.80),
+        color       = (IMPRINT[dom_cat], 0.80),
         markersize  = bubble_sz,
         strokewidth = 2.5,
-        strokecolor = ANYPLOT_PALETTE[dom_cat],
+        strokecolor = IMPRINT[dom_cat],
     )
     text!(ax, clon, clat;
         text     = string(npts),

--- a/plots/map-marker-clustered/implementations/r/ggplot2.R
+++ b/plots/map-marker-clustered/implementations/r/ggplot2.R
@@ -19,10 +19,10 @@ INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
 WATER_BG    <- if (THEME == "light") "#CDDFF0" else "#101E2A"
 LAND_FILL   <- if (THEME == "light") "#E0EBD5" else "#263322"
 
-ANYPLOT_PALETTE <- c(
+IMPRINT <- c(
     "#009E73",  # 1: Music venues
-    "#9418DB",  # 2: Sports venues
-    "#B71D27"   # 3: Arts venues
+    "#C475FD",  # 2: Sports venues
+    "#AE3030"   # 3: Arts venues
 )
 categories <- c("Music", "Sports", "Arts")
 
@@ -95,7 +95,7 @@ p <- ggplot() +
         fontface = "bold"
     ) +
     scale_fill_manual(
-        values = setNames(ANYPLOT_PALETTE, categories),
+        values = setNames(IMPRINT, categories),
         name   = "Venue Type"
     ) +
     scale_size_area(

--- a/plots/map-projections/implementations/r/ggplot2.R
+++ b/plots/map-projections/implementations/r/ggplot2.R
@@ -15,9 +15,9 @@ INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 OCEAN_BG    <- if (THEME == "light") "#C4DCF0" else "#152030"
 LAND_BG     <- if (THEME == "light") "#D4C9A8" else "#2A3020"
 
-ANYPLOT_PALETTE <- c(
-    "#009E73", "#9418DB", "#B71D27", "#16B8F3",
-    "#99B314", "#D359A7", "#BA843E"
+IMPRINT <- c(
+    "#009E73", "#C475FD", "#AE3030", "#4467A3",
+    "#99B314", "#954477", "#BD8233"
 )
 
 # --- Mollweide projection math -----------------------------------------------
@@ -138,7 +138,7 @@ p <- ggplot() +
     # Tissot indicatrices — anyplot brand green (position 1)
     geom_polygon(
         data = tissot, aes(x = x, y = y, group = group),
-        fill = ANYPLOT_PALETTE[1], color = PAGE_BG,
+        fill = IMPRINT[1], color = PAGE_BG,
         linewidth = 0.06, alpha = 0.78
     ) +
     # Ellipse outline

--- a/plots/map-route-path/implementations/r/ggplot2.R
+++ b/plots/map-route-path/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 GRID_COLOR  <- if (THEME == "light") INK_SOFT else "#3A3A36"
 
 # Data: Synthetic GPS track for a mountain trail in Colorado Rockies
@@ -77,7 +77,7 @@ p <- ggplot(df, aes(x = lon, y = lat)) +
     )
   ) +
   scale_fill_manual(
-    values = c("Start" = OKABE_ITO[1], "End" = OKABE_ITO[2]),
+    values = c("Start" = IMPRINT[1], "End" = IMPRINT[2]),
     name   = NULL
   ) +
   scale_shape_manual(

--- a/plots/mosaic-categorical/implementations/r/ggplot2.R
+++ b/plots/mosaic-categorical/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # Data: product category vs customer satisfaction (retail survey, n = 500)
 category_levels     <- c("Electronics", "Clothing", "Food", "Books")
@@ -75,7 +75,7 @@ p <- ggplot(plot_data) +
     color = PAGE_BG, linewidth = 0.6
   ) +
   scale_fill_manual(
-    values = setNames(OKABE_ITO[1:3], satisfaction_levels),
+    values = setNames(IMPRINT[1:3], satisfaction_levels),
     name   = "Customer\nSatisfaction"
   ) +
   scale_x_continuous(

--- a/plots/network-hierarchical/implementations/r/ggplot2.R
+++ b/plots/network-hierarchical/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Organization hierarchy -------------------------------------------
 # Define nodes with their level (depth in tree)
@@ -99,7 +99,7 @@ p <- ggplot() +
   geom_point(
     data = nodes,
     aes(x = x, y = y),
-    color = OKABE_ITO[1], size = 12, alpha = 0.9
+    color = IMPRINT[1], size = 12, alpha = 0.9
   ) +
   # Add node labels
   geom_text(

--- a/plots/network-transport-static/implementations/r/ggplot2.R
+++ b/plots/network-transport-static/implementations/r/ggplot2.R
@@ -19,10 +19,10 @@ INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
 
-OKABE_ITO   <- c(
+IMPRINT   <- c(
   "#009E73",  # 1 — regional (first categorical series)
-  "#D55E00",  # 2 — express
-  "#0072B2"   # 3 — local
+  "#C475FD",  # 2 — express
+  "#4467A3"   # 3 — local
 )
 
 # --- Data: Regional rail network with 12 stations and 30 routes ----------------
@@ -48,7 +48,7 @@ routes <- data.frame(
 # Map route types to colors
 route_colors <- data.frame(
   route_type = c("Regional", "Express", "Local"),
-  color = OKABE_ITO,
+  color = IMPRINT,
   stringsAsFactors = FALSE
 )
 
@@ -133,7 +133,7 @@ p <- ggplot() +
   # Scale colors for route types
   scale_color_manual(
     name = "Route Type",
-    values = c("Regional" = OKABE_ITO[1], "Express" = OKABE_ITO[2], "Local" = OKABE_ITO[3])
+    values = c("Regional" = IMPRINT[1], "Express" = IMPRINT[2], "Local" = IMPRINT[3])
   ) +
   coord_fixed(ratio = 1) +
   labs(title = "network-transport-static · r · ggplot2 · anyplot.ai") +

--- a/plots/network-weighted/implementations/r/ggplot2.R
+++ b/plots/network-weighted/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # Data: Trade network between countries (weighted by annual trade volume)
 set.seed(42)
@@ -74,7 +74,7 @@ p <- ggplot() +
   geom_segment(
     data = edges_positioned,
     aes(x = x_start, y = y_start, xend = x_end, yend = y_end, linewidth = linewidth),
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     alpha = 0.5,
     lineend = "round"
   ) +
@@ -82,7 +82,7 @@ p <- ggplot() +
   geom_point(
     data = nodes,
     aes(x = x, y = y),
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     size = 8,
     alpha = 0.9
   ) +

--- a/plots/ohlc-bar/implementations/r/ggplot2.R
+++ b/plots/ohlc-bar/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 BORDER_COL  <- if (THEME == "light") "#D0CEC4" else "#3F3D37"
 GRID_COL    <- if (THEME == "light") "#E8E6DC" else "#2A2824"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Realistic stock prices over 50 trading days ----------------------
 dates <- seq(as.Date("2024-01-01"), by = "1 day", length.out = 50)
@@ -39,7 +39,7 @@ ohlc_data <- data.frame(
 ) %>%
   mutate(
     direction = ifelse(close > open, "up", "down"),
-    color_val = if_else(direction == "up", OKABE_ITO[1], OKABE_ITO[2]),
+    color_val = if_else(direction == "up", "#009E73", "#AE3030"),  # imprint green / red
     x_pos = as.numeric(date),
     volatility = (high - low) / low,
     opacity_val = 0.6 + 0.4 * min(volatility / max(volatility), 1.0)
@@ -113,7 +113,7 @@ p <- ggplot() +
     show.legend = FALSE
   ) +
   scale_color_manual(
-    values = c("up" = OKABE_ITO[1], "down" = OKABE_ITO[2])
+    values = c("up" = "#009E73", "down" = "#AE3030")  # imprint semantic anchors
   ) +
   scale_alpha_identity() +
   scale_x_continuous(

--- a/plots/parliament-basic/implementations/r/ggplot2.R
+++ b/plots/parliament-basic/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Create party data with seat counts
@@ -41,7 +41,7 @@ seat_idx <- 1
 for (i in 1:nrow(parties)) {
   party_name <- parties$party[i]
   party_seats <- parties$seats[i]
-  party_color_idx <- min(i, length(OKABE_ITO))
+  party_color_idx <- min(i, length(IMPRINT))
 
   for (j in 1:party_seats) {
     row_idx <- ceiling(seat_idx / seats_per_row)
@@ -69,7 +69,7 @@ for (i in 1:nrow(parties)) {
 }
 
 # Map color indices to actual colors
-seat_data$color <- OKABE_ITO[seat_data$color_idx]
+seat_data$color <- IMPRINT[seat_data$color_idx]
 
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(seat_data, aes(x = x, y = y, fill = party)) +
@@ -82,11 +82,11 @@ p <- ggplot(seat_data, aes(x = x, y = y, fill = party)) +
     show.legend = TRUE
   ) +
   scale_color_manual(
-    values = setNames(OKABE_ITO[1:nrow(parties)], parties$party),
+    values = setNames(IMPRINT[1:nrow(parties)], parties$party),
     guide = guide_legend(ncol = 1, title = "Party", title.position = "top")
   ) +
   scale_fill_manual(
-    values = setNames(OKABE_ITO[1:nrow(parties)], parties$party),
+    values = setNames(IMPRINT[1:nrow(parties)], parties$party),
     guide = "none"
   ) +
   coord_fixed() +

--- a/plots/point-and-figure-basic/implementations/r/ggplot2.R
+++ b/plots/point-and-figure-basic/implementations/r/ggplot2.R
@@ -15,7 +15,7 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 BULL_COLOR  <- "#009E73"   # Okabe-Ito #1 — bullish X columns
-BEAR_COLOR  <- "#D55E00"   # Okabe-Ito #2 — bearish O columns
+BEAR_COLOR  <- "#AE3030"   # imprint red — bearish O columns
 
 # --- Synthetic daily close prices (ACME Corp., 300 trading days) ---
 n_days <- 300

--- a/plots/renko-basic/implementations/r/ggplot2.R
+++ b/plots/renko-basic/implementations/r/ggplot2.R
@@ -17,7 +17,7 @@ INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 
 # Color palette
 BULL        <- "#009E73"  # Okabe-Ito position 1 (green)
-BEAR        <- "#D55E00"  # Okabe-Ito position 2 (red/orange)
+BEAR        <- "#AE3030"  # imprint red — bearish
 
 # --- Data generation --------------------------------------------------------
 # Generate synthetic stock price data

--- a/plots/scatter-basic/implementations/r/ggplot2.R
+++ b/plots/scatter-basic/implementations/r/ggplot2.R
@@ -13,8 +13,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # Data — marketing spend vs quarterly revenue across 200 campaigns
 n       <- 200
@@ -27,7 +27,7 @@ df <- data.frame(spend = spend, revenue = revenue)
 # Plot
 p <- ggplot(df, aes(x = spend, y = revenue)) +
   geom_point(
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     size  = 4,
     alpha = 0.7,
     shape = 16

--- a/plots/scatter-map-geographic/implementations/r/ggplot2.R
+++ b/plots/scatter-map-geographic/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 GRID_COLOR  <- if (THEME == "light") scales::alpha("#1A1A17", 0.08) else scales::alpha("#F0EFE8", 0.08)
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Earthquake epicenters with magnitude and depth -------------------
 earthquakes <- tibble::tibble(

--- a/plots/scatter-text/implementations/r/ggplot2.R
+++ b/plots/scatter-text/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Product positioning in competitive landscape ---------------------
 # Scenario: Tech products positioned by price (x) vs quality rating (y)
@@ -42,7 +42,7 @@ products$y <- products$quality
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(products, aes(x = x, y = y, label = name)) +
   geom_text(
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     size = 5.5,
     alpha = 0.85,
     fontface = "plain"

--- a/plots/skewt-logp-atmospheric/implementations/julia/makie.jl
+++ b/plots/skewt-logp-atmospheric/implementations/julia/makie.jl
@@ -14,14 +14,14 @@ const PAGE_BG     = THEME == "light" ? colorant"#FAF8F1" : colorant"#1A1A17"
 const ELEVATED_BG = THEME == "light" ? colorant"#FFFDF6" : colorant"#242420"
 const INK         = THEME == "light" ? colorant"#1A1A17" : colorant"#F0EFE8"
 const INK_SOFT    = THEME == "light" ? colorant"#4A4A44" : colorant"#B8B7B0"
-const OKABE_ITO   = [
+const IMPRINT   = [
     colorant"#009E73",
-    colorant"#D55E00",
-    colorant"#0072B2",
-    colorant"#CC79A7",
-    colorant"#E69F00",
-    colorant"#56B4E9",
-    colorant"#F0E442",
+    colorant"#C475FD",
+    colorant"#4467A3",
+    colorant"#BD8233",
+    colorant"#AE3030",
+    colorant"#2ABCCD",
+    colorant"#954477",
 ]
 
 # Skew-T parameters and thermodynamic constants
@@ -275,25 +275,25 @@ if any(cape_mask)
         vcat(par_xs_c, reverse(env_xs_c)),
         vcat(ys_c,     reverse(ys_c)),
     )
-    cape_fill = RGBAf(OKABE_ITO[5].r, OKABE_ITO[5].g, OKABE_ITO[5].b, 0.22f0)
+    cape_fill = RGBAf(IMPRINT[5].r, IMPRINT[5].g, IMPRINT[5].b, 0.22f0)
     poly!(ax, cape_pts; color = cape_fill, strokewidth = 0, label = "CAPE")
 end
 
 # Lifted parcel trace (smooth, fine resolution)
 parcel_xs_fine = [skew_x(T, P) for (T, P) in zip(parcel_Ts_fine, P_FINE)]
 lines!(ax, parcel_xs_fine, y_p.(P_FINE);
-       color = OKABE_ITO[4], linewidth = 2.0, linestyle = :dashdotdot,
+       color = IMPRINT[4], linewidth = 2.0, linestyle = :dashdotdot,
        label = "Lifted parcel")
 
 # LCL marker
 lcl_x = skew_x(T_LCL_C, P_LCL_hPa)
 lcl_y = y_p(P_LCL_hPa)
 scatter!(ax, [lcl_x], [lcl_y];
-         color = OKABE_ITO[4], markersize = 10, marker = :diamond, strokewidth = 0)
+         color = IMPRINT[4], markersize = 10, marker = :diamond, strokewidth = 0)
 text!(ax, lcl_x + 1.5, lcl_y;
       text    = "LCL",
       fontsize = 9,
-      color   = OKABE_ITO[4],
+      color   = IMPRINT[4],
       align   = (:left, :center))
 
 # Sounding profiles
@@ -302,14 +302,14 @@ TD_xs  = [skew_x(Td, P) for (Td, P) in zip(TD_OBS, P_OBS)]
 obs_ys = y_p.(P_OBS)
 
 lines!(ax, T_xs, obs_ys;
-       color = OKABE_ITO[1], linewidth = 3.5, label = "Temperature")
+       color = IMPRINT[1], linewidth = 3.5, label = "Temperature")
 scatter!(ax, T_xs, obs_ys;
-         color = OKABE_ITO[1], markersize = 7, strokewidth = 0)
+         color = IMPRINT[1], markersize = 7, strokewidth = 0)
 
 lines!(ax, TD_xs, obs_ys;
-       color = OKABE_ITO[2], linewidth = 3.5, linestyle = :dash, label = "Dewpoint")
+       color = IMPRINT[2], linewidth = 3.5, linestyle = :dash, label = "Dewpoint")
 scatter!(ax, TD_xs, obs_ys;
-         color = OKABE_ITO[2], markersize = 7, strokewidth = 0)
+         color = IMPRINT[2], markersize = 7, strokewidth = 0)
 
 axislegend(ax;
     position        = :rt,

--- a/plots/skewt-logp-atmospheric/implementations/r/ggplot2.R
+++ b/plots/skewt-logp-atmospheric/implementations/r/ggplot2.R
@@ -15,8 +15,8 @@ ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Coordinate Helpers ------------------------------------------------------
 # Y-axis: negative log10 of pressure so that high pressure (surface) sits at
@@ -129,12 +129,12 @@ series_order <- c("Temperature", "Dewpoint", "Isotherms",
                   "Dry Adiabats", "Moist Adiabats", "Mixing Ratios")
 
 color_values <- c(
-  "Temperature"   = OKABE_ITO[1],   # #009E73 green
-  "Dewpoint"      = OKABE_ITO[2],   # #D55E00 orange-red
+  "Temperature"   = IMPRINT[1],   # #009E73 green
+  "Dewpoint"      = IMPRINT[2],   # #C475FD orange-red
   "Isotherms"     = INK_MUTED,      # gray, theme-adaptive
-  "Dry Adiabats"  = OKABE_ITO[5],   # #E69F00 amber
-  "Moist Adiabats"= OKABE_ITO[4],   # #CC79A7 purple (distinct from sky blue)
-  "Mixing Ratios" = OKABE_ITO[6]    # #56B4E9 sky blue
+  "Dry Adiabats"  = IMPRINT[5],   # #AE3030 amber
+  "Moist Adiabats"= IMPRINT[4],   # #BD8233 purple (distinct from sky blue)
+  "Mixing Ratios" = IMPRINT[6]    # #2ABCCD sky blue
 )
 
 linetype_values <- c(

--- a/plots/smith-chart-basic/implementations/r/ggplot2.R
+++ b/plots/smith-chart-basic/implementations/r/ggplot2.R
@@ -11,8 +11,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Smith chart grid -------------------------------------------------------
 theta <- seq(0, 2 * pi, length.out = 361)
@@ -101,26 +101,26 @@ p <- ggplot() +
                color = INK_SOFT, linewidth = 0.3) +
   # VSWR = 2 reference circle
   geom_path(data = vswr_circle, aes(x = x, y = y),
-            color = OKABE_ITO[3], linewidth = 0.5, linetype = "dashed") +
+            color = IMPRINT[3], linewidth = 0.5, linetype = "dashed") +
   annotate("text", x = -0.38, y = 0.06,
-           label = "VSWR = 2", size = 3.0, color = OKABE_ITO[3]) +
+           label = "VSWR = 2", size = 3.0, color = IMPRINT[3]) +
   # Matched-load centre marker
   geom_point(aes(x = 0, y = 0),
              color = INK_SOFT, size = 1.8, shape = 3) +
   # Impedance locus
   geom_path(data = locus, aes(x = gre, y = gim),
-            color = OKABE_ITO[1], linewidth = 1.4) +
+            color = IMPRINT[1], linewidth = 1.4) +
   # Directional arrow at 3 GHz end showing sweep direction
   annotate("segment",
            x = arr_x0, xend = locus$gre[n_loc],
            y = arr_y0, yend = locus$gim[n_loc],
-           color = OKABE_ITO[1], linewidth = 1.4,
+           color = IMPRINT[1], linewidth = 1.4,
            arrow = arrow(length = unit(0.1, "inches"), type = "closed")) +
   # Start (1 GHz) and end (3 GHz) markers
   geom_point(data = locus[1, ], aes(x = gre, y = gim),
-             color = OKABE_ITO[1], size = 3.5, shape = 16) +
+             color = IMPRINT[1], size = 3.5, shape = 16) +
   geom_point(data = locus[nrow(locus), ], aes(x = gre, y = gim),
-             color = OKABE_ITO[2], size = 3.5, shape = 17) +
+             color = IMPRINT[2], size = 3.5, shape = 17) +
   # Frequency labels
   geom_text(data = label_pts, aes(x = gre, y = gim, label = lbl),
             color = INK, size = 3.2, hjust = -0.15, lineheight = 0.9) +

--- a/plots/sn-curve-basic/implementations/r/ggplot2.R
+++ b/plots/sn-curve-basic/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 GRID        <- adjustcolor(INK_SOFT, alpha.f = 0.25)
 
 # AISI 1045 Steel material properties (MPa)
@@ -51,33 +51,33 @@ p <- ggplot() +
     annotate("rect",
         xmin = N_endurance, xmax = 10^8,
         ymin = 310, ymax = sigma_e,
-        fill = OKABE_ITO[5], alpha = 0.14
+        fill = IMPRINT[5], alpha = 0.14
     ) +
     # Reference lines for key material properties
     geom_hline(yintercept = sigma_u, linetype = "dashed",
-               color = OKABE_ITO[2], linewidth = 0.65, alpha = 0.85) +
+               color = IMPRINT[2], linewidth = 0.65, alpha = 0.85) +
     geom_hline(yintercept = sigma_y, linetype = "dashed",
-               color = OKABE_ITO[3], linewidth = 0.65, alpha = 0.85) +
+               color = IMPRINT[3], linewidth = 0.65, alpha = 0.85) +
     # Endurance limit thicker — the key design threshold for infinite life
     geom_hline(yintercept = sigma_e, linetype = "longdash",
-               color = OKABE_ITO[5], linewidth = 1.1, alpha = 0.95) +
+               color = IMPRINT[5], linewidth = 1.1, alpha = 0.95) +
     # Basquin fit curve
     geom_line(data = fit_df, aes(x = cycles, y = stress),
               color = INK_MUTED, linewidth = 1.0) +
     # Test data scatter (multiple replicates per stress level)
     geom_point(data = df, aes(x = cycles, y = stress),
                shape = 21, size = 3.0, stroke = 0.5,
-               color = OKABE_ITO[1], fill = OKABE_ITO[1], alpha = 0.85) +
+               color = IMPRINT[1], fill = IMPRINT[1], alpha = 0.85) +
     # Reference line labels — right-aligned at x = 10^7.5
     annotate("text", x = 10^7.5, y = sigma_u * 1.05,
              label = "Ultimate Strength (750 MPa)",
-             color = OKABE_ITO[2], hjust = 1, vjust = 0, size = 4.0) +
+             color = IMPRINT[2], hjust = 1, vjust = 0, size = 4.0) +
     annotate("text", x = 10^7.5, y = sigma_y * 1.05,
              label = "Yield Strength (530 MPa)",
-             color = OKABE_ITO[3], hjust = 1, vjust = 0, size = 4.0) +
+             color = IMPRINT[3], hjust = 1, vjust = 0, size = 4.0) +
     annotate("text", x = 10^7.5, y = sigma_e * 1.06,
              label = "Endurance Limit (375 MPa)",
-             color = OKABE_ITO[5], hjust = 1, vjust = 0, size = 4.0,
+             color = IMPRINT[5], hjust = 1, vjust = 0, size = 4.0,
              fontface = "bold") +
     # Infinite-life region label inside shaded zone
     annotate("text", x = 10^7.2, y = 340,

--- a/plots/timeseries-forecast-uncertainty/implementations/r/ggplot2.R
+++ b/plots/timeseries-forecast-uncertainty/implementations/r/ggplot2.R
@@ -13,8 +13,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 # On dark backgrounds, orange at low alpha reads as muddy brown; use higher
 # alpha so the hue stays clearly orange rather than blending to near-black.
 ALPHA_95    <- if (THEME == "light") 0.10 else 0.30
@@ -65,11 +65,11 @@ p <- ggplot(df, aes(x = date)) +
   geom_vline(xintercept = dates_hist[36] + 15.5, linetype = "dashed",
              color = INK_SOFT, linewidth = 0.8, alpha = 0.6) +
   scale_color_manual(
-    values = c("Historical" = OKABE_ITO[1], "Forecast" = OKABE_ITO[2]),
+    values = c("Historical" = IMPRINT[1], "Forecast" = IMPRINT[2]),
     breaks = c("Historical", "Forecast")
   ) +
   scale_fill_manual(
-    values = c("80% CI" = OKABE_ITO[2], "95% CI" = OKABE_ITO[2]),
+    values = c("80% CI" = IMPRINT[2], "95% CI" = IMPRINT[2]),
     breaks = c("95% CI", "80% CI")
   ) +
   scale_x_date(expand = expansion(mult = c(0.02, 0.05))) +

--- a/plots/violin-grouped-swarm/implementations/r/ggplot2.R
+++ b/plots/violin-grouped-swarm/implementations/r/ggplot2.R
@@ -13,8 +13,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 # Response times (ms) across task types and expertise levels
@@ -65,8 +65,8 @@ p <- ggplot(df, aes(x = category, y = value, fill = group, color = group)) +
     shape = 21,
     stroke = 0.5
   ) +
-  scale_fill_manual(values = OKABE_ITO[1:2]) +
-  scale_color_manual(values = OKABE_ITO[1:2]) +
+  scale_fill_manual(values = IMPRINT[1:2]) +
+  scale_color_manual(values = IMPRINT[1:2]) +
   labs(
     title = "violin-grouped-swarm · R · ggplot2 · anyplot.ai",
     x = "Task Type",

--- a/plots/violin-swarm/implementations/r/ggplot2.R
+++ b/plots/violin-swarm/implementations/r/ggplot2.R
@@ -14,8 +14,8 @@ THEME       <- Sys.getenv("ANYPLOT_THEME", "light")
 PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data -------------------------------------------------------------------
 df <- tibble::tibble(
@@ -32,13 +32,13 @@ df <- tibble::tibble(
 # --- Plot -------------------------------------------------------------------
 p <- ggplot(df, aes(x = condition, y = reaction_time)) +
   geom_violin(
-    fill = OKABE_ITO[1],
+    fill = IMPRINT[1],
     alpha = 0.4,
     color = INK_SOFT,
     linewidth = 0.8
   ) +
   geom_jitter(
-    color = OKABE_ITO[1],
+    color = IMPRINT[1],
     size = 2.5,
     alpha = 0.7,
     width = 0.2,

--- a/plots/voronoi-basic/implementations/r/ggplot2.R
+++ b/plots/voronoi-basic/implementations/r/ggplot2.R
@@ -16,8 +16,8 @@ PAGE_BG     <- if (THEME == "light") "#FAF8F1" else "#1A1A17"
 ELEVATED_BG <- if (THEME == "light") "#FFFDF6" else "#242420"
 INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
 
 # --- Data: Seed points for Voronoi diagram --------------------------------
 n_points <- 25
@@ -52,7 +52,7 @@ grid_df$cell_id <- seed_points$id[grid_df$region]
 grid_df <- grid_df %>%
   mutate(
     color_idx = ((cell_id - 1) %% 7) + 1,
-    color = OKABE_ITO[color_idx]
+    color = IMPRINT[color_idx]
   )
 
 # --- Plot -------------------------------------------------------------------

--- a/plots/windbarb-basic/implementations/r/ggplot2.R
+++ b/plots/windbarb-basic/implementations/r/ggplot2.R
@@ -16,9 +16,9 @@ INK         <- if (THEME == "light") "#1A1A17" else "#F0EFE8"
 INK_SOFT    <- if (THEME == "light") "#4A4A44" else "#B8B7B0"
 INK_MUTED   <- if (THEME == "light") "#6B6A63" else "#A8A79F"
 GRID_COLOR  <- if (THEME == "light") "#E4E2DB" else "#2F2F2C"
-OKABE_ITO   <- c("#009E73", "#D55E00", "#0072B2", "#CC79A7",
-                 "#E69F00", "#56B4E9", "#F0E442")
-BARB_COLOR  <- OKABE_ITO[1]
+IMPRINT   <- c("#009E73", "#C475FD", "#4467A3", "#BD8233",
+                 "#AE3030", "#2ABCCD", "#954477")
+BARB_COLOR  <- IMPRINT[1]
 
 # --- Wind field data ----------------------------------------------------------
 # 9x7 grid of surface weather stations over eastern North America


### PR DESCRIPTION
## Summary

- Positional hex replacement across **48 ggplot2 impls** + **5 makie impls** that already ship light+dark renders.
- **No new R/Julia impls** are created for specs that lacked them — those continue through the normal regen workflow (per scope: only migrate existing dual-theme impls).
- Final library pass for the imprint migration. With this merged, every Python lib + R + Julia is on the imprint palette.

## Semantic fixes (proactive, 5 ggplot2 impls)

- dashboard-metrics-tiles: `COL_WARNING` → amber, `COL_CRITICAL` → red
- kagi-basic: `COLOR_YIN` (downtrend) → red
- ohlc-bar: down direction → red (instead of `IMPRINT[2]` slot 1 lavender)
- point-and-figure-basic: `BEAR_COLOR` → red
- renko-basic: `BEAR` → red

No semantic anchor issues in the 5 Julia impls — those use the canonical IMPRINT list categorically.

## What's left after this PR

Only Stage B (local render + GCS upload) for the recently-merged libraries. Currently chained in the background:

- ✅ matplotlib (137/137 done)
- ✅ seaborn (138/138 done)
- 🔄 plotnine (132/132 done), plotly (in progress)
- ⏳ bokeh, altair, pygal, highcharts, letsplot, ggplot2, makie (queued)

## Test plan

- [x] `ruff check .` + format green
- [ ] CI green
- [ ] Copilot triage
- [ ] After merge: Stage B for 53 R/Julia impls → GCS

🤖 Generated with [Claude Code](https://claude.com/claude-code)