### PR TITLE
fix(palette): make diverging midpoint swatch theme-adaptive

### DIFF
--- a/app/src/pages/PalettePage.tsx
+++ b/app/src/pages/PalettePage.tsx
@@ -843,7 +843,7 @@ export function PalettePage() {
                 <Box sx={{
                   height: 28,
                   borderRadius: 1,
-                  background: 'linear-gradient(to right, #AE3030, #FAF8F1, #4467A3)',
+                  background: 'linear-gradient(to right, #AE3030, var(--bg-surface), #4467A3)',
                   boxShadow: '0 0 0 1px var(--rule)',
                 }} />
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.5, fontFamily: typography.mono, fontSize: '10px', color: 'var(--ink-muted)' }}>


### PR DESCRIPTION
## Bug report

> diverging mitte neutral passt sich nicht an light,dark modus an
> *(the diverging middle neutral does not adapt to light/dark mode)*

— left via the feedback widget on https://anyplot.ai/palette

## Root cause

In the **continuous cmaps** section of `PalettePage.tsx`, the `imprint_div` diverging colormap preview hardcoded its midpoint color:

```tsx
background: 'linear-gradient(to right, #AE3030, #FAF8F1, #4467A3)',
```

`#FAF8F1` is the **light-mode** surface color. The caption directly beneath the swatch already documents the midpoint as theme-adaptive:

> the diverging midpoint flips per theme — `#FAF8F1` on cream bg / `#1A1A17` on warm-near-black

…and the copy-paste code snippets all branch on theme. But the visible swatch itself never switched, so in **dark mode** the center rendered as a bright cream blob instead of blending into the page — exactly what the reporter saw.

Those two documented values (`#FAF8F1` / `#1A1A17`) are precisely the `--bg-surface` token in light/dark (`tokens.css`).

## Fix

Swap the hardcoded literal for the CSS variable so the swatch follows `[data-theme]` like everything else:

```tsx
background: 'linear-gradient(to right, #AE3030, var(--bg-surface), #4467A3)',
```

One-line change; the endpoints (`#AE3030` red, `#4467A3` blue) are fixed palette hues and stay as-is.

## Verification

- `yarn type-check` — passes
- `yarn vitest run src/pages/PalettePage.snippet.test.ts` — 10/10 pass (snippet copy-paste logic unaffected)

https://claude.ai/code/session_014xvyQxAShVvotxA93aPrVN

---
_Generated by [Claude Code](https://claude.ai/code/session_014xvyQxAShVvotxA93aPrVN)_