### PR TITLE
feat(impl-generate): enable interactive HTML previews for JavaScript libs

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -649,11 +649,18 @@ jobs:
           fi
           echo "::notice::Library version: $LIBRARY = $LIBRARY_VERSION ($LANGUAGE runtime $LANGUAGE_VERSION, pipeline python $PYTHON_VERSION)"
 
-          # Interactive libraries additionally produce HTML previews (one per theme)
+          # Interactive libraries additionally produce HTML previews (one per theme).
+          # Python interactive libs are listed explicitly. JavaScript libs are
+          # interactive too (the browser render harness emits standalone
+          # plot-{light,dark}.html) — but gate on the files actually existing, so a
+          # lib/render that produced no HTML never points preview_html at a 404.
           HAS_HTML="false"
           case "$LIBRARY" in
             plotly|bokeh|altair|highcharts|pygal|letsplot) HAS_HTML="true" ;;
           esac
+          if [ "$LANGUAGE" = "javascript" ] && [ -f "$IMPL_DIR/plot-light.html" ] && [ -f "$IMPL_DIR/plot-dark.html" ]; then
+            HAS_HTML="true"
+          fi
 
           # Write metadata file using Python for proper YAML formatting
           # Pass all variables inline to avoid export/env issues
@@ -943,6 +950,13 @@ jobs:
               HTML_DARK="${BASE}/plot-dark.html"
               ;;
           esac
+          # JS libs are interactive too — link the HTML only when the render
+          # produced it (mirrors the existence gate used for preview_html).
+          IMPL_DIR="plots/${SPEC_ID}/implementations/${LANGUAGE}"
+          if [ "$LANGUAGE" = "javascript" ] && [ -f "$IMPL_DIR/plot-light.html" ] && [ -f "$IMPL_DIR/plot-dark.html" ]; then
+            HTML_LIGHT="${BASE}/plot-light.html"
+            HTML_DARK="${BASE}/plot-dark.html"
+          fi
 
           BODY="## :art: ${LANGUAGE}/${LIBRARY} Preview
 


### PR DESCRIPTION
## Problem

Interactive JS charts (echarts/chartjs/d3) render no **Interactive** toggle on the site, even though the interactive HTML already exists in production GCS:

```
.../plots/scatter-basic/javascript/echarts/plot-light.html → 200
.../plots/scatter-basic/javascript/echarts/plot-dark.html  → 200
```

The pipeline already does the hard parts: the render harness emits standalone `plot-{light,dark}.html`, the GCS upload promotes them (gated only on file existence, not library), and the frontend (`themedPreview.ts` + `SpecDetailView`/`SpecOverview`) renders `preview_html` when present.

**The only gap:** the metadata `HAS_HTML` allowlist lists only the 6 Python interactive libs, so `preview_html_light/dark` are written as `null` for all JavaScript libs → the frontend never shows the toggle and the uploaded HTML sits unused.

## Fix

Enable HTML for JavaScript libs in both places that carried the allowlist:
- the metadata block (`HAS_HTML` → `preview_html_*`)
- the issue-preview step (cosmetic "Interactive" links)

**Gated on file existence**, not language alone:

```bash
if [ "$LANGUAGE" = "javascript" ] && [ -f "$IMPL_DIR/plot-light.html" ] && [ -f "$IMPL_DIR/plot-dark.html" ]; then
  HAS_HTML="true"
fi
```

so a JS lib (or a failed render) that produces no HTML can never wire `preview_html` to a 404 — strictly safer than the current `null`. Verified all three current JS libs emit both theme HTMLs (staging 200 for chartjs/d3, production 200 for echarts). The Python interactive allowlist is left untouched.

## Follow-up after merge

Re-dispatch `impl-generate` for echarts/chartjs/d3 on scatter-basic so their metadata picks up the `preview_html` URLs (the HTML is already in GCS). No frontend change needed — the `Interactive` toggle is already wired to `preview_html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)