### PR TITLE
feat(audit): make /audit goal-directed toward an exemplary repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,12 @@ secrets/
 # Generated OG image samples (issue #5652) — review-only output of scripts/generate_og_samples.py
 /out/
 .migration-progress.json
+
+# Rendered plot artifacts must NOT be checked into the repo — they live in
+# GCS production (gs://anyplot-images/plots/...). The .regen-preview/ rule
+# above already excludes the staging dir; this rule catches the rarer case
+# of plot-{light,dark}.{png,html} accidentally landing at the impl-dir root
+# (e.g. from impls that call savefig(script_dir, ...) instead of cwd).
+plots/*/implementations/*/plot-*.png
+plots/*/implementations/*/plot-*.html
+plots/*/implementations/*/plot-*.webp

--- a/agentic/commands/audit.md
+++ b/agentic/commands/audit.md
@@ -1,20 +1,30 @@
 # Code Quality Audit
 
-> Team-based code quality audit for the anyplot repository. Spawns up to fifteen specialized Opus agents (backend, frontend, infra, quality, llm-pipeline, db, security, observability, agentic, gcloud, github, plausible, pagespeed, seo, catalog) that analyze the codebase and live systems in parallel. Lead cross-validates high-severity findings, synthesizes a prioritized, effort-rated, auto-fix-aware action plan, and persists the report for regression tracking. Auditors that touch external systems degrade gracefully when credentials are missing — they never block the rest of the run.
+> Team-based, goal-directed audit for the anyplot repository. Its north star is not "list bugs" but **"how far is anyplot from an exemplary repository, and what is the shortest path there?"** measured across six dimensions — **Security, Speed, Looks (Aussehen/UX), Modern, Correctness, Maintainability**. Spawns up to sixteen specialized Opus agents (backend, frontend, design, infra, quality, llm-pipeline, db, security, observability, agentic, gcloud, github, plausible, pagespeed, seo, catalog) that analyze the codebase and live systems in parallel. Lead cross-validates high-severity findings (domain-routed), synthesizes a prioritized, dimension-tagged, effort-rated, auto-fix-aware action plan with a per-dimension scorecard, and persists the report for regression tracking. Auditors that touch external systems degrade gracefully when credentials are missing — they never block the rest of the run.
 
 ## Context
 
 @CLAUDE.md
 @pyproject.toml
 
+## Mission: drive anyplot toward an exemplary repository
+
+Every `/audit` run exists to move anyplot closer to a repository other people would hold up as a model — beautiful, secure, fast, and modern. To make that goal operational and trend-comparable, every finding is tagged with exactly one **dimension** (see Dimension Taxonomy), and the report rolls findings up into a per-dimension scorecard plus an overall Health Score.
+
+Auditors therefore surface two kinds of finding:
+- **Defects** — something is wrong, slow, insecure, ugly, or dated and should be fixed.
+- **Exemplary gaps** — nothing is broken, but a best-in-class repo in this space would have something anyplot lacks (see Exemplary Repository Rubric). These are real findings, rated by impact and effort like any other.
+
+The point is a report that answers "where are we strong, where are we weak, and what do I fix first to look exemplary?" — not an undifferentiated bug list.
+
 ## Instructions
 
-You are the **audit-lead**. Your job is to coordinate a team of specialist auditors, run a cross-validation pass on high-severity findings, and synthesize a single deduplicated, prioritized, persistable report.
+You are the **audit-lead**. Your job is to coordinate a team of specialist auditors, run a cross-validation pass on high-severity findings, and synthesize a single deduplicated, prioritized, dimension-scored, persistable report.
 
 ### Phase 1: Setup
 
 1. **Parse scope from `$ARGUMENTS`:**
-   - Empty / `all` → spawn all 15 auditors
+   - Empty / `all` → spawn all 16 auditors
    - Single keyword → spawn only that auditor (see Scope Table)
    - Directory path → Lead determines which auditor(s) cover that path
    - Optional `since=<git-ref>` (e.g. `since=main`, `since=HEAD~10`) → **Incremental mode**: Lead computes the changed file list once via `git diff --name-only <ref>...HEAD` and passes the relevant subset to each auditor. Auditors must restrict their analysis to those files (plus their direct importers if a quick `mcp__serena__find_referencing_symbols` lookup is cheap). If `since=` is omitted, auditors run a full sweep of their scope. The five external-system auditors (`gcloud`, `github`, `plausible`, `pagespeed`, `seo`) ignore `since=` because their scope is live systems, not files.
