### PR TITLE
Fix: adapt spec detail overlay buttons to dark mode

### DIFF
--- a/app/src/components/SpecDetailView.test.tsx
+++ b/app/src/components/SpecDetailView.test.tsx
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, userEvent } from '../test-utils';
 import { SpecDetailView } from './SpecDetailView';
+import { ThemeContext, type ThemeContextValue } from '../hooks/useLayoutContext';
 import type { Implementation } from '../types';
+
+const darkThemeValue: ThemeContextValue = {
+  mode: 'dark',
+  effective: 'dark',
+  isDark: true,
+  setMode: vi.fn(),
+  cycle: vi.fn(),
+};
 
 vi.mock('../utils/responsiveImage', () => ({
   buildDetailSrcSet: (url: string, fmt: string) => `${url}-srcset-${fmt}`,
@@ -153,6 +162,23 @@ describe('SpecDetailView', () => {
 
     await user.click(screen.getByRole('button', { name: 'Zoom out' }));
     expect(screen.getByRole('button', { name: 'Zoom in' })).toBeInTheDocument();
+  });
+
+  it('adapts overlay action buttons to a dark surface in dark mode', () => {
+    // Light mode (default context): bright surface so buttons read on a light preview.
+    const { unmount } = render(<SpecDetailView {...defaultProps} />);
+    const lightBtn = screen.getByRole('button', { name: /download png/i });
+    expect(lightBtn).toHaveStyle({ backgroundColor: 'rgba(255,255,255,0.9)' });
+    unmount();
+
+    // Dark mode: dark surface so the button no longer clashes with the dark preview.
+    render(
+      <ThemeContext.Provider value={darkThemeValue}>
+        <SpecDetailView {...defaultProps} />
+      </ThemeContext.Provider>,
+    );
+    const darkBtn = screen.getByRole('button', { name: /download png/i });
+    expect(darkBtn).toHaveStyle({ backgroundColor: 'rgba(36,36,32,0.9)' });
   });
 
   it('renders nothing special when currentImpl is null', () => {

--- a/app/src/components/SpecDetailView.tsx
+++ b/app/src/components/SpecDetailView.tsx
@@ -192,6 +192,18 @@ export function SpecDetailView({
   const previewUrl = selectPreviewUrl(currentImpl, isDark);
   const previewHtml = selectPreviewHtml(currentImpl, isDark);
   const interactiveAvailable = !!previewHtml;
+
+  // Overlay action buttons (report/copy/download/open/preview/raw) sit on top of
+  // the preview image. In dark mode the preview is dark, so a bright white button
+  // clashes — adapt the surface and icon ink to the active theme.
+  const overlayButtonSx = {
+    bgcolor: isDark ? 'rgba(36,36,32,0.9)' : 'rgba(255,255,255,0.9)',
+    color: 'var(--ink)',
+    '&:hover': {
+      bgcolor: isDark ? '#242420' : '#fff',
+      color: colors.primary,
+    },
+  } as const;
   const proxyUrl = (url: string) =>
     `${API_URL}/proxy/html?url=${encodeURIComponent(url)}&origin=${encodeURIComponent(window.location.origin)}`;
 
@@ -247,7 +259,7 @@ export function SpecDetailView({
                 rel="noopener noreferrer"
                 onClick={onReport}
                 aria-label="Report issue"
-                sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                sx={overlayButtonSx}
                 size="medium"
               >
                 <FlagOutlinedIcon fontSize="small" />
@@ -263,7 +275,7 @@ export function SpecDetailView({
                   onTrackEvent('view_mode_change', { mode: 'preview', library: selectedLibrary });
                 }}
                 aria-label="Show static preview"
-                sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                sx={overlayButtonSx}
                 size="medium"
               >
                 <ImageOutlinedIcon fontSize="small" />
@@ -273,7 +285,7 @@ export function SpecDetailView({
               <IconButton
                 onClick={() => previewHtml && window.open(previewHtml, '_blank', 'noopener,noreferrer')}
                 aria-label="Open raw HTML"
-                sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                sx={overlayButtonSx}
                 size="medium"
               >
                 <OpenInNewIcon fontSize="small" />
@@ -374,7 +386,7 @@ export function SpecDetailView({
                 rel="noopener noreferrer"
                 onClick={(e: React.MouseEvent) => { (e.currentTarget as HTMLElement).blur(); onReport(); }}
                 aria-label="Report issue"
-                sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                sx={overlayButtonSx}
                 size="medium"
               >
                 <FlagOutlinedIcon fontSize="small" />
@@ -391,7 +403,7 @@ export function SpecDetailView({
                 <IconButton
                   onClick={(e: React.MouseEvent) => { (e.currentTarget as HTMLElement).blur(); onCopyCode(currentImpl); }}
                   aria-label="Copy code"
-                  sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                  sx={overlayButtonSx}
                   size="medium"
                 >
                   <ContentCopyIcon fontSize="small" />
@@ -403,7 +415,7 @@ export function SpecDetailView({
                 <IconButton
                   onClick={(e: React.MouseEvent) => { (e.currentTarget as HTMLElement).blur(); onDownload(currentImpl); }}
                   aria-label="Download PNG"
-                  sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                  sx={overlayButtonSx}
                   size="medium"
                 >
                   <DownloadIcon fontSize="small" />
@@ -418,7 +430,7 @@ export function SpecDetailView({
                     onTrackEvent('view_mode_change', { mode: 'interactive', library: selectedLibrary });
                   }}
                   aria-label="Show interactive"
-                  sx={{ bgcolor: 'rgba(255,255,255,0.9)', '&:hover': { bgcolor: '#fff', color: colors.primary } }}
+                  sx={overlayButtonSx}
                   size="medium"
                 >
                   <PlayArrowIcon fontSize="small" />


### PR DESCRIPTION
## Problem

A user reported on `https://anyplot.ai/raincloud-basic/python/plotnine`:

> die Buttons Download... passen sich nicht an dark an

("the Download… buttons don't adapt to dark [mode]").

On the spec detail view, the overlay action buttons — report, copy, download, open-interactive, preview, and raw-HTML — all hardcoded a white background (`rgba(255,255,255,0.9)`) with a white hover. In dark mode the preview image and surrounding surfaces are dark, so these buttons stayed bright white and clashed with the rest of the UI.

## Fix

`SpecDetailView` already reads `isDark` from the theme context. I introduced a shared `overlayButtonSx` that derives its surface and icon ink from the active theme:

- **Light mode** — unchanged: `rgba(255,255,255,0.9)` surface, white hover.
- **Dark mode** — warm near-black surface (`rgba(36,36,32,0.9)`, matching the `--bg-elevated` token) with light ink (`var(--ink)`), so the buttons sit naturally on the dark preview.

Hover still flips the icon to brand green in both themes. All 7 overlay buttons now share this one adaptive style instead of repeating the hardcoded white literal.

## Testing

- `yarn type-check` — clean
- `yarn lint` — no new warnings (only pre-existing ones in unrelated files)
- `yarn test src/components/SpecDetailView.test.tsx` — 14 passed, including a new regression test asserting the download button surface is light in light mode and dark in dark mode.

https://claude.ai/code/session_01Jo9Qt6iQwqrusKXQzq8yT2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jo9Qt6iQwqrusKXQzq8yT2)_