### PR TITLE
docs: refresh library catalog (11 libs / 3 languages) + add MUI X Charts to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 ## What is anyplot?
 
 **anyplot** is an AI-powered platform for data visualization that automatically discovers, generates, tests, and
-maintains plotting examples. Browse hundreds of plots across major visualization libraries — matplotlib, seaborn,
-plotly, bokeh, altair, plotnine, pygal, highcharts, and lets-plot — with an architecture ready to welcome additional
-ecosystems over time.
+maintains plotting examples. Browse hundreds of plots across 11 major visualization libraries in Python, R, and Julia —
+matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, lets-plot, ggplot2, and Makie.jl — with an
+architecture ready to welcome additional ecosystems over time.
 
 **Community-driven, AI-maintained** - Propose plot ideas via GitHub Issues, AI generates the code, automated quality
 checks ensure excellence. Zero manual coding required.
@@ -38,7 +38,7 @@ checks ensure excellence. Zero manual coding required.
 ## Architecture
 
 **Specification-first design**: Every plot starts as a Markdown spec (library-agnostic), then AI generates
-implementations for all 10 supported libraries across Python and R.
+implementations for all 11 supported libraries across Python, R, and Julia.
 
 ```
 plots/scatter-basic/
@@ -72,6 +72,7 @@ See [docs/reference/](docs/reference/) for details.
 
 **Plotting (Python)**: matplotlib • seaborn • plotly • bokeh • altair • plotnine • pygal • highcharts • lets-plot
 **Plotting (R)**: ggplot2
+**Plotting (Julia)**: Makie.jl
 
 **Infrastructure**: Google Cloud Run • Cloud SQL • Cloud Storage
 

--- a/docs/concepts/library-expansion.md
+++ b/docs/concepts/library-expansion.md
@@ -77,7 +77,11 @@ Estimated share *within* JS charting demand. (npm downloads + GitHub stars +
 | **ApexCharts**       |  ~4 %  | MIT         | SVG             | yes     | Popular in admin templates / dashboards.                             |
 | **Observable Plot**  |  ~3 %  | ISC         | SVG, declarative| yes     | Mike Bostock's modern successor concept to D3 for everyday charts.   |
 | **Vega / Vega-Lite** |  ~3 %  | BSD         | JSON spec       | yes     | Altair already covers Vega-Lite from Python.                         |
+| **MUI X Charts**     |  ~2 %  | MIT †       | React (SVG)     | yes     | Charts in the MUI ecosystem. Community pkg `@mui/x-charts` is MIT; Pro features (zoom/pan, …) are commercial → out of scope. |
 | Nivo, Visx, amCharts |  ~4 %  | mixed       | various         | yes     | React/enterprise niches.                                             |
+
+† MIT applies to the community package `@mui/x-charts`. `@mui/x-charts-pro` (advanced
+zoom & pan, etc.) is commercially licensed and out of scope — see §9.
 
 ---
 
@@ -206,9 +210,9 @@ Benefits:
   relevant — no schema change needed.
 
 Framework-agnostic libraries set `framework: "none"` (the default).
-Framework-only libraries get tagged accordingly. **Recharts** is the only
-Tier 3 entry currently affected; everything in Tier 1 / Tier 2 is
-framework-agnostic.
+Framework-only libraries get tagged accordingly. **Recharts** and **MUI X
+Charts** are the Tier 3 entries currently affected; everything in Tier 1 /
+Tier 2 is framework-agnostic.
 
 ### Licensing policy
 
@@ -287,6 +291,9 @@ Ranked by `reach × ease-of-integration ÷ duplication-risk`.
    is mature.
 9. **ApexCharts (JavaScript)** — fills the "admin-template / dashboard" SEO
    long tail.
+10. **MUI X Charts (TypeScript / React)** — community `@mui/x-charts` (MIT) serves the
+    MUI/React dashboard audience; **Pro features stay out** (see §9). Framework-locked
+    like Recharts, so it sits in the same niche tier.
 
 ### Defer / skip
 
@@ -352,6 +359,10 @@ entries.
   commercial-with-free-tier model) at ~18× lower download volume, and a
   second commercial entry would weaken the FOSS-first stance. Revisit only
   if Plausible data shows unmet demand for amCharts-specific examples.
+- **MUI X Charts: community tier only.** `@mui/x-charts` (MIT) is in scope as a
+  React/JavaScript entry (Tier 3, §7). `@mui/x-charts-pro` / Premium features (advanced
+  zoom & pan, etc.) are commercially licensed and out of scope — same FOSS-first reasoning
+  as the Highcharts/amCharts policy in §6. Snippets must use only the MIT community surface.
 - **Phase 5 (Julia / Makie.jl) shipped before Phases 1+2 (JavaScript).**
   The original roadmap order was Phase 1 (Chart.js / D3 / ECharts) →
   Phase 2 (Highcharts JS) → Phase 3 (ggplot2) → Phase 4 (Recharts /


### PR DESCRIPTION
## Summary

Two docs-only updates, split out into their own PR (the palette redesign is unrelated and still in progress):

1. **README** — corrected the library/language coverage. It still said *"10 libraries across Python and R"* and omitted Julia/Makie. Now aligned with `core/constants.py` (`SUPPORTED_LIBRARIES` / `SUPPORTED_LANGUAGES`): **11 libraries across Python, R, and Julia** (added the `Plotting (Julia): Makie.jl` line and ggplot2/Makie.jl to the intro).

2. **`docs/concepts/library-expansion.md`** — added **MUI X Charts** as a Tier 3 React/JavaScript candidate, triaged from issue #8085 (D3.js / JS-library expansion request). The community package `@mui/x-charts` (MIT) is in scope; Pro/Premium features (`@mui/x-charts-pro`) are commercially licensed and out of scope, consistent with the FOSS-first Highcharts/amCharts policy.
   - §3 JS candidates table: new row + license footnote
   - §6 framework note: Recharts **and** MUI X Charts are the affected Tier 3 entries
   - §7 Tier 3: added as item 10
   - §9 settled decisions: recorded the community-tier-only stance

## Notes

No code changes — docs only. Relates to #8085 (kept open as the JS/React expansion tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)