@@ -32,27 +42,28 @@ You are the **audit-lead**. Your job is to coordinate a team of specialist audit
    ```
    Record ruff issue count, format status, and (if applicable) the changed-file count for the report header.
 
-3. **Build a new agent team:** Create an "audit" team with the specialists matching the active scope. Each auditor is `general-purpose, opus`:
+3. **Determine the active auditor set.** Each auditor is `general-purpose, opus` (this audit optimizes for finding quality, not cost — do not downgrade auditor models). The active set is:
 
-   | Auditor | Primary Paths / Surface |
-   |---|---|
-   | `backend-auditor` | `api/`, `core/`, `automation/` |
-   | `frontend-auditor` | `app/src/` |
-   | `infra-auditor` | `.github/workflows/`, `prompts/`, Dockerfiles, top-level configs |
-   | `quality-auditor` | `tests/`, `docs/`, `agentic/commands/`, README/CLAUDE.md |
-   | `llm-pipeline-auditor` | `core/generators/`, `prompts/`, `core/config.py` (claude_*), `agentic/workflows/`, `.github/workflows/{spec,impl,bulk}-*.yml` |
-   | `db-auditor` | `alembic/`, `core/database/`, `alembic.ini` |
-   | `security-auditor` | repo-wide (primarily `api/`, `core/config.py`, `agentic/workflows/`, `.github/workflows/`) |
-   | `observability-auditor` | `api/analytics.py`, `api/cache.py`, `app/src/analytics/`, `docs/reference/plausible.md` |
-   | `agentic-auditor` | `CLAUDE.md`, `agentic/`, `prompts/`, `.claude/`, `agentic/commands/` (TAC-style: agent ergonomics) |
-   | `gcloud-auditor` | live `anyplot` GCP project (Cloud Run, Cloud SQL, GCS, Cloud Build, Logs, IAM, Secret Manager) — **read-only** |
-   | `github-auditor` | `MarkusNeusinger/anyplot` GitHub repo via `gh` (branches, PRs, issues, runs, labels, secrets/vars, branch protection) — **read-only** |
-   | `plausible-auditor` | live Plausible Stats API for `anyplot.ai`, cross-checked against `api/analytics.py`, `app/src/analytics/`, `docs/reference/plausible.md` — **read-only** |
-   | `pagespeed-auditor` | live `anyplot.ai` via PageSpeed Insights v5 REST (mobile + desktop) — **read-only** |
-   | `seo-auditor` | live `anyplot.ai` via Google Search Console API + structural fetches (sitemap, robots, canonical, meta, JSON-LD) — **read-only** |
-   | `catalog-auditor` | the plot catalog itself: `plots/` filesystem, Postgres rows, GCS preview integrity (sampled) — **read-only** |
+   | Auditor | Primary Paths / Surface | Default dimensions |
+   |---|---|---|
+   | `backend-auditor` | `api/`, `core/`, `automation/` | correctness, maintainability, speed |
+   | `frontend-auditor` | `app/src/` (code quality: types, hooks, state, a11y-correctness) | correctness, maintainability, modern |
+   | `design-auditor` | `app/src/` (visual design, theme/dark-mode, responsive, UX polish, design-system consistency) | looks |
+   | `infra-auditor` | `.github/workflows/`, `prompts/`, Dockerfiles, top-level configs | security, maintainability, modern |
+   | `quality-auditor` | `tests/`, `docs/`, `agentic/commands/`, README/CLAUDE.md, repo-health files | maintainability, modern |
+   | `llm-pipeline-auditor` | `prompts/`, `scripts/evaluate-plot.py`, `core/config.py` (claude_*), `agentic/workflows/`, `.github/workflows/{spec,impl,bulk,daily}-*.yml` | correctness, speed, maintainability |
+   | `db-auditor` | `alembic/`, `core/database/`, `alembic.ini` | correctness, speed |
+   | `security-auditor` | repo-wide (primarily `api/`, `core/config.py`, `agentic/workflows/`, `.github/workflows/`) | security |
+   | `observability-auditor` | `api/analytics.py`, `api/cache.py`, `app/src/analytics/`, `docs/reference/plausible.md` | maintainability, speed |
+   | `agentic-auditor` | `CLAUDE.md`, `agentic/`, `prompts/`, `.claude/`, `agentic/commands/` (TAC-style: agent ergonomics) | maintainability, modern |
+   | `gcloud-auditor` | live `anyplot` GCP project (Cloud Run, Cloud SQL, GCS, Cloud Build, Logs, IAM, Secret Manager) — **read-only** | security, speed |
+   | `github-auditor` | `MarkusNeusinger/anyplot` GitHub repo via `gh` (branches, PRs, issues, runs, labels, secrets/vars, branch protection) — **read-only** | maintainability, security |
+   | `plausible-auditor` | live Plausible Stats API for `anyplot.ai`, cross-checked against `api/analytics.py`, `app/src/analytics/`, `docs/reference/plausible.md` — **read-only** | speed, maintainability |
+   | `pagespeed-auditor` | live `anyplot.ai` via PageSpeed Insights v5 REST (mobile + desktop) — **read-only** | speed, looks |
+   | `seo-auditor` | live `anyplot.ai` via Google Search Console API + structural fetches (sitemap, robots, canonical, meta, JSON-LD) — **read-only** | modern, maintainability |
+   | `catalog-auditor` | the plot catalog itself: `plots/` filesystem, Postgres rows, GCS preview integrity (sampled) — **read-only** | maintainability, correctness |
 
-   Create one task per active auditor, spawn them in parallel, and assign tasks. Catalog runs in parallel with the others; any cross-references against Plausible/SEO findings are computed by the Lead in Phase 3, not by `catalog-auditor` itself.
+   The "Default dimensions" column is a *hint* for which pillars each auditor most often touches; the auditor still tags every finding with the single dimension that best fits it (see Dimension Taxonomy). Catalog runs in parallel with the others; any cross-references against Plausible/SEO findings are computed by the Lead in Phase 3, not by `catalog-auditor` itself.
 
 4. **Tool-budget hint** (paste into every auditor prompt): each auditor should keep itself under ~30 read/search tool calls (the `gcloud-auditor` may use ~50 because each `gcloud` invocation is one shell call). If they cannot finish within budget, they must report partial findings + a `COVERAGE: partial` flag rather than running unbounded.
 
@@ -61,13 +72,28 @@ You are the **audit-lead**. Your job is to coordinate a team of specialist audit
    - **Auth never blocks the run.** If a credential is missing or the wrong project/account is active, the auditor reports `COVERAGE: blocked` if it cannot do meaningful work, or `COVERAGE: partial` (optionally an auditor-specific reduced mode such as `structural-only` or `filesystem-only`) if it can still complete part of its job, plus a single `LIMITATION:` line explaining what was unavailable, then returns no/partial findings. Other auditors are unaffected. The Lead never aborts `/audit` because of one auditor's auth failure — it just notes the limitation in the Coverage section.
    - **Flexibility.** The starter checks listed in each specialist prompt are *ideas*, not a checklist to grind through. Each auditor uses judgment about what is most worth surfacing for THIS run within the tool budget, and is free to drop low-signal areas or follow a thread that is producing real findings.
 
+### Orchestration: how the Lead runs the auditors
+
+The audit has the same logical shape regardless of mechanism — fan out the active auditors (Phase 2), domain-route a cross-validation pass over high-severity findings (Phase 2.5), then synthesize (Phase 3). Pick the execution mechanism by what is available:
+
+**Preferred — Workflow tool (deterministic).** If you are permitted to call the `Workflow` tool (ultracode on, or the user opted into workflows), drive Phases 2 + 2.5 with the committed script `agentic/commands/audit/audit.workflow.js`:
+1. For each active auditor, `Read` its prompt file (`agentic/commands/audit/<name>-auditor.md`) and build a single combined prompt = **Shared Rules** (Tool-budget hint, Severity Calibration, Dimension Taxonomy + tagging rule, Exemplary Repository Rubric, Read-only/degraded-mode contract, Findings Schema) **+** the auditor file's contents. The script forces structured output via the Findings Schema, so the auditor returns validated JSON rather than the text protocol.
+2. Invoke `Workflow({ scriptPath: "agentic/commands/audit/audit.workflow.js", args: { auditors: [{ name, prompt }], partnerMap: <cross-validation routing>, baseline: { ruff, format } } })`. Pass `args` as a real JSON object (the script also defends against `args` arriving JSON-stringified). The script fans out one agent per auditor, then cross-validates each `importance >= 4` finding with a domain-routed skeptic (Phase 2.5) and returns verdict-applied structured findings (`{ reports: [{ auditor, coverage, findings, crossValidationStats }], baseline }`).
+3. The Lead does NOT write files from inside the workflow. The script returns the structured reports; the Lead performs Phase 3 synthesis (Health Score, Dimension Scorecard, dedup, persist) itself, because persistence needs `Write`.
+4. The script is **generic and args-driven** — it never hardcodes the auditor roster. Adding or editing an auditor never requires touching the `.js` file.
+
+**Fallback — team-based.** If the Workflow tool is not available, run the classic team flow: build an "audit" team, create one task per active auditor (`general-purpose, opus`), spawn them in parallel, and have each send findings to `audit-lead` via `SendMessage` (text protocol mirroring the Findings Schema), mark its task done via `TaskUpdate`, and the Lead routes cross-validation by message and synthesizes. After synthesis, send `shutdown_request` to all auditors, then `TeamDelete`.
+
+Both mechanisms use the **same** active set, Shared Rules, Findings Schema, Dimension Taxonomy, cross-validation routing, and synthesis — only the plumbing differs. Everything below (Phases 2–3, schema, output) is mechanism-agnostic.
+
 ### Scope Table
 
 | `$ARGUMENTS` | Active Auditors |
 |------------|----------------|
-| _(empty / `all`)_ | backend, frontend, infra, quality, llm-pipeline, db, security, observability, agentic, gcloud, github, plausible, pagespeed, seo, catalog |
+| _(empty / `all`)_ | backend, frontend, design, infra, quality, llm-pipeline, db, security, observability, agentic, gcloud, github, plausible, pagespeed, seo, catalog |
 | `backend` | backend-auditor only |
 | `frontend` | frontend-auditor only |
+| `design` or `looks` or `ux` | design-auditor only |
 | `infra` | infra-auditor only |
 | `quality` or `tests` | quality-auditor only |
 | `llm` or `pipeline` | llm-pipeline-auditor only |
@@ -86,92 +112,127 @@ You are the **audit-lead**. Your job is to coordinate a team of specialist audit
 
 ### Phase 2: Parallel Analysis
 
-Each specialist receives a focused prompt loaded from `agentic/commands/audit/<name>-auditor.md` (see the Specialist Prompts index below). They:
+Each specialist receives a focused prompt loaded from `agentic/commands/audit/<name>-auditor.md` (see the Specialist Prompts index below), prepended with the Shared Rules. They:
 - Use **Serena tools** (`mcp__serena__get_symbols_overview`, `mcp__serena__find_symbol`, `search_for_pattern`, `list_dir`, `find_file`, `mcp__serena__find_referencing_symbols`) and **Glob/Grep/Read** for code analysis. **Tool-naming note:** `mcp__serena__*` is the canonical MCP-registered prefix that matches `.claude/settings.json` (`mcp__serena__*` is in `permissions.allow`). A few external configs (`CLAUDE.md`, `.serena/project.yml`) may still reference legacy `jet_brains_*` aliases — treat those as the same tools and use the `mcp__serena__*` form here.
 - Use `think_about_collected_information` after non-trivial research sequences
 - Do **NOT** use Bash for file discovery or code searching — only for the per-auditor whitelisted shell commands
 - Stay within the tool budget (~30 calls); set `COVERAGE: partial` if forced to stop early
-- Send findings to `audit-lead` via `SendMessage` when done
-- Mark their task completed via `TaskUpdate`
+- Tag every finding with exactly one **dimension** (see Dimension Taxonomy) and emit it per the **Findings Schema**
+- Return findings (structured JSON in Workflow mode; text protocol via `SendMessage` in team mode)
 
 #### Severity Calibration (use the SAME yardstick across all auditors)
 
 | Importance | Definition | anyplot-typical examples |
 |---|---|---|
 | **5 — Critical** | Production-breaking bugs, real security risks, data-loss potential, broken builds | Workflow uses unquoted `${{ github.event.issue.title }}` in `run:` (script injection); raw `ANTHROPIC_API_KEY` logged; Alembic migration without `downgrade()`; SQL constructed via f-string |
-| **4 — High** | Significant code smells with concrete failure modes, test gaps for core paths, clear performance bottlenecks | N+1 query in `core/database/repositories/`; missing retry/timeout on Anthropic SDK call; `any` covering an entire MUI component tree; prompt file references a removed library |
-| **3 — Medium** | Modernization, consistency, maintainability — non-urgent but real debt | Outdated 3.10-style typing where 3.14 idioms apply; inconsistent router naming; duplicated pydantic schemas |
+| **4 — High** | Significant code smells with concrete failure modes, test gaps for core paths, clear performance bottlenecks, or a high-impact exemplary gap | N+1 query in `core/database/repositories/`; missing retry/timeout on Anthropic SDK call; `any` covering an entire MUI component tree; prompt file references a removed library; no dark-mode contrast on a primary surface |
+| **3 — Medium** | Modernization, consistency, maintainability — non-urgent but real debt; medium-impact exemplary gap | Outdated 3.10-style typing where 3.13 idioms apply; inconsistent router naming; duplicated pydantic schemas; missing CONTRIBUTING.md |
 | **2 — Low** | Cosmetic, comment-only, nit-level | Inconsistent docstring style; unused dev-only `print`; trailing whitespace not auto-fixed |
-| **1 — Positive** | Patterns worth preserving (no action needed; informational) | Solid repository pattern in `core/database/`; well-isolated cache layer in `api/cache.py` |
+| **1 — Positive** | Patterns worth preserving (no action needed; informational) | Solid repository pattern in `core/database/`; well-isolated cache layer in `api/cache.py`; clean theme-token usage |
 
 Auditors MUST self-check against this table before assigning a number; if unsure between two levels, choose the lower one.
 
-### Phase 2.5: Cross-Validation (Lead)
+#### Dimension Taxonomy (tag every finding with exactly ONE)
 
-Before synthesis, the Lead runs a sanity pass on every finding with `IMPORTANCE >= 4`:
+The dimension answers "which pillar of an exemplary repo does this finding move?" Pick the single best fit; do not multi-tag.
 
-1. Route each such finding to **a different** auditor whose scope overlaps the affected files / surface:
+| Dimension | What it covers | Owns (typical auditors) |
+|---|---|---|
+| **security** | Auth, secrets, injection, CVEs, IAM, branch protection, data exposure | security, gcloud, github, infra |
+| **speed** | Latency, CWV, bundle size, N+1, cold starts, caching, query plans | pagespeed, plausible, backend, db, gcloud |
+| **looks** | Visual design, theme/dark-mode correctness, responsive layout, UX polish, design-system consistency, a11y *as user experience* | design, pagespeed (a11y/visual audits) |
+| **modern** | Up-to-date deps & framework idioms, current language features, no deprecated APIs, modern tooling/CI, structured data | frontend, backend, infra, agentic, seo |
+| **correctness** | Bugs, broken builds, data integrity, wrong behavior, failing/missing tests for core paths | backend, frontend, db, llm-pipeline, catalog |
+| **maintainability** | Code smells, duplication, dead code, docs/repo-health, naming, agent ergonomics, hygiene | quality, agentic, observability, github |
+
+When a finding plausibly fits two dimensions, prefer the one a reader would act on first (a slow query that is also a smell → **speed**; an insecure dependency that is also outdated → **security**).
+
+#### Exemplary Repository Rubric (the target each auditor measures against)
+
+Beyond "is anything broken?", each auditor should ask "what would the best repo in this space have that anyplot lacks?" and emit any high-value gap as a finding. A concise target per pillar:
+
+- **Security (exemplary):** least-privilege everywhere; secrets only in Secret Manager with rotation; all `pull_request_target`/`issue_comment` workflows gated by `author_association` and never interpolate untrusted `${{ github.event.* }}` into `run:`/prompts; third-party actions pinned to SHA; zero High/Critical dependency CVEs; documented threat model (`SECURITY.md`).
+- **Speed (exemplary):** all Core Web Vitals in the "good" bucket (field + lab); a tracked JS/CSS bundle budget; no N+1; indexes on every filtered/ordered column; warm Cloud Run (min-instances tuned to traffic); cache hit-rate observable.
+- **Looks (exemplary):** a single coherent design system; dark + light mode both correct (contrast, no hardcoded colors, theme tokens only); responsive at mobile/tablet/desktop; consistent spacing/typography scale; polished empty/loading/error states; WCAG AA.
+- **Modern (exemplary):** current language idioms (Python ≥3.13, React 19, MUI 9 patterns), no deprecated APIs, dependencies near-current, modern CI (caching, matrix, pinned actions), structured data / JSON-LD for content pages.
+- **Correctness (exemplary):** green CI on every required check; meaningful test coverage on core paths; no swallowed errors; migrations reversible; spec→impl pipeline idempotent.
+- **Maintainability (exemplary):** complete repo-health set (README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY.md, issue/PR templates, `.editorconfig`); docs match code; no dead code; consistent naming; clean agent ergonomics (right-sized commands, fresh CLAUDE.md).
+
+Exemplary gaps are tagged with the matching dimension and rated by impact/effort like any other finding. Do not invent low-value gaps to pad the rubric — only surface a gap if closing it would visibly move anyplot toward exemplary.
+
+### Phase 2.5: Cross-Validation (Lead / Workflow stage)
+
+Before synthesis, every finding with `IMPORTANCE >= 4` is peer-reviewed by a **different, domain-overlapping** reviewer (in Workflow mode this is a pipeline stage that spawns a domain reviewer carrying the partner lens; in team mode the Lead routes by message). This is a specialist peer-review with the **burden of proof on DROP** — a finding is dropped only on positive evidence it is a false positive, never merely because a budget-limited reviewer couldn't fully re-derive it. The domain routing — the reviewer must bring expertise the original auditor lacks, not just re-read:
+
    - Backend ↔ security / db / llm-pipeline (depending on the file)
-   - Frontend ↔ observability (analytics paths) or quality (test gaps)
+   - Frontend ↔ design (theme/UX overlap) or observability (analytics paths) or quality (test gaps)
+   - Design ↔ frontend (component code behind the visual issue) or pagespeed (a11y/visual lab audits)
    - Infra ↔ security (workflow injection / secret exposure) or github (workflow runs side) or gcloud (deploy-target side)
    - llm-pipeline ↔ infra (workflow side) or backend (SDK call site)
    - Agentic ↔ quality (commands/docs overlap) or infra (prompts and workflow integration)
    - Gcloud ↔ observability (logs/metrics overlap) or infra (deploy/workflow side) or security (IAM/secrets)
    - Github ↔ infra (workflow files) or quality (issue/docs hygiene) or security (branch protection, secret hygiene)
    - Plausible ↔ observability (event drift) or frontend (Web Vitals → component code)
-   - Pagespeed ↔ frontend (perf opportunities → component code) or infra (caching/headers/Cloud Run config)
+   - Pagespeed ↔ frontend (perf opportunities → component code) or design (visual/a11y → component code) or infra (caching/headers/Cloud Run config)
    - Seo ↔ frontend (missing meta/JSON-LD → component code) or infra (robots/sitemap/headers) or pagespeed (lab vs field Web Vitals)
    - Catalog ↔ db (FS/DB drift) or llm-pipeline (specs failing generation) or infra (sync workflow)
-2. The reviewing auditor responds with one of:
+
+The reviewer responds with one of:
    - `KEEP` — finding stands as rated
    - `DOWNGRADE` — drop one importance level (with one-sentence reason)
    - `DROP` — false positive (with one-sentence reason)
-3. The Lead records each verdict alongside the finding. `DROP` removes the finding; `DOWNGRADE` re-rates it. The reviewer's reason is preserved in the synthesis notes (not the final report) for traceability.
-4. Findings with `IMPORTANCE <= 3` skip cross-validation to keep the pass cheap.
+
+`DROP` removes the finding; `DOWNGRADE` re-rates it (and may move it out of the cross-validation tier). The reviewer's reason is preserved in the synthesis notes (not the final report) for traceability. Findings with `IMPORTANCE <= 3` skip cross-validation to keep the pass cheap.
 
 ### Phase 3: Synthesis (Lead)
 
 After all specialists report back and cross-validation has run:
 
-1. **Collect** all findings from messages (post cross-validation)
-2. **Deduplicate** — merge identical issues found by different auditors; keep the highest IMPORTANCE and union the FILES
+1. **Collect** all findings (post cross-validation)
+2. **Deduplicate** — merge identical issues found by different auditors; keep the highest IMPORTANCE, union the FILES, and keep the dimension of the highest-rated copy
 3. **Flag contradictions** — if two auditors disagree on the same file, surface that explicitly in the synthesis notes
-4. **Rate each finding:**
+4. **Confirm each finding's rating:**
    - **Importance** (1-5): see Severity Calibration table above
+   - **Dimension** (1 of 6): see Dimension Taxonomy — every finding must carry exactly one
    - **Effort**: S (<30min, 1 file, mechanical), M (1-3h, 2-5 files, local context), L (half day+, 5-15 files, design decisions), XL (multi-day, 15+ files, needs own plan)
    - **Auto-fix**: classify each finding as `ruff` (auto-fixable via `uv run ruff check --fix`), `eslint` (`yarn lint --fix`), `format` (`uv run ruff format`), `codemod` (mechanical rewrite that a small script could do), or `manual` (requires judgment)
-5. **Compute Health Score (30-100):**
+5. **Compute Health Score (30-100)** — unchanged formula, trend-comparable across all prior reports:
    - Start at 100
    - Subtract: `min(70, 10 * critical_count + 3 * high_count + 1 * medium_count)`
    - Round to integer; clamp to `[30, 100]` (the cap on subtractions intentionally floors the score at 30 so that very-bad audits remain comparable to bad ones)
-   - This score is reproducible and trend-comparable across runs
-6. **Build Quick Wins list:** every finding with `IMPORTANCE >= 4` AND `EFFORT == S`. This list answers "what should we tackle first?" and goes near the top of the report.
-7. **Sort** within each importance bucket: Effort ascending, then Auto-fix `ruff` / `eslint` / `format` / `codemod` / `manual` (auto-fixable first)
-7b. **Optional cross-auditor synthesis** — only when the relevant auditors all ran in this session and produced data:
-   - **Deprecation candidates** (Catalog × Plausible × SEO): specs that show up as low-traffic in Plausible AND zero-impression in Search Console AND have low coverage / low quality in catalog → emit a single Medium-importance finding listing the candidate spec-ids with effort `M` and auto-fix `manual`.
-   - **Web Vitals lab vs field divergence** (Pagespeed × Plausible / Pagespeed × SEO): URLs where lab CWV passes but field CWV fails (or vice-versa) → emit one finding per affected URL, importance derived from how far off the field metric is.
-   - These are computed from the auditors' findings, not by re-querying. If any required auditor is `COVERAGE: blocked`, skip the synthesis silently.
-8. **Persist** the final report to disk:
+6. **Compute the Dimension Scorecard** — a per-pillar grade so the user sees exactly where anyplot is and isn't exemplary. For each dimension D in {security, speed, looks, modern, correctness, maintainability}, using only findings tagged D:
+   - `penalty_D = min(70, 10 * critical_D + 3 * high_D + 1 * medium_D)` (same weights as Health Score)
+   - `score_D = clamp(100 - penalty_D, 30, 100)`
+   - Letter grade (deterministic): ≥95 `A+`, ≥90 `A`, ≥85 `A-`, ≥80 `B+`, ≥75 `B`, ≥70 `B-`, ≥65 `C+`, ≥60 `C`, ≥55 `C-`, ≥50 `D`, <50 `F`
+   - A dimension with zero findings scores `A+` **but** annotate it `(no findings — limited by coverage)` if the auditors that own that dimension were `blocked`/`partial`, so a high grade is never mistaken for proven excellence.
+7. **Build Quick Wins list:** every finding with `IMPORTANCE >= 4` AND `EFFORT == S`. This list answers "what should we tackle first?" and goes near the top of the report.
+8. **Sort** within each importance bucket: Effort ascending, then Auto-fix `ruff` / `eslint` / `format` / `codemod` / `manual` (auto-fixable first)
+9. **Optional cross-auditor synthesis** — only when the relevant auditors all ran in this session and produced data:
+   - **Deprecation candidates** (Catalog × Plausible × SEO): specs that show up as low-traffic in Plausible AND zero-impression in Search Console AND have low coverage / low quality in catalog → emit a single Medium-importance `maintainability` finding listing the candidate spec-ids with effort `M` and auto-fix `manual`.
+   - **Web Vitals lab vs field divergence** (Pagespeed × Plausible / Pagespeed × SEO): URLs where lab CWV passes but field CWV fails (or vice-versa) → emit one `speed` finding per affected URL, importance derived from how far off the field metric is.
+   - **Exemplary-gap rollup** (any auditor): if multiple auditors flagged the same missing-best-practice theme (e.g. missing repo-health files, no JSON-LD anywhere, no bundle budget), merge into one rollup finding tagged with the dominant dimension.
+   - These are computed from the auditors' findings, not by re-querying. If any required auditor is `COVERAGE: blocked`, skip that synthesis silently.
+10. **Persist** the final report to disk:
    - Path: `agentic/audits/{YYYY-MM-DD}-{scope_slug}.md` (e.g. `agentic/audits/2026-04-25-all.md`, `agentic/audits/2026-04-25-backend.md`, `agentic/audits/2026-04-25-since_main.md`)
    - **Build `scope_slug` deterministically from `$ARGUMENTS`:**
      - Empty / `all` → `all`
-     - Single keyword (`backend`, `frontend`, `infra`, `quality`, `tests`, `llm`, `pipeline`, `db`, `database`, `security`, `sec`, `observability`, `obs`, `agentic`, `gcloud`, `gcp`, `github`, `gh`, `plausible`, `pagespeed`, `psi`, `seo`, `catalog`) → that keyword verbatim
+     - Single keyword (`backend`, `frontend`, `design`, `looks`, `ux`, `infra`, `quality`, `tests`, `llm`, `pipeline`, `db`, `database`, `security`, `sec`, `observability`, `obs`, `agentic`, `gcloud`, `gcp`, `github`, `gh`, `plausible`, `pagespeed`, `psi`, `seo`, `catalog`) → that keyword verbatim
      - Directory path → replace `/` with `_`, drop leading/trailing `_`, lowercase (e.g. `core/database/` → `core_database`)
      - `since=<ref>` → `since_<ref>` with `<ref>` sanitized: replace any character not matching `[A-Za-z0-9._-]` with `_` (e.g. `since=feature/foo` → `since_feature_foo`, `since=HEAD~10` → `since_HEAD_10`)
      - Combinations (e.g. `backend since=main`) → join the parts with `_` (`backend_since_main`)
      - Final slug must match `^[A-Za-z0-9._-]+$`; if anything still doesn't match after the rules above, fall back to `all`
    - Also overwrite `agentic/audits/latest.md` with the same content
    - Create `agentic/audits/` if missing
-9. **Output** the report (see Output Format below) inline AND confirm the persisted path
-10. **Cleanup**: Send `shutdown_request` to all auditors, then `TeamDelete`
+11. **Output** the report (see Output Format below) inline AND confirm the persisted path
+12. **Cleanup**: in team mode, send `shutdown_request` to all auditors, then `TeamDelete`. In Workflow mode, no cleanup is needed (the workflow self-terminates).
 
 ### Output Format
 
 ```markdown
 # Audit Report: anyplot
 
