### PR TITLE
fix(frontend): library-card descriptions for chartjs, d3, echarts

### DIFF
--- a/app/src/components/LibraryCard.test.tsx
+++ b/app/src/components/LibraryCard.test.tsx
@@ -8,6 +8,11 @@ describe('LibraryCard', () => {
     expect(screen.getByText('matplotlib')).toBeInTheDocument();
   });
 
+  it('renders the description for a javascript library', () => {
+    render(<LibraryCard name="echarts" language="javascript" onClick={vi.fn()} />);
+    expect(screen.getByText(/Powerful interactive charts for the browser/i)).toBeInTheDocument();
+  });
+
   it('renders the language chip in the corner when language is provided', () => {
     render(<LibraryCard name="ggplot2" language="r" onClick={vi.fn()} />);
     expect(screen.getByLabelText('Language: R')).toHaveTextContent('R');

--- a/app/src/components/LibraryCard.tsx
+++ b/app/src/components/LibraryCard.tsx
@@ -14,6 +14,9 @@ const DESCRIPTIONS: Record<string, string> = {
   letsplot: 'Grammar of graphics by JetBrains. Interactive.',
   ggplot2: 'The reference grammar of graphics. R’s expressive plotting standard.',
   makie: 'High-performance Julia visualization. CairoMakie ships publication-quality static charts.',
+  chartjs: 'Simple, flexible HTML5-canvas charts. The popular JS default.',
+  d3: 'Data-driven SVG. Low-level, maximum control on the web.',
+  echarts: 'Powerful interactive charts for the browser. Vast chart catalog.',
 };
 
 interface LibraryCardProps {


### PR DESCRIPTION
## Problem

The new JavaScript libraries render **no description** on their library cards.

`LibraryCard.tsx` doesn't read the blurb from the backend — it uses a **hardcoded** `DESCRIPTIONS` map that still listed only the original 11 libraries. For chartjs/d3/echarts, `DESCRIPTIONS[name] || ''` resolves to an empty string.

(The backend `core/constants.py` already has full descriptions for these libs — that feeds the API/DB path used elsewhere, e.g. `ImageCard`. This PR only fixes the separate hardcoded frontend map.)

## Fix

Add concise, one-line entries for the three JS libs, matching the existing style:

```ts
chartjs: 'Simple, flexible HTML5-canvas charts. The popular JS default.',
d3: 'Data-driven SVG. Low-level, maximum control on the web.',
echarts: 'Powerful interactive charts for the browser. Vast chart catalog.',
```

Plus a `LibraryCard` test asserting a JS library's description renders (locks the regression).

Verified locally: `tsc --noEmit` clean, `LibraryCard.test.tsx` 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)