### PR TITLE
chore(design-sync): app-shape sync inputs for anyplot.ai Design System

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,38 @@
+# design-sync notes — anyplot.ai Design System
+
+Target project: **anyplot.ai Design System** (`bdf69a23-f0d2-40d5-b6cb-3ef035579852`) on claude.ai/design.
+This is an **app-shape** sync: the source is the `app/` website (`anyplot-website`), not a published component library. Only `pkg`/`globalName`/`projectId` are conventional; the rest of the config exists to make an app build like a DS.
+
+## How this sync is wired (gotchas)
+
+- **Curated entry, not synth.** `app/designsync-entry.tsx` re-exports the 5 reusable components + `AppProviders`. It lives OUTSIDE the app tsconfig `include` so the app build/typecheck never touch it, and it deliberately does NOT import `src/main.tsx` (which would call `createRoot().render()` on load). `cfg.entry` points at it → PKG_DIR resolves to `app/`.
+- **Component list = `cfg.componentSrcMap` keys.** The app ships no `.d.ts`, so the converter's `.d.ts`-based discovery finds nothing — every synced component must be listed in `componentSrcMap`. The 8 infrastructural components (error boundaries, data/router shell, FeedbackWidget) are simply omitted.
+- **Props = `cfg.dtsPropsFor` (hand-written).** No `.d.ts` ⇒ auto prop-extraction yields nothing, so each component's props interface is hand-written. **If a component's real props change upstream, update `dtsPropsFor` by hand** — nothing extracts them automatically.
+- **Barrel tsconfig.** `app/tsconfig.designsync.json` maps each `src/<barrel>` folder to its `index.*` BEFORE the `src/*` wildcard. Without the explicit mappings, the esbuild tsconfig-paths plugin's empty-extension probe matches the directory itself and esbuild fails to bundle it. Add a mapping there if a new barrel import appears in the transitive graph.
+- **Provider chain.** `cfg.provider = AppProviders` = `MemoryRouter` → MUI `ThemeProvider(theme)` → `CssBaseline`. `useAnalytics` is context-free (a pure hook, no-ops off `anyplot.ai`), so SectionHeader/Footer only need the router, not an analytics provider.
+- **CSS / tokens.** `cfg.cssEntry = src/styles/tokens.css` (the `var(--*)` token system, incl. `[data-theme="dark"]`). Component styles are MUI/emotion injected at runtime → build prints `[CSS_RUNTIME]` (expected, non-blocking). Tokens land inside `_ds_bundle.css`, reachable via the `styles.css` `@import` closure.
+- **Render check uses system chrome:** `DS_CHROMIUM_PATH=/usr/bin/google-chrome` on every build/validate/capture/driver run. Playwright is installed in `.ds-sync` with `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` (no 200 MB download). Node is v20 (works; root `engines` asks for 22 but the converter doesn't need it).
+- **`assets/` is preserved in the project.** The target's `assets/*.svg` (logo/favicon/palette-strip) are hand-authored, NOT produced by this build. They were deliberately kept OUT of the delete set. **On every re-sync, keep `assets/**` out of the deletes** or the reconciliation will remove them.
+
+## MonoLisa fonts (re-fetch on a fresh clone)
+
+MonoLisa is proprietary (© FaceType Foundry, CORS-locked GCS) and is **NOT in this public repo**. The variable ttf are fetched at sync time into the gitignored `app/.designsync-fonts/` and shipped only to the private design project — never committed. `app/.designsync-fonts/monolisa.css` (the `@font-face`, committed) references them. On a fresh clone, re-fetch before building:
+
+```sh
+mkdir -p app/.designsync-fonts && cd app/.designsync-fonts
+curl -sSfo MonoLisaVariableNormal.ttf https://storage.googleapis.com/anyplot-static/fonts/MonoLisaVariableNormal.ttf
+curl -sSfo MonoLisaVariableItalic.ttf https://storage.googleapis.com/anyplot-static/fonts/MonoLisaVariableItalic.ttf
+```
+
+The variable ttf cover the full glyph range (normal + italic, weights 100–900, the `ss02` script set intact). CORS is browser-only, so `curl` works even though browser fetches are restricted to `anyplot.ai`.
+
+## Known render warns
+- None. (`[RENDER_THIN]` on Footer in an early pass was fixed by collapsing its preview to a single cell — its two variants differed only in a hidden link href.)
+
+## Re-sync risks (what can silently go stale)
+- **Fonts**: a fresh clone has no ttf until re-fetched (above). If the GCS objects move or access changes, MonoLisa silently won't ship and designs render in the fallback mono stack.
+- **`assets/**` deletion**: see above — must stay out of every re-sync's delete set.
+- **`dtsPropsFor` drift**: hand-written props can diverge from the real components; re-check against the sources on a major app change.
+- **`componentSrcMap` paths**: if a component's source file moves, its `componentSrcMap` entry must move too.
+- **conventions.md token names**: re-validate against the fresh build on re-sync (the conventions-header step does this) — a renamed/removed token in `tokens.css` would make the header name something that no longer exists.
+- This replaced an older **hand-authored** version of the same project (landing.html, design_system.html, source/*.tsx). That content was intentionally removed; it lives in git history if ever needed.

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,7 +1,7 @@
 # design-sync notes — anyplot.ai Design System
 
 Target project: **anyplot.ai Design System** (`bdf69a23-f0d2-40d5-b6cb-3ef035579852`) on claude.ai/design.
-This is an **app-shape** sync: the source is the `app/` website (`anyplot-website`), not a published component library. Only `pkg`/`globalName`/`projectId` are conventional; the rest of the config exists to make an app build like a DS.
+This is an **app-shape** sync — the *source* is the `app/` website (`anyplot-website`), not a published component library, although the converter `shape` is the normal `"package"` (see `config.json`). Only `pkg`/`globalName`/`projectId` are conventional; the rest of the config exists to make an app build like a DS.
 
 ## How this sync is wired (gotchas)
 
@@ -16,7 +16,7 @@ This is an **app-shape** sync: the source is the `app/` website (`anyplot-websit
 
 ## MonoLisa fonts (re-fetch on a fresh clone)
 
-MonoLisa is proprietary (© FaceType Foundry, CORS-locked GCS) and is **NOT in this public repo**. The variable ttf are fetched at sync time into the gitignored `app/.designsync-fonts/` and shipped only to the private design project — never committed. `app/.designsync-fonts/monolisa.css` (the `@font-face`, committed) references them. On a fresh clone, re-fetch before building:
+MonoLisa is proprietary (© FaceType Foundry, CORS-locked GCS) and is **NOT in this public repo**. The variable ttf are fetched at sync time into `app/.designsync-fonts/` (the `.ttf`/`.woff2` binaries are gitignored; only the `@font-face` CSS there is committed) and shipped only to the private design project — never committed. `app/.designsync-fonts/monolisa.css` (the `@font-face`, committed) references them. On a fresh clone, re-fetch before building:
 
 ```sh
 mkdir -p app/.designsync-fonts && cd app/.designsync-fonts

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,28 @@
+{
+  "pkg": "anyplot",
+  "globalName": "Anyplot",
+  "projectId": "bdf69a23-f0d2-40d5-b6cb-3ef035579852",
+  "shape": "package",
+  "entry": "app/designsync-entry.tsx",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.designsync.json",
+  "cssEntry": "src/styles/tokens.css",
+  "provider": { "component": "AppProviders" },
+  "extraFonts": ".designsync-fonts/monolisa.css",
+  "guidelinesGlob": ["../docs/reference/style-guide.md"],
+  "readmeHeader": ".design-sync/conventions.md",
+  "componentSrcMap": {
+    "CodeHighlighter": "src/components/CodeHighlighter.tsx",
+    "LoaderSpinner": "src/components/LoaderSpinner.tsx",
+    "ThemeToggle": "src/components/ThemeToggle.tsx",
+    "SectionHeader": "src/components/SectionHeader.tsx",
+    "Footer": "src/layouts/Footer.tsx"
+  },
+  "dtsPropsFor": {
+    "CodeHighlighter": "  /** Source code to render, syntax-highlighted with the anyplot imprint theme. */\n  code: string;\n  /** anyplot language id: \"python\" | \"r\" | \"julia\" | \"javascript\". Defaults to \"python\"; unknown ids render as plain text. */\n  language?: string;\n  /** Library id — overrides the language's default grammar (e.g. \"muix\" highlights as React TSX). */\n  library?: string;",
+    "LoaderSpinner": "  /** Spinner scale. Defaults to \"large\". */\n  size?: 'large' | 'small';",
+    "ThemeToggle": "  /** Current theme mode. */\n  mode: 'system' | 'light' | 'dark';\n  /** Advance to the next mode in the system → light → dark cycle. */\n  onCycle: () => void;",
+    "SectionHeader": "  /** Prefix symbol rendered at title size — e.g. \"§\", \"❯\", \"$\". */\n  prompt?: string;\n  /** Heading content; a string or rich nodes. An <em> child renders in brand green italic. */\n  title: React.ReactNode;\n  /** Trailing link label. Pair with `linkTo` (internal route) OR `linkHref` (external URL). */\n  linkText?: string;\n  /** Internal react-router route for the trailing link. Mutually exclusive with `linkHref`. */\n  linkTo?: string;\n  /** External URL for the trailing link (opens in a new tab). Mutually exclusive with `linkTo`. */\n  linkHref?: string;",
+    "Footer": "  /** Optional analytics callback fired on footer link clicks. */\n  onTrackEvent?: (name: string, props?: Record<string, string | undefined>) => void;\n  /** Currently-selected spec id, passed through to the \"report an issue\" link. */\n  selectedSpec?: string;\n  /** Currently-selected library id, passed through to the \"report an issue\" link. */\n  selectedLibrary?: string;"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,57 @@
+# anyplot.ai — design conventions
+
+anyplot.ai is a reference catalogue styled like **a code editor over a paper magazine**: warm editorial paper × terminal/tmux overlay (arXiv × lazygit, *never* a SaaS dashboard or AI-startup landing). Code is the native register — section headers carry shell prompts, buttons read as method calls.
+
+## Setup (required)
+
+Every component is MUI-based and reads the anyplot theme + design tokens from context. Always wrap your tree in **`AppProviders`** (a DS export): it applies the MUI `ThemeProvider` (anyplot theme), `CssBaseline`, and an in-memory router so the link-bearing components render. Without it, components fall back to MUI defaults and lose the brand.
+
+```jsx
+const { AppProviders, SectionHeader, CodeHighlighter } = window.Anyplot;
+
+ReactDOM.createRoot(document.getElementById('ds-root')).render(
+  <AppProviders>
+    <div style={{ maxWidth: 'var(--max)', margin: '0 auto', padding: '0 var(--gutter)' }}>
+      <SectionHeader prompt="❯" title={<>browse the <em>full</em> catalog</>} linkText="all plots →" linkTo="/plots" />
+      <CodeHighlighter language="python" code={'import anyplot as ap\nap.plot()'} />
+    </div>
+  </AppProviders>
+);
+```
+
+Link `styles.css` once — it `@import`s the tokens, MonoLisa fonts, and component styles. **Dark mode** flips via `[data-theme="dark"]` on `<html>`; never hard-code light/dark colors — the `var(--*)` tokens adapt automatically.
+
+## Styling idiom — CSS custom properties (+ MUI `sx`)
+
+Style with the `var(--*)` tokens, not invented hex. The vocabulary (all defined in `styles.css`):
+
+- **Surfaces** — warm off-white, *never* pure `#fff`: `--bg-page`, `--bg-surface`, `--bg-elevated`
+- **Ink** (warm grayscale text) + hairlines: `--ink`, `--ink-soft`, `--ink-muted`, `--rule`
+- **imprint palette — 8 categorical hues, reserved for PLOTS/charts, not UI chrome:** `--imprint-green` (`#009E73`, the brand), `--imprint-lavender`, `--imprint-blue`, `--imprint-ochre`, `--imprint-red`, `--imprint-cyan`, `--imprint-rose`, `--imprint-lime`; `--imprint-amber` = warning.
+- **Type stacks:** `--mono` ( = `--serif` = `--sans`, all MonoLisa); **code surface:** `--code-bg`, `--code-text`, `--code-border` (+ `--code-comment`/`-keyword`/`-string`/… syntax tokens)
+- **Layout:** `--gutter` (24px), `--max` (1240px — paper/reading width), `--max-catalog` (2200px — plot grids)
+
+## Typography — one typeface, two voices
+
+**MonoLisa everywhere** — body, UI, nav, buttons, logo, headlines. There is no second font. The editorial accent is **italic**, which auto-triggers MonoLisa's `ss02` script set (enabled globally via `font-feature-settings: "ss02"` on `html`). So: upright = structure/prose/labels; `font-style: italic` = emphasis/taglines/title accents (renders as flowing script). Bold (700) only at display sizes.
+
+## Color discipline (the core rule)
+
+Brand green `--imprint-green` appears in only ~5–10 deliberate spots per page (logo dot, one italic accent, hover, active nav, terminal cursor). **Everything else is warm grayscale.** The 8-hue palette is precious — spend it on charts, not buttons/banners/hero backgrounds, or the plots lose their punch.
+
+## Idioms
+
+- **Section headers** = shell prompts: use `SectionHeader` with `prompt="❯"` (the default; `$` or `~/path/` only when it adds meaning — no other glyphs). Title renders in script italic; an `<em>` child flips to brand green.
+- **Buttons & labels:** lowercase, read as code — `browse plots →`, `.copy()`, `.open()`. Self-evident, not explained.
+- **Voice:** precise, understated, code-native. Avoid sales-y/corporate words ("unlock", "leverage", "powered by AI", "supercharge") and emoji.
+
+## Where the truth lives
+
+- `styles.css` → `_ds_bundle.css` — every token, light + dark, names verbatim from upstream.
+- `guidelines/style-guide.md` — the full brand guide (palette rationale, type roles, three-tier layout, animation, anti-patterns). Read it before introducing anything new.
+
+## Don't
+
+- Pure `#fff` / `#000` backgrounds — use `--bg-page` and the dark tokens.
+- The categorical palette on UI chrome — it belongs to plots.
+- A second font, or decorative italic — italic is semantic emphasis only.

--- a/.design-sync/previews/CodeHighlighter.tsx
+++ b/.design-sync/previews/CodeHighlighter.tsx
@@ -1,0 +1,87 @@
+import { CodeHighlighter } from 'anyplot';
+
+// The anyplot imprint syntax theme across the four catalog languages. Each
+// cell is a real plotting snippet in the brand's "first series is green"
+// idiom — text-heavy on purpose so MonoLisa + the var(--code-*) token colors
+// are visible.
+const frame = (el: React.ReactNode) => <div style={{ maxWidth: 680, padding: 8 }}>{el}</div>;
+
+export function Python() {
+  return frame(
+    <CodeHighlighter
+      language="python"
+      code={`import matplotlib.pyplot as plt
+import numpy as np
+
+# imprint palette — brand green is always the first series
+phases = ["Render", "Parse", "Layout", "Paint", "Idle"]
+ms = np.array([42, 31, 18, 12, 7])
+
+fig, ax = plt.subplots(figsize=(8, 5))
+ax.bar(phases, ms, color="#009E73")
+ax.set_title("Frame budget by phase")
+ax.spines[["top", "right"]].set_visible(False)
+fig.savefig("pareto.svg")`}
+    />,
+  );
+}
+
+export function RGgplot2() {
+  return frame(
+    <CodeHighlighter
+      language="r"
+      code={`library(ggplot2)
+
+df <- data.frame(
+  phase = c("Render", "Parse", "Layout", "Paint", "Idle"),
+  ms    = c(42, 31, 18, 12, 7)
+)
+
+ggplot(df, aes(reorder(phase, -ms), ms)) +
+  geom_col(fill = "#009E73") +
+  labs(title = "Frame budget by phase", x = NULL, y = "ms") +
+  theme_minimal(base_family = "MonoLisa")`}
+    />,
+  );
+}
+
+export function JuliaMakie() {
+  return frame(
+    <CodeHighlighter
+      language="julia"
+      code={`using CairoMakie
+
+phases = ["Render", "Parse", "Layout", "Paint", "Idle"]
+ms = [42, 31, 18, 12, 7]
+
+fig = Figure(size = (800, 500))
+ax = Axis(fig[1, 1], title = "Frame budget by phase")
+barplot!(ax, 1:length(ms), ms; color = "#009E73")
+ax.xticks = (1:length(phases), phases)
+save("pareto.svg", fig)`}
+    />,
+  );
+}
+
+export function MuiXReact() {
+  return frame(
+    <CodeHighlighter
+      language="javascript"
+      library="muix"
+      code={`import { BarChart } from '@mui/x-charts/BarChart';
+
+const phases = ['Render', 'Parse', 'Layout', 'Paint', 'Idle'];
+const ms = [42, 31, 18, 12, 7];
+
+export default function FrameBudget() {
+  return (
+    <BarChart
+      xAxis={[{ data: phases, scaleType: 'band' }]}
+      series={[{ data: ms, color: '#009E73' }]}
+      height={320}
+    />
+  );
+}`}
+    />,
+  );
+}

--- a/.design-sync/previews/Footer.tsx
+++ b/.design-sync/previews/Footer.tsx
@@ -1,0 +1,9 @@
+import { Footer } from 'anyplot';
+
+// The site footer — a single mono row of links with an animated underline on
+// hover. One cell: the footer has a single appearance (the selectedSpec /
+// selectedLibrary props only retarget a hidden "report an issue" href, so a
+// second variant would render identically).
+export function Default() {
+  return <Footer />;
+}

--- a/.design-sync/previews/LoaderSpinner.tsx
+++ b/.design-sync/previews/LoaderSpinner.tsx
@@ -1,0 +1,19 @@
+import { LoaderSpinner } from 'anyplot';
+
+// The brand loader — two dots tween between imprint green and ochre. The frozen
+// screenshot catches one frame of the 2s loop; both sizes shown.
+export function Large() {
+  return (
+    <div style={{ padding: 40, display: 'flex', justifyContent: 'center' }}>
+      <LoaderSpinner size="large" />
+    </div>
+  );
+}
+
+export function Small() {
+  return (
+    <div style={{ padding: 40, display: 'flex', justifyContent: 'center' }}>
+      <LoaderSpinner size="small" />
+    </div>
+  );
+}

--- a/.design-sync/previews/SectionHeader.tsx
+++ b/.design-sync/previews/SectionHeader.tsx
@@ -1,0 +1,36 @@
+import { SectionHeader } from 'anyplot';
+
+// The §6.3 section-header pattern: a mono prompt symbol, a serif title (an <em>
+// child flips to brand-green italic), and an optional trailing link (internal
+// route or external URL).
+const frame = (el: React.ReactNode) => <div style={{ padding: '8px 28px', maxWidth: 860 }}>{el}</div>;
+
+export function Plain() {
+  return frame(<SectionHeader prompt="❯" title="Featured plots" />);
+}
+
+export function WithInternalLink() {
+  return frame(
+    <SectionHeader
+      prompt="§"
+      title={
+        <>
+          Browse the <em>full</em> catalog
+        </>
+      }
+      linkText="all plots →"
+      linkTo="/plots"
+    />,
+  );
+}
+
+export function WithExternalLink() {
+  return frame(
+    <SectionHeader
+      prompt="$"
+      title="Open source"
+      linkText="GitHub ↗"
+      linkHref="https://github.com/MarkusNeusinger/anyplot"
+    />,
+  );
+}

--- a/.design-sync/previews/ThemeToggle.tsx
+++ b/.design-sync/previews/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+import { ThemeToggle } from 'anyplot';
+
+// Controlled tri-state toggle (system → light → dark). onCycle is a no-op here
+// so each cell shows one fixed mode with its glyph (◑ / ☀ / ☾) and label.
+const noop = () => {};
+const frame = (el: React.ReactNode) => (
+  <div style={{ padding: 40, display: 'flex', justifyContent: 'center' }}>{el}</div>
+);
+
+export function System() {
+  return frame(<ThemeToggle mode="system" onCycle={noop} />);
+}
+
+export function Light() {
+  return frame(<ThemeToggle mode="light" onCycle={noop} />);
+}
+
+export function Dark() {
+  return frame(<ThemeToggle mode="dark" onCycle={noop} />);
+}

--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,14 @@ secrets/
 plots/*/implementations/*/plot-*.png
 plots/*/implementations/*/plot-*.html
 plots/*/implementations/*/plot-*.webp
+
+# design-sync (local sync scaffolding) — generated/staged, never committed
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+# proprietary brand font (MonoLisa, © FaceType Foundry) — fetched at sync time, never committed
+# (the @font-face CSS at app/.designsync-fonts/monolisa.css IS committed)
+app/.designsync-fonts/*.ttf
+app/.designsync-fonts/*.woff2

--- a/app/.designsync-fonts/monolisa.css
+++ b/app/.designsync-fonts/monolisa.css
@@ -1,8 +1,9 @@
 /*
  * MonoLisa (variable) — brand typeface for the anyplot design system.
- * Proprietary, © FaceType Foundry. Fetched at sync time from the anyplot GCS
- * bucket into this gitignored directory; shipped only into the private
- * claude.ai/design project, never committed to the (public) repo.
+ * Proprietary, © FaceType Foundry. The .ttf binaries are fetched at sync time
+ * from the anyplot GCS bucket into this directory and gitignored (this CSS is
+ * committed); they are shipped only into the private claude.ai/design project,
+ * never committed to the (public) repo.
  *
  * Re-fetch (see .design-sync/NOTES.md):
  *   curl -sSfo MonoLisaVariableNormal.ttf https://storage.googleapis.com/anyplot-static/fonts/MonoLisaVariableNormal.ttf

--- a/app/.designsync-fonts/monolisa.css
+++ b/app/.designsync-fonts/monolisa.css
@@ -1,0 +1,33 @@
+/*
+ * MonoLisa (variable) — brand typeface for the anyplot design system.
+ * Proprietary, © FaceType Foundry. Fetched at sync time from the anyplot GCS
+ * bucket into this gitignored directory; shipped only into the private
+ * claude.ai/design project, never committed to the (public) repo.
+ *
+ * Re-fetch (see .design-sync/NOTES.md):
+ *   curl -sSfo MonoLisaVariableNormal.ttf https://storage.googleapis.com/anyplot-static/fonts/MonoLisaVariableNormal.ttf
+ *   curl -sSfo MonoLisaVariableItalic.ttf https://storage.googleapis.com/anyplot-static/fonts/MonoLisaVariableItalic.ttf
+ */
+@font-face {
+  font-family: 'MonoLisa';
+  src: url('./MonoLisaVariableNormal.ttf') format('truetype');
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'MonoLisa';
+  src: url('./MonoLisaVariableItalic.ttf') format('truetype');
+  font-weight: 100 900;
+  font-style: italic;
+  font-display: swap;
+}
+/* Metric-compatible fallback so layout stays stable before MonoLisa loads. */
+@font-face {
+  font-family: 'MonoLisa Fallback';
+  src: local('Consolas'), local('Menlo'), local('Monaco'), local('DejaVu Sans Mono');
+  size-adjust: 106.5%;
+  ascent-override: 105%;
+  descent-override: 25%;
+  line-gap-override: 0%;
+}

--- a/app/designsync-entry.tsx
+++ b/app/designsync-entry.tsx
@@ -1,0 +1,42 @@
+/**
+ * Curated entry point for the anyplot design system (/design-sync converter).
+ *
+ * Re-exports the reusable, presentational components plus an `AppProviders`
+ * wrapper used to render the preview cards: the MUI theme, a CSS baseline, and
+ * an in-memory router so the link-bearing components (SectionHeader, Footer)
+ * render outside a real browser history.
+ *
+ * This file lives OUTSIDE the app tsconfig `include` (see
+ * tsconfig.designsync.json) so the app's build and typecheck never touch it.
+ * It exists only as the esbuild entry for the design-system bundle — importing
+ * `src/main.tsx` (which calls ReactDOM.createRoot().render()) is deliberately
+ * avoided so nothing mounts the real app when the bundle loads.
+ */
+import * as React from 'react';
+
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
+
+import { theme } from 'src/theme';
+
+export { default as CodeHighlighter } from 'src/components/CodeHighlighter';
+export { LoaderSpinner } from 'src/components/LoaderSpinner';
+export { ThemeToggle } from 'src/components/ThemeToggle';
+export { SectionHeader } from 'src/components/SectionHeader';
+export { Footer } from 'src/layouts/Footer';
+
+/**
+ * Preview wrapper: applies the anyplot theme + CSS baseline and provides an
+ * in-memory router so components that render react-router `Link`s work.
+ */
+export function AppProviders({ children }: { children?: React.ReactNode }) {
+  return (
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+}

--- a/app/tsconfig.designsync.json
+++ b/app/tsconfig.designsync.json
@@ -1,0 +1,18 @@
+{
+  "//": "Dedicated tsconfig for the /design-sync converter. Only compilerOptions.paths is read (by the esbuild tsconfig-paths plugin) to resolve the app's `src/*` aliases when bundling app/designsync-entry.tsx. Each barrel folder is mapped to its index file BEFORE the `src/*` wildcard — otherwise the wildcard's empty-extension probe matches the directory itself and esbuild fails to bundle it. Not used by the app's own build.",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "paths": {
+      "src/components": ["./src/components/index.ts"],
+      "src/constants": ["./src/constants/index.ts"],
+      "src/hooks": ["./src/hooks/index.ts"],
+      "src/layouts": ["./src/layouts/index.ts"],
+      "src/routes": ["./src/routes/index.tsx"],
+      "src/theme": ["./src/theme/index.ts"],
+      "src/types": ["./src/types/index.ts"],
+      "src/utils": ["./src/utils/index.ts"],
+      "src/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Adds the reproducible inputs for syncing the frontend `app/` to the **anyplot.ai Design System** project on claude.ai/design (`bdf69a23`) via the `/design-sync` skill. The first full sync is already live in that project; this PR commits the inputs so future re-syncs are deterministic.

## Why app-shape

`app/` is a website (`anyplot-website`), not a published component library, so the converter is pointed at a **curated entry** rather than a `dist/`:

- **`app/designsync-entry.tsx`** — re-exports the 5 reusable components + an `AppProviders` wrapper (`MemoryRouter` → MUI `ThemeProvider` → `CssBaseline`). Outside the app tsconfig `include`, so the app build/typecheck never touch it.
- **`app/tsconfig.designsync.json`** — maps each `src/<barrel>` to its index before the `src/*` wildcard (else esbuild resolves the directory and fails).
- **`.design-sync/config.json`** — component list via `componentSrcMap`, props via hand-written `dtsPropsFor` (the app ships no `.d.ts`), `provider=AppProviders`, `cssEntry=src/styles/tokens.css`, `guidelinesGlob` ships `style-guide.md`, `readmeHeader=conventions.md`.

## Synced surface

`CodeHighlighter`, `LoaderSpinner`, `ThemeToggle`, `SectionHeader`, `Footer` — each with an authored preview card (`.design-sync/previews/*.tsx`), all graded good. The 8 infrastructural components (error boundaries, data/router shell, FeedbackWidget) are intentionally excluded.

## Fonts

MonoLisa (proprietary, © FaceType Foundry) is **not** committed — the repo is public. `app/.designsync-fonts/monolisa.css` (the `@font-face`) is committed; the variable `.ttf` are gitignored and fetched from `gs://anyplot-static/fonts/` at sync time (commands in `.design-sync/NOTES.md`). They ship only to the private design project.

## Not included

Generated/staged dirs (`ds-bundle/`, `.ds-sync/`, `.design-sync/.cache/`) and the font binaries are gitignored.

See `.design-sync/NOTES.md` for the one-command re-sync procedure and re-sync risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)