-**Date:** {date} | **Scope:** {scope} | **Mode:** {full | incremental since=<ref>, N files}
-**Health Score:** {0-100} | **Baseline:** ruff: {N issues}, format: {status}
+**Date:** {date} | **Scope:** {scope} | **Mode:** {full | incremental since=<ref>, N files} | **Engine:** {workflow | team}
+**Health Score:** {30-100} | **Baseline:** ruff: {N issues}, format: {status}
 **Auditors:** {n} ran ({list}) | **Findings:** {total} | **Auto-fixable:** {n}/{total}
 **External sources:** {only include lines that apply}
 - GCP project: {project-id} (gcloud-auditor)
@@ -181,39 +242,50 @@ After all specialists report back and cross-validation has run:
 - GitHub: {gh user / repo} (github-auditor)
 - Catalog DB rows: {n specs / n implementations} (catalog-auditor)
 
+## Dimension Scorecard (how close to exemplary?)
+| Dimension | Grade | Score | Findings (C/H/M) | Biggest lever |
+|---|---|---|---|---|
+| Security | {A+..F} | {30-100} | {c}/{h}/{m} | {one-line: the single highest-impact fix} |
+| Speed | | | | |
+| Looks | | | | |
+| Modern | | | | |
+| Correctness | | | | |
+| Maintainability | | | | |
+
 ## Summary
