### PR TITLE
chore(app): typed global-config module

### DIFF
--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -9,6 +9,8 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 
+import { CONFIG } from 'src/global-config';
+
 interface Props {
   children: ReactNode;
   fallback?: ReactNode;
@@ -210,7 +212,7 @@ export class ErrorBoundary extends Component<Props, State> {
               </Typography>
             )}
 
-            {componentStack && import.meta.env.DEV && !showDetails && (
+            {componentStack && CONFIG.isDev && !showDetails && (
               <Typography
                 variant="caption"
                 sx={{ mt: 1, display: 'block', color: 'var(--ink-muted)' }}

--- a/app/src/components/RouteErrorBoundary.tsx
+++ b/app/src/components/RouteErrorBoundary.tsx
@@ -10,6 +10,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 
+import { CONFIG } from 'src/global-config';
 import { NotFoundPage } from 'src/pages/NotFoundPage';
 
 const RELOAD_ATTEMPT_KEY = 'anyplot:chunk-reload-attempt';
@@ -142,7 +143,7 @@ export function RouteErrorBoundary() {
         <Typography variant="body2" sx={{ color: 'var(--ink-muted)' }}>
           {body}
         </Typography>
-        {import.meta.env.DEV && (
+        {CONFIG.isDev && (
           <Typography
             variant="caption"
             component="pre"

--- a/app/src/constants/index.ts
+++ b/app/src/constants/index.ts
@@ -1,10 +1,11 @@
 // Constants for anyplot.ai frontend
 
-export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-// DebugPage uses this — set to "/api" in prod (same-origin via the
-// Cloudflare Worker on anyplot.ai/api/*) so the CF Access cookie can be
-// sent with fetch. Falls back to API_URL locally where there's no Worker.
-export const DEBUG_API_URL = import.meta.env.VITE_DEBUG_API_URL || API_URL;
+import { CONFIG } from 'src/global-config';
+
+export { CONFIG };
+// Compat aliases — prefer CONFIG.api.* in new code.
+export const API_URL = CONFIG.api.baseUrl;
+export const DEBUG_API_URL = CONFIG.api.debugBaseUrl;
 export const GITHUB_URL = 'https://github.com/MarkusNeusinger/anyplot';
 export const LIBRARIES = [
   'altair',

--- a/app/src/global-config.ts
+++ b/app/src/global-config.ts
@@ -1,0 +1,27 @@
+import packageJson from '../package.json';
+
+interface GlobalConfig {
+  appName: string;
+  appVersion: string;
+  api: {
+    baseUrl: string;
+    debugBaseUrl: string;
+  };
+  isDev: boolean;
+}
+
+const apiBaseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+export const CONFIG: GlobalConfig = {
+  appName: 'anyplot',
+  appVersion: packageJson.version,
+  api: {
+    baseUrl: apiBaseUrl,
+    // DebugPage uses this — set to "/api" in prod (same-origin via the
+    // Cloudflare Worker on anyplot.ai/api/*) so the CF Access cookie can be
+    // sent with fetch. Falls back to the API base locally where there's no
+    // Worker.
+    debugBaseUrl: import.meta.env.VITE_DEBUG_API_URL || apiBaseUrl,
+  },
+  isDev: import.meta.env.DEV,
+};

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string;
-  readonly VITE_DEBUG_API_URL: string;
+  readonly VITE_API_URL?: string;
+  readonly VITE_DEBUG_API_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Part 4 of the frontend modernization roadmap.

- `src/global-config.ts`: typed `CONFIG` object — `appName`, `appVersion` (from package.json), `api.baseUrl`/`api.debugBaseUrl` (from `VITE_*` env vars with the existing fallbacks), `isDev`
- `constants/index.ts` re-exports `CONFIG` and keeps `API_URL`/`DEBUG_API_URL` as compat aliases — no call-site churn in this PR (the upcoming API-client PR consumes `CONFIG.api` directly)
- `vite-env.d.ts`: `VITE_*` vars typed optional (they may be unset; the fallbacks handle it)
- Error boundaries use `CONFIG.isDev` instead of raw `import.meta.env.DEV`

## Verification

`yarn lint` ✓ · `yarn fm:check` ✓ · `yarn type-check` (app + tests) ✓ · `yarn test` ✓ · `yarn build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)