### PR TITLE
fix(impl-generate): JS library-version lookup exports-proof + set -e-safe

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -555,7 +555,8 @@ jobs:
           get_r_version() {
             local v
             v=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1)
-            is_version "$v" && printf '%s' "$v"
+            # if/fi, not `&&`: never return non-zero (would abort under `set -e`).
+            if is_version "$v"; then printf '%s' "$v"; fi
           }
           get_julia_version() {
             # Pkg.dependencies() returns a Dict{UUID, PackageInfo}; locate the
@@ -571,15 +572,22 @@ jobs:
                 end
               end
             " 2>/dev/null | tail -n1)
-            is_version "$v" && printf '%s' "$v"
+            # if/fi, not `&&`: never return non-zero (would abort under `set -e`).
+            if is_version "$v"; then printf '%s' "$v"; fi
           }
           get_npm_version() {
             # Read the installed version straight out of the package's own
             # package.json (restored by `npm ci` from the committed lockfile).
-            # `require('<pkg>/package.json')` resolves the subpath reliably.
+            # NB: read the file via fs, NOT `require('<pkg>/package.json')`:
+            # packages with an `exports` map (d3, chart.js) block that subpath
+            # with ERR_PACKAGE_PATH_NOT_EXPORTED, while echarts happens to allow
+            # it — reading node_modules/<pkg>/package.json directly is uniform.
             local v
-            v=$(node -p "require('$1/package.json').version" 2>/dev/null | tail -n1)
-            is_version "$v" && printf '%s' "$v"
+            v=$(node -p "JSON.parse(require('fs').readFileSync('node_modules/$1/package.json','utf8')).version" 2>/dev/null | tail -n1)
+            # if/fi, not `&&`: a failing is_version must not propagate a non-zero
+            # exit, or `LIBRARY_VERSION=$(get_npm_version …)` aborts the whole
+            # step under `set -e` before the `"unknown"` fallback can run.
+            if is_version "$v"; then printf '%s' "$v"; fi
           }
 
           if [ "$LANGUAGE" = "r" ]; then

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -554,8 +554,9 @@ jobs:
           }
           get_r_version() {
             local v
-            v=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1)
-            # if/fi, not `&&`: never return non-zero (would abort under `set -e`).
+            # `|| true` on the read + if/fi (not `&&`) on the check: neither may
+            # propagate a non-zero exit, or it aborts under `set -e`/`-o pipefail`.
+            v=$(RENV_CONFIG_STARTUP_QUIET=TRUE Rscript -e "cat(as.character(packageVersion('$1')))" 2>/dev/null | tail -n1) || true
             if is_version "$v"; then printf '%s' "$v"; fi
           }
           get_julia_version() {
@@ -571,8 +572,9 @@ jobs:
                   break
                 end
               end
-            " 2>/dev/null | tail -n1)
-            # if/fi, not `&&`: never return non-zero (would abort under `set -e`).
+            " 2>/dev/null | tail -n1) || true
+            # `|| true` on the read + if/fi (not `&&`) on the check: neither may
+            # propagate a non-zero exit, or it aborts under `set -e`/`-o pipefail`.
             if is_version "$v"; then printf '%s' "$v"; fi
           }
           get_npm_version() {
@@ -583,10 +585,11 @@ jobs:
             # with ERR_PACKAGE_PATH_NOT_EXPORTED, while echarts happens to allow
             # it — reading node_modules/<pkg>/package.json directly is uniform.
             local v
-            v=$(node -p "JSON.parse(require('fs').readFileSync('node_modules/$1/package.json','utf8')).version" 2>/dev/null | tail -n1)
-            # if/fi, not `&&`: a failing is_version must not propagate a non-zero
-            # exit, or `LIBRARY_VERSION=$(get_npm_version …)` aborts the whole
-            # step under `set -e` before the `"unknown"` fallback can run.
+            # `|| true` on the read + if/fi (not `&&`) on the check guard BOTH
+            # abort points: otherwise `LIBRARY_VERSION=$(get_npm_version …)`
+            # inherits a non-zero exit and dies under `set -e`/`-o pipefail`
+            # before the `"unknown"` fallback can run.
+            v=$(node -p "JSON.parse(require('fs').readFileSync('node_modules/$1/package.json','utf8')).version" 2>/dev/null | tail -n1) || true
             if is_version "$v"; then printf '%s' "$v"; fi
           }
 


### PR DESCRIPTION
## Problem

The first real exercise of the Phase-1 JS pipeline (#8244) silently blocked **chartjs** and **d3** while **echarts** worked. Both failures land in the *Create library metadata file* step with a bare `exit 1` and **no PR is created**.

Run evidence (manual `scatter-basic` dispatch):
- echarts → PR #8247 (✅, review running)
- d3 → `d3.js` pushed, step dies before writing metadata → no PR
- chartjs → same step death (branch removed by failure cleanup)

## Root cause

The step runs under `bash -e`. The version getters end in:

```bash
is_version "$v" && printf '%s' "$v"
```

When the version can't be read, `is_version` fails, so the getter returns **non-zero**. That exit code is inherited by `LIBRARY_VERSION=$(get_npm_version …)`, and **`set -e` aborts the whole step** — *before* the `[ -z "$LIBRARY_VERSION" ] → "unknown"` fallback two lines down can run. A `test` emits nothing, hence the silent `exit 1`.

Why only chartjs/d3: `d3` and `chart.js` ship an `exports` map that blocks the `./package.json` subpath, so `require('<pkg>/package.json')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. `echarts` allows it, so its lookup succeeds and the step survives.

## Fix

- **npm getter:** read `node_modules/<pkg>/package.json` via `fs.readFileSync` instead of `require(...)` — bypasses the `exports` restriction and returns the correct version uniformly across all JS libs.
- **All three getters (npm, R, Julia):** use `if is_version …; then …; fi` instead of `&&`, so a missing version degrades to `"unknown"` (existing fallback) instead of aborting the step under `set -e`. R/Julia don't trip this today (their packages always resolve) but carry the same latent trap.

No behavior change for libraries whose version already resolves; only the failure path changes (abort → `"unknown"`).

## Follow-up after merge

Re-dispatch `impl-generate` for **chartjs** and **d3** on `scatter-basic`. The daily-regen (`library=all`) will then also stop dying on these two libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)