-{2-3 sentences: overall health, key themes, biggest risks}
+{2-3 sentences: overall health, weakest pillar(s), biggest risks, shortest path to a more exemplary repo}
 
 ## Quick Wins (Importance ≥4 & Effort=S)
-| # | Finding | Auto-fix | Files | Hint |
-|---|---------|----------|-------|------|
-| 1 | {description} | ruff/eslint/format/codemod/manual | `{files}` | {one-line fix hint} |
+| # | Finding | Dim | Auto-fix | Files | Hint |
+|---|---------|-----|----------|-------|------|
+| 1 | {description} | {dimension} | ruff/eslint/format/codemod/manual | `{files}` | {one-line fix hint} |
 
 ## Critical (Importance 5)
-| # | Finding | Effort | Auto-fix | Files | Hint |
-|---|---------|--------|----------|-------|------|
-| 1 | {description} | S/M/L/XL | ruff/eslint/format/codemod/manual | `{files}` | {one-line fix hint} |
+| # | Finding | Dim | Effort | Auto-fix | Files | Hint |
+|---|---------|-----|--------|----------|-------|------|
+| 1 | {description} | {dimension} | S/M/L/XL | ruff/eslint/format/codemod/manual | `{files}` | {one-line fix hint} |
 
 ## High (Importance 4)
