### PR TITLE
chore(release): bump version to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # pyproject.toml
 [project]
 name = "anyplot"
-version = "2.4.0"
+version = "3.0.0"
 description = "AI-powered plotting examples"
 authors = [{ name = "Markus Neusinger", email = "admin@anyplot.ai" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -227,7 +227,7 @@ wheels = [
 
 [[package]]
 name = "anyplot"
-version = "2.4.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Version bump for the v3.0.0 release. Full release notes will be attached to the tag once this lands (draft release already prepared).

## Why a major version

- **Highcharts Python → JavaScript was a clean break** (#8516): all 322 legacy `highcharts.py` implementations were removed and replaced by native `highcharts.js` 12.6.0.
- The catalog scope changed fundamentally: **2 → 4 languages, 10 → 15 libraries**.
- The **Imprint palette** replaced Okabe-Ito in every implementation — a complete visual identity change.

## Highlights since v2.4.0

- **Julia / Makie.jl added as the 3rd language** (#7613) — 74 implementations.
- **JavaScript added as the 4th language** with Chart.js, D3.js, Apache ECharts and a Node 22 + Playwright browser render harness emitting PNG + interactive HTML (#8244, #8251).
- **MUI X Charts** as the first React/TSX library (#8517).
- **Highcharts migrated to native JavaScript** (clean break, #8516).
- **Imprint palette**: 8 colorblind-safe hues + 3 semantic anchors; ~1,300 implementations migrated in one wave (#7692, #7776–#7798); `/palette` page rebuilt with OKLCH wheel + ΔE matrices (#8125).
- **Frontend modernization**: 11-PR restructure of `app/` + CI lint/format/type-check gates + `ARCHITECTURE.md` (#8519–#8596).
- **Render quality**: canvas halved to 3200×1800 / 2400×2400 (#7387), hard canvas-size gate (#7517), AR-09 edge-clipping auto-reject (#7528).
- **Pipeline**: watchdog rescues 3 more stuck-PR failure modes (#7687), daily-regen 10×/day on Sonnet (#7717, #7286), alembic dual-head fix for Postgres sync (#7285).
- 885 regenerations + 310 new implementations; 21 dependency updates.

Known follow-up (not in this PR): `highcharts-core` is still listed in `pyproject.toml` although the Python wrapper is no longer used (deferred in #8516).

**Full Changelog:** https://github.com/MarkusNeusinger/anyplot/compare/v2.4.0...main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