-| # | Finding | Effort | Auto-fix | Files | Hint |
-|---|---------|--------|----------|-------|------|
+| # | Finding | Dim | Effort | Auto-fix | Files | Hint |
+|---|---------|-----|--------|----------|-------|------|
 
 ## Medium (Importance 3)
-| # | Finding | Effort | Auto-fix | Files | Hint |
-|---|---------|--------|----------|-------|------|
+| # | Finding | Dim | Effort | Auto-fix | Files | Hint |
+|---|---------|-----|--------|----------|-------|------|
 
 ## Low (Importance 2)
-| # | Finding | Effort | Auto-fix | Files | Hint |
-|---|---------|--------|----------|-------|------|
+| # | Finding | Dim | Effort | Auto-fix | Files | Hint |
+|---|---------|-----|--------|----------|-------|------|
 
 ## Positive Patterns (Importance 1)
 - {good patterns to keep}
 
 ## Statistics
 - Total: {N} | Critical: {n}, High: {n}, Medium: {n}, Low: {n}
+- By Dimension: security {n}, speed {n}, looks {n}, modern {n}, correctness {n}, maintainability {n}
 - Effort: S {n}, M {n}, L {n}, XL {n}
 - Auto-fix: ruff {n}, eslint {n}, format {n}, codemod {n}, manual {n}
-- By Auditor: backend {n}, frontend {n}, infra {n}, quality {n}, llm {n}, db {n}, security {n}, obs {n}, agentic {n}, gcloud {n}, github {n}, plausible {n}, pagespeed {n}, seo {n}, catalog {n}
+- By Auditor: backend {n}, frontend {n}, design {n}, infra {n}, quality {n}, llm {n}, db {n}, security {n}, obs {n}, agentic {n}, gcloud {n}, github {n}, plausible {n}, pagespeed {n}, seo {n}, catalog {n}
 - Cross-validation: {n} reviewed, {n} dropped, {n} downgraded
 - Coverage: {n} auditors complete, {n} partial, {n} blocked (auth/credentials missing — list which)
 ```
@@ -231,14 +303,45 @@ Do NOT flag:
 
 ---
 
+## Findings Schema (authoritative — prepended to every auditor as part of the Shared Rules)
+
+Every finding, in every auditor, in every mechanism, carries these fields. This list is authoritative and supersedes any field enumeration in an individual auditor file.
+
+| Field | Type | Notes |
+|---|---|---|
+| `FINDING` | string | Short title |
+| `IMPORTANCE` | 1–5 | Severity Calibration table |
+| `DIMENSION` | enum | one of `security \| speed \| looks \| modern \| correctness \| maintainability` (Dimension Taxonomy) |
+| `EFFORT` | enum | `S \| M \| L \| XL` |
+| `AUTO-FIX` | enum | `ruff \| eslint \| format \| codemod \| manual` |
+| `FILES` | string(s) | comma-separated paths, or a non-file resource handle (`gcp:…`, `gh:…`, `plausible:…`, `psi:…`, `sc:…`) |
+| `DESCRIPTION` | string | what's wrong (or what's missing vs. exemplary) and why it matters |
+| `HINT` | string | one-line fix suggestion |
+
+Text-protocol form (team mode) — one block per finding, preceded by the per-auditor `COVERAGE:` (and any auditor-specific header) line:
+```
+COVERAGE: full | partial | blocked
+---
+FINDING: {short title}
+IMPORTANCE: {1-5}
+DIMENSION: {security | speed | looks | modern | correctness | maintainability}
+EFFORT: {S/M/L/XL}
+AUTO-FIX: {ruff | eslint | format | codemod | manual}
+FILES: {comma-separated file paths or resource handle}
+DESCRIPTION: {what's wrong / missing and why it matters}
+HINT: {one-line fix suggestion}
+```
+In Workflow mode the same fields are returned as validated JSON (see `audit.workflow.js`); the auditor does not hand-format the block.
+
 ## Specialist Prompts
 
-Each auditor's full prompt lives in its own file under `agentic/commands/audit/`. The Lead reads the file for each active auditor and passes its content as the spawn prompt. Editing one auditor's prompt does not touch the others.
+Each auditor's full prompt lives in its own file under `agentic/commands/audit/`. The Lead reads the file for each active auditor and passes its content (prepended with the Shared Rules) as the spawn prompt. Editing one auditor's prompt does not touch the others, and the orchestration (`audit.workflow.js`) never needs to change.
 
 | Auditor | Prompt file |
 |---|---|
 | `backend-auditor` | `agentic/commands/audit/backend-auditor.md` |
 | `frontend-auditor` | `agentic/commands/audit/frontend-auditor.md` |
+| `design-auditor` | `agentic/commands/audit/design-auditor.md` |
 | `infra-auditor` | `agentic/commands/audit/infra-auditor.md` |
 | `quality-auditor` | `agentic/commands/audit/quality-auditor.md` |
 | `llm-pipeline-auditor` | `agentic/commands/audit/llm-pipeline-auditor.md` |
@@ -253,7 +356,6 @@ Each auditor's full prompt lives in its own file under `agentic/commands/audit/`
 | `seo-auditor` | `agentic/commands/audit/seo-auditor.md` |
 | `catalog-auditor` | `agentic/commands/audit/catalog-auditor.md` |
 
-**Spawn pattern (Lead):** for each active auditor, Read the corresponding file and use its full contents as the task prompt. Prepend the shared rules from Phase 1 (tool budget, severity calibration, read-only / degraded-mode contract for external auditors) so each spawned subagent has the full context without the per-auditor file having to repeat them. The auditor files describe scope and how-to-work; the orchestrator (this file) owns the cross-cutting rules.
+**Spawn pattern (Lead):** for each active auditor, Read the corresponding file and use its full contents as the task prompt. Prepend the **Shared Rules** (tool budget, Severity Calibration, Dimension Taxonomy + tagging rule, Exemplary Repository Rubric, read-only / degraded-mode contract, Findings Schema) so each spawned subagent has the full context without the per-auditor file having to repeat them. The auditor files describe scope and how-to-work; the orchestrator (this file) owns the cross-cutting rules.
 
-**Adding a new auditor:** create `agentic/commands/audit/<name>-auditor.md`, add a row to the Auditor table in Phase 1 + a Scope-Table entry + a Statistics-line key in Phase 3 + a row above. No other code changes required.
-
+**Adding a new auditor:** create `agentic/commands/audit/<name>-auditor.md`, add a row to the active-set table in Phase 1 (with its default dimensions) + a Scope-Table entry + a cross-validation routing line + a Statistics-line key in Phase 3 + a row above. No code changes required — `audit.workflow.js` is generic and reads the roster from `args`.

--- a/agentic/commands/audit/agentic-auditor.md
+++ b/agentic/commands/audit/agentic-auditor.md
@@ -16,7 +16,7 @@ You are the **agentic-auditor** on the audit team. Your scope is the **agent erg
 3. `mcp__serena__get_symbols_overview` is mostly not useful here (markdown); rely on Read + Grep + Glob
 4. Glob for `agentic/commands/*.md`, `prompts/**/*.md`, `.claude/**/*.json`
 5. Cross-check `@`-references in CLAUDE.md and command files against the actual file paths
-6. Grep for inline prompt strings inside `core/generators/` and `agentic/workflows/` that look like they should live in `prompts/`
+6. Grep for inline prompt strings inside `agentic/workflows/`, `automation/scripts/`, and `scripts/` that look like they should live in `prompts/` (note: `core/generators/` is now empty — skip it)
 7. `think_about_collected_information` after the docs+commands sweep
 8. **Do NOT use Bash** for file discovery
 9. You MAY skip `/agentic`-style numerical scoring — this is an audit, not a TAC scorecard. Surface findings, not a score.

--- a/agentic/commands/audit/agentic-auditor.md
+++ b/agentic/commands/audit/agentic-auditor.md
@@ -16,7 +16,7 @@ You are the **agentic-auditor** on the audit team. Your scope is the **agent erg
 3. `mcp__serena__get_symbols_overview` is mostly not useful here (markdown); rely on Read + Grep + Glob
 4. Glob for `agentic/commands/*.md`, `prompts/**/*.md`, `.claude/**/*.json`
 5. Cross-check `@`-references in CLAUDE.md and command files against the actual file paths
-6. Grep for inline prompt strings inside `agentic/workflows/`, `automation/scripts/`, and `scripts/` that look like they should live in `prompts/` (note: `core/generators/` is now empty — skip it)
+6. Grep for inline prompt strings inside `agentic/workflows/`, `automation/scripts/`, and `scripts/` that look like they should live in `prompts/` (note: the old `core/generators/` package was removed — don't look for it)
 7. `think_about_collected_information` after the docs+commands sweep
 8. **Do NOT use Bash** for file discovery
 9. You MAY skip `/agentic`-style numerical scoring — this is an audit, not a TAC scorecard. Surface findings, not a score.

--- a/agentic/commands/audit/audit.workflow.js
+++ b/agentic/commands/audit/audit.workflow.js
@@ -107,6 +107,10 @@ async function crossValidate(report, auditor) {
       schema: VERDICT_SCHEMA,
       agentType: 'general-purpose',
     }).then((v) => ({ ...f, verdict: v }))
+      // KEEP-biased: a verifier that errors must not drop the finding. parallel()
+      // already maps a rejected thunk to null, but catch explicitly so the intent
+      // is unmistakable — an unverified finding falls through to merge and is kept.
+      .catch(() => null)
   ))).filter(Boolean)
 
   const vmap = new Map(verified.map((v) => [fkey(v), v]))

--- a/agentic/commands/audit/audit.workflow.js
+++ b/agentic/commands/audit/audit.workflow.js
@@ -1,0 +1,157 @@
+export const meta = {
+  name: 'anyplot-audit',
+  description: 'Fan out repo auditors, domain-route an adversarial cross-validation of high-severity findings, return structured findings for the Lead to synthesize',
+  phases: [
+    { title: 'Analyze', detail: 'one agent per active auditor (general-purpose, inherits Opus)' },
+    { title: 'Cross-validate', detail: 'domain-routed skeptic verify of every importance>=4 finding' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// This script is GENERIC and args-driven. It never hardcodes the auditor
+// roster, so adding/editing an auditor never requires touching this file.
+//
+// The Lead (which has filesystem access; this script does not) builds:
+//   args = {
+//     auditors: [{ name: 'security-auditor',
+//                  prompt: '<Shared Rules + the auditor .md file contents>',
+//                  agentType?: 'general-purpose' }],
+//     partnerMap: { 'backend-auditor': 'security / db / llm-pipeline', ... },  // Phase 2.5 routing hint per auditor
+//     baseline?: { ruff: '...', format: '...' }                               // optional context, echoed back
+//   }
+// The Lead then performs Phase 3 synthesis (Health Score, Dimension Scorecard,
+// dedup, persist) on the returned reports — persistence needs Write, which the
+// workflow does not do.
+// ---------------------------------------------------------------------------
+
+const FINDING_SCHEMA = {
+  type: 'object',
+  required: ['title', 'importance', 'dimension', 'effort', 'autofix', 'files', 'description', 'hint'],
+  properties: {
+    title: { type: 'string' },
+    importance: { type: 'integer', minimum: 1, maximum: 5 },
+    dimension: { type: 'string', enum: ['security', 'speed', 'looks', 'modern', 'correctness', 'maintainability'] },
+    effort: { type: 'string', enum: ['S', 'M', 'L', 'XL'] },
+    autofix: { type: 'string', enum: ['ruff', 'eslint', 'format', 'codemod', 'manual'] },
+    files: { type: 'array', items: { type: 'string' } },
+    description: { type: 'string' },
+    hint: { type: 'string' },
+  },
+}
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  required: ['auditor', 'coverage', 'findings'],
+  properties: {
+    auditor: { type: 'string' },
+    coverage: { type: 'string', enum: ['full', 'partial', 'blocked', 'structural-only', 'filesystem-only'] },
+    limitation: { type: 'string' },
+    findings: { type: 'array', items: FINDING_SCHEMA },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['verdict', 'reason'],
+  properties: {
+    verdict: { type: 'string', enum: ['KEEP', 'DOWNGRADE', 'DROP'] },
+    reason: { type: 'string' },
+  },
+}
+
+// args normally arrives as a JSON value, but some invocation paths deliver it
+// JSON-stringified; normalize once so the rest of the script sees a real object.
+const ARGS = (typeof args === 'string') ? (() => { try { return JSON.parse(args) } catch (e) { return {} } })() : (args || {})
+let PARTNER = (ARGS && ARGS.partnerMap) || {}
+
+function fkey(f) {
+  return f.title + '::' + ((f.files || []).join(','))
+}
+
+function verifyPrompt(finding, auditorName, partnerHint) {
+  return [
+    `You are a rigorous ${partnerHint} reviewer peer-reviewing a finding raised by the ${auditorName}.`,
+    `Bring your own domain expertise and independently check it against the actual repo / live system`,
+    `(use Read / Grep / Serena / read-only Bash as needed). Do NOT just re-read the original auditor's reasoning.`,
+    ``,
+    `FINDING: ${finding.title}`,
+    `IMPORTANCE: ${finding.importance}`,
+    `DIMENSION: ${finding.dimension}`,
+    `FILES: ${(finding.files || []).join(', ') || '(none)'}`,
+    `DESCRIPTION: ${finding.description}`,
+    ``,
+    `This is a specialist peer-review: the BURDEN OF PROOF IS ON DROP. Decide exactly one verdict:`,
+    `- KEEP      — real and correctly rated. ALSO keep when you cannot disprove it within your budget;`,
+    `              do NOT drop a finding merely because you ran low on tool calls or couldn't fully re-derive it.`,
+    `- DOWNGRADE — clearly real but over-rated (the Lead drops it one importance level).`,
+    `- DROP      — ONLY with positive primary evidence that it is a false positive (e.g. the code/system`,
+    `              actually does the opposite of what the finding claims, or the cited file/line says otherwise).`,
+    `              Cite that concrete evidence in your reason.`,
+    `Give a one-sentence reason.`,
+  ].join('\n')
+}
+
+// Cross-validate one auditor's importance>=4 findings, each via a domain-routed skeptic.
+async function crossValidate(report, auditor) {
+  if (!report) return report
+  const partnerHint = PARTNER[auditor.name] || 'independent domain'
+  const all = report.findings || []
+  const high = all.filter((f) => f.importance >= 4)
+  if (!high.length) {
+    return { ...report, auditor: auditor.name, crossValidationStats: { reviewed: 0, dropped: 0, downgraded: 0 } }
+  }
+  const verified = (await parallel(high.map((f) => () =>
+    agent(verifyPrompt(f, auditor.name, partnerHint), {
+      label: 'verify:' + auditor.name,
+      phase: 'Cross-validate',
+      schema: VERDICT_SCHEMA,
+      agentType: 'general-purpose',
+    }).then((v) => ({ ...f, verdict: v }))
+  ))).filter(Boolean)
+
+  const vmap = new Map(verified.map((v) => [fkey(v), v]))
+  let dropped = 0
+  let downgraded = 0
+  const merged = []
+  for (const f of all) {
+    const v = vmap.get(fkey(f))
+    if (!v) { merged.push(f); continue } // importance<4, or its verifier errored -> keep as-is
+    const verdict = v.verdict && v.verdict.verdict
+    const reason = (v.verdict && v.verdict.reason) || ''
+    if (verdict === 'DROP') { dropped++; continue }
+    if (verdict === 'DOWNGRADE') {
+      downgraded++
+      merged.push({ ...f, importance: Math.max(1, f.importance - 1), crossvalidation: 'DOWNGRADE: ' + reason })
+      continue
+    }
+    merged.push({ ...f, crossvalidation: 'KEEP' })
+  }
+  return { ...report, auditor: auditor.name, findings: merged, crossValidationStats: { reviewed: verified.length, dropped, downgraded } }
+}
+
+// --- main ------------------------------------------------------------------
+const auditors = (ARGS && ARGS.auditors) || []
+if (!auditors.length) {
+  log('No auditors supplied in args.auditors — nothing to run.')
+  return { reports: [], baseline: (ARGS && ARGS.baseline) || null }
+}
+log('Auditing with ' + auditors.length + ' auditor(s): ' + auditors.map((a) => a.name).join(', '))
+
+// Each item flows Analyze -> Cross-validate independently (no barrier): a fast
+// auditor's findings get verified while a slow auditor is still analyzing.
+const reports = await pipeline(
+  auditors,
+  (a) => agent(a.prompt, {
+    label: a.name,
+    phase: 'Analyze',
+    schema: REPORT_SCHEMA,
+    agentType: a.agentType || 'general-purpose',
+  }),
+  (report, a) => crossValidate(report, a)
+)
+
+const clean = reports.filter(Boolean)
+const totalFindings = clean.reduce((n, r) => n + ((r.findings || []).length), 0)
+log('Done: ' + clean.length + '/' + auditors.length + ' auditors returned a report; ' + totalFindings + ' findings after cross-validation.')
+
+return { reports: clean, baseline: (ARGS && ARGS.baseline) || null }

--- a/agentic/commands/audit/backend-auditor.md
+++ b/agentic/commands/audit/backend-auditor.md
@@ -8,7 +8,7 @@ You are the **backend-auditor** on the audit team. Analyze `api/`, `core/`, and 
 - **Type safety**: Missing type hints, `Any` overuse, incorrect types, Protocol/ABC usage
 - **Code smells**: Dead code, duplication, overly complex functions (high cyclomatic complexity), god classes
 - **Error handling**: Consistency, missing error handlers, bare except clauses, error propagation
-- **Python modernization**: Old patterns that could use 3.14 features, deprecated APIs
+- **Python modernization**: Old patterns that could use modern 3.13 idioms, deprecated APIs
 - **Performance**: N+1 queries, unnecessary computations, inefficient patterns, missing caching opportunities
 - **Import hygiene**: Unused imports, circular imports, import order
 
@@ -22,15 +22,16 @@ You are the **backend-auditor** on the audit team. Analyze `api/`, `core/`, and 
 7. **Do NOT use Bash** for `find`, `ls`, `grep`, `cat` — use Serena/Glob/Grep/Read tools instead
 8. You MAY use Bash for: `uv run ruff check api/ core/ automation/` or `uv run pytest tests/unit -x -q`
 
-**Report format:** Send findings to `audit-lead` via `SendMessage`. Start the message with one `COVERAGE: full` or `COVERAGE: partial` line, then list findings:
+**Report format:** Emit findings per the **Findings Schema** in the orchestrator (`audit.md`). Every finding carries `DIMENSION` (one of `security | speed | looks | modern | correctness | maintainability`) in addition to importance/effort/auto-fix. Backend findings are usually `correctness`, `speed`, or `maintainability` — tag the single best fit. Also surface any high-value **exemplary gap** (something a best-in-class backend would have that anyplot lacks), rated like any other finding. In team mode, send findings to `audit-lead` via `SendMessage`, starting with one `COVERAGE: full | partial` line, then one block per finding:
 ```
 COVERAGE: full | partial
 ---
 FINDING: {short title}
 IMPORTANCE: {1-5}     # see Severity Calibration table
+DIMENSION: {security | speed | looks | modern | correctness | maintainability}
 EFFORT: {S/M/L/XL}
 AUTO-FIX: {ruff | eslint | format | codemod | manual}
 FILES: {comma-separated file paths}
-DESCRIPTION: {what's wrong and why it matters}
+DESCRIPTION: {what's wrong (or missing vs. exemplary) and why it matters}
 HINT: {one-line fix suggestion}
 ```

--- a/agentic/commands/audit/design-auditor.md
+++ b/agentic/commands/audit/design-auditor.md
@@ -1,0 +1,32 @@
+# design-auditor
+
+You are the **design-auditor** on the audit team. You own the **looks** dimension — anyplot's *Aussehen*: is the web app beautiful, coherent, polished, and correct in both themes? You analyze `app/src/` from the **visual / UX** angle. The `frontend-auditor` owns code quality (types, hooks, state, render correctness); you own how it *looks and feels*. Where the two overlap (a visual bug rooted in component code), surface the visual symptom and let cross-validation route to frontend.
+
+Almost every finding you emit is `DIMENSION: looks`. Tag the rare exception accurately (a genuinely broken render path is `correctness`).
+
+**Your scope:**
+- **Design-system coherence**: Is there a single source of truth for spacing, typography, radius, elevation, and color? Are components built from theme tokens, or are there one-off hardcoded values (`#hex`, `px` magic numbers, inline `style={{...}}`) that drift from the system? Inconsistent button/card/chip styling across pages.
+- **Theme / dark-mode correctness** (the live concern — see `app/src/theme/`, `useThemeMode`, `ThemeToggle`, `PaletteStrip`, `themedPreview`): every surface readable and on-brand in **both** light and dark; no hardcoded colors that ignore the active palette; sufficient contrast (WCAG AA: 4.5:1 text, 3:1 large/UI); no "white card on white page" or invisible icons in one mode; theme-adaptive images/previews actually swap.
+- **Responsive design**: layouts hold at mobile / tablet / desktop breakpoints; no horizontal scroll, clipped content, or cramped tap targets (<44px) on mobile; image-heavy pages (catalog) reflow sensibly.
+- **Visual hierarchy & spacing**: consistent vertical rhythm and spacing scale; clear primary/secondary action distinction; headings and body sizes follow a type scale; no crowded or unbalanced layouts.
+- **State polish**: empty states, loading states (skeletons vs. spinners vs. layout shift), and error states are designed — not raw text or a blank screen. Hover/focus/active states present and visible (keyboard focus rings not removed).
+- **Accessibility as experience**: focus order, visible focus, color is never the only signal, alt text on meaningful images, motion respects `prefers-reduced-motion`. (Lighthouse-style a11y *audits* are pagespeed's lab job; you judge the lived UX.)
+- **Brand & consistency**: favicon/og-image quality, consistent iconography, logo usage, 404/error page design, copy tone consistency at the surface level.
+- **Exemplary gap**: what would a best-in-class product site have here that anyplot lacks (a polished design system, motion/micro-interactions, a cohesive empty-state language)? Emit high-value gaps as `looks` findings.
+
+**How to work:**
+1. `list_dir` on `app/src/theme/`, `app/src/components/`, `app/src/pages/`, `app/src/styles/`
+2. Read the theme definition(s) and `useThemeMode` to learn the token system and how light/dark are derived
+3. Grep for hardcoded visual values that bypass the theme: `#[0-9a-fA-F]{3,8}`, `rgb\(`, `style=\{\{`, `px`-literal sizing in `sx`, `color:\s*['"]`, `backgroundColor`
+4. `mcp__serena__get_symbols_overview` on a representative set of pages/components to see how consistently theme tokens vs. literals are used
+5. Sample a handful of pages end-to-end (landing, catalog, a spec detail, the palette page) and reason about both themes from the code
+6. Look for missing/undesigned empty-loading-error states and removed focus outlines (`outline:\s*none`, `:focus` overrides)
+7. `think_about_collected_information` after the design sweep
+8. **Do NOT use Bash** for file discovery — use Serena/Glob/Grep/Read
+9. You MAY use Bash for: `cd app && yarn build 2>&1 | tail -20` (confirm the styled bundle builds) — optional, skip if budget-tight
+
+**Tool budget:** ~30 calls. If insufficient, set `COVERAGE: partial` and prioritize dark-mode contrast correctness first, design-system token drift second.
+
+**Read-only:** This auditor only reads files. No external systems, no shell mutations.
+
+**Report format:** Same as backend-auditor — emit findings per the Findings Schema (every field, including `DIMENSION` — almost always `looks`).

--- a/agentic/commands/audit/frontend-auditor.md
+++ b/agentic/commands/audit/frontend-auditor.md
@@ -1,16 +1,17 @@
 # frontend-auditor
 
-You are the **frontend-auditor** on the audit team. Analyze the `app/src/` directory.
+You are the **frontend-auditor** on the audit team. Analyze the `app/src/` directory from the **code-quality** angle. The `design-auditor` owns how the app *looks and feels* (visual design, theme/dark-mode correctness, responsive layout, UX polish) — you own how the code is *built*. When you hit a visual symptom, note it and let cross-validation route to design; don't double-report it.
 
 **Your scope:**
 - **Component quality**: Structure, reusability, separation of concerns, prop drilling vs context
 - **TypeScript strictness**: `any` usage, missing interfaces, proper generics, type-only imports
-- **Hooks**: Custom hook patterns, missing dependency arrays, stale closures, unnecessary re-renders
-- **Performance**: Missing `memo`/`useMemo`/`useCallback` where needed, large bundles, unnecessary renders
-- **Accessibility**: Missing aria-labels, keyboard navigation, focus management, color contrast
-- **MUI 9 patterns**: Correct theme usage, sx prop vs styled, consistent component usage
+- **Hooks**: Custom hook patterns, missing dependency arrays, stale closures, set-state-in-effect cascades, unnecessary re-renders
+- **Performance (code-level)**: Missing `memo`/`useMemo`/`useCallback` where needed, unstable props, unnecessary renders, code-split opportunities, oversized eager imports
+- **Accessibility (code-level)**: Missing `aria-*` attributes, semantic elements vs. div-soup, keyboard handlers wired correctly (the *lived* a11y experience — visible focus, contrast — is design's call)
+- **MUI 9 API correctness**: Using current (non-deprecated) MUI 9 APIs, `sx` vs `styled` used correctly, no deprecated v5/v6 props (the *visual* consistency of MUI usage is design's call)
 - **Dead code**: Unused components, unused imports, unreachable code, commented-out code
-- **Error handling**: Error boundaries, loading states, empty states, fallbacks
+- **Error handling (code-level)**: Error boundaries present, async failures caught, fallback components wired (whether those states are *designed* is design's call)
+- **Modern frontend**: React 19 idioms, type-only imports, no deprecated browser/React APIs
 - **Consistency**: Naming conventions, file organization, export patterns
 
 **How to work:**

--- a/agentic/commands/audit/llm-pipeline-auditor.md
+++ b/agentic/commands/audit/llm-pipeline-auditor.md
@@ -1,6 +1,6 @@
 # llm-pipeline-auditor
 
-You are the **llm-pipeline-auditor** on the audit team. anyplot's core is a spec→impl LLM pipeline; you own its end-to-end quality. Your scope spans `prompts/`, the SDK call site in `scripts/evaluate-plot.py`, the `claude_*` knobs in `core/config.py`, the orchestration in `agentic/workflows/`, and the AI-pipeline GitHub workflows (`.github/workflows/{spec,impl,bulk,daily}-*.yml`). Most of the legacy `core/generators/` package was removed; today the heavy generation lives in workflow-driven `claude-code-action` invocations rather than in repo Python.
+You are the **llm-pipeline-auditor** on the audit team. anyplot's core is a spec→impl LLM pipeline; you own its end-to-end quality. Your scope spans `prompts/`, the SDK call site in `scripts/evaluate-plot.py`, the `claude_*` knobs in `core/config.py`, the orchestration in `agentic/workflows/`, and the AI-pipeline GitHub workflows (`.github/workflows/{spec,impl,bulk,daily}-*.yml`). The legacy `core/generators/` package is gone (only an empty dir / `__pycache__` remains — don't spend budget there); today the heavy generation lives in workflow-driven `claude-code-action` invocations rather than in repo Python.
 
 **Your scope:**
 - **Anthropic SDK usage**: Correct `client.messages.create` shape; explicit `max_tokens`, `timeout`, and retry on `RateLimitError` / `APIStatusError`; streaming used where it should be; no swallowed `APIError`

--- a/agentic/commands/audit/llm-pipeline-auditor.md
+++ b/agentic/commands/audit/llm-pipeline-auditor.md
@@ -1,6 +1,6 @@
 # llm-pipeline-auditor
 
-You are the **llm-pipeline-auditor** on the audit team. anyplot's core is a spec→impl LLM pipeline; you own its end-to-end quality. Your scope spans `prompts/`, the SDK call site in `scripts/evaluate-plot.py`, the `claude_*` knobs in `core/config.py`, the orchestration in `agentic/workflows/`, and the AI-pipeline GitHub workflows (`.github/workflows/{spec,impl,bulk,daily}-*.yml`). The legacy `core/generators/` package is gone (only an empty dir / `__pycache__` remains — don't spend budget there); today the heavy generation lives in workflow-driven `claude-code-action` invocations rather than in repo Python.
+You are the **llm-pipeline-auditor** on the audit team. anyplot's core is a spec→impl LLM pipeline; you own its end-to-end quality. Your scope spans `prompts/`, the SDK call site in `scripts/evaluate-plot.py`, the `claude_*` knobs in `core/config.py`, the orchestration in `agentic/workflows/`, and the AI-pipeline GitHub workflows (`.github/workflows/{spec,impl,bulk,daily}-*.yml`). The legacy `core/generators/` package was removed and no longer exists in the repo (don't look for it); today the heavy generation lives in workflow-driven `claude-code-action` invocations rather than in repo Python.
 
 **Your scope:**
 - **Anthropic SDK usage**: Correct `client.messages.create` shape; explicit `max_tokens`, `timeout`, and retry on `RateLimitError` / `APIStatusError`; streaming used where it should be; no swallowed `APIError`

--- a/agentic/commands/audit/quality-auditor.md
+++ b/agentic/commands/audit/quality-auditor.md
@@ -10,6 +10,7 @@ You are the **quality-auditor** on the audit team. Analyze `tests/`, `docs/`, `a
 - **Command consistency**: Are agentic commands in `agentic/commands/` well-structured, up-to-date, consistent with each other?
 - **README quality**: Is the main README accurate and helpful? Does it reflect current project state?
 - **CLAUDE.md accuracy**: Does CLAUDE.md match the actual project structure and conventions?
+- **Repo-health / exemplary baseline** (`maintainability`, mostly Importance 3): a top-tier public repo has the full community-health set. anyplot already has `LICENSE`, `SECURITY.md`, `.github/ISSUE_TEMPLATE/`, `.github/dependabot.yml`. Flag *missing* high-value pieces as exemplary-gap findings: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, a PR template (`.github/pull_request_template.md`), `.editorconfig`, a `CHANGELOG.md` (or release notes), and CI/coverage/license badges in the README. Don't over-flag — only the ones that would visibly raise the repo's polish. A single rolled-up finding listing the missing files is better than one finding each.
 
 **How to work:**
 1. Use `list_dir` to map `tests/` structure and compare with `api/`, `core/`, `automation/` structure


### PR DESCRIPTION
## Why

`/audit` was a strong bug-finder, but its output was an undifferentiated list. This re-tools it around a single north star: **how far is anyplot from an *exemplary* repository, and what's the shortest path there?** — measured across six dimensions: **Security, Speed, Looks (Aussehen), Modern, Correctness, Maintainability**.

## What changed

**Goal-directed reporting**
- Every finding is tagged with exactly one **dimension**.
- New **Dimension Scorecard**: a deterministic per-pillar letter grade (same weights as Health Score) so the weakest pillar is obvious at a glance. The existing Health Score formula and Critical/High/Medium/Low buckets are **unchanged** — reports stay trend-comparable with the prior runs in `agentic/audits/`.
- New **Exemplary Repository Rubric**: auditors now surface best-in-class *gaps* (what a top-tier repo has that anyplot lacks), not just defects.

**"Aussehen" coverage**
- New **`design-auditor`** owns the *looks* dimension: theme / dark-mode correctness (a live concern per recent palette/dark-mode PRs), responsive layout, design-system token drift, undesigned empty/loading/error states, UX polish.
- `frontend-auditor` narrowed to code-quality so the two don't overlap.

**Repo-health**
- `quality-auditor` now flags missing community-health files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, PR template, `.editorconfig`, README badges).

**Orchestration → Workflow tool**
- New generic, args-driven `audit.workflow.js`: fan-out one agent per auditor → **domain-routed cross-validation** of every `importance ≥ 4` finding → structured (schema-validated) findings. The script never hardcodes the roster, so adding an auditor never touches it.
- Cross-validation is **KEEP-biased** (burden of proof on DROP) to match the original Phase 2.5 semantics — a finding dies only on positive evidence it's a false positive, never because a budget-limited verifier couldn't re-derive it.
- A **team-based fallback** is retained so `/audit` still works for non-ultracode / non-workflow sessions.

**Hygiene**
- Findings Schema centralized (adds `DIMENSION`).
- Staleness fixed: Python `3.14`→`3.13`; reconciled the now-empty `core/generators`.

## Validation
- Workflow engine smoke-tested end-to-end: args flow, schema validation, the cross-validation stage spawning a domain verifier, and verdict application all confirmed.
- Equivalence test against a known **live critical** (the `spec-create.yml` prompt-injection vector, still present) to confirm the KEEP-biased verifier *retains* real criticals rather than culling them — result folded into this branch.

No Python/TS source touched (markdown + a workflow script that is `node --check`-clean), so no build/test impact.
