### PR TITLE
fix: crawlers get 502 on every page — raise proxy_ssl_verify_depth + add synthetic bot monitor

### DIFF
--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -48,8 +48,8 @@ jobs:
 
           # Bot path: prerendered per-route HTML from the seo-proxy
           check "$GOOGLEBOT"  "https://anyplot.ai/"                                "<title>anyplot.ai</title>"
-          check "$GOOGLEBOT"  "https://anyplot.ai/scatter-basic"                   "Basic Scatter Plot | anyplot.ai"
-          check "$TWITTERBOT" "https://anyplot.ai/scatter-basic/python/matplotlib" "Basic Scatter Plot - matplotlib"
+          check "$GOOGLEBOT"  "https://anyplot.ai/scatter-basic"                   "<title>Basic Scatter Plot | anyplot.ai</title>"
+          check "$TWITTERBOT" "https://anyplot.ai/scatter-basic/python/matplotlib" "<title>Basic Scatter Plot - matplotlib | anyplot.ai</title>"
 
           # Control: humans must still get the SPA shell
           check "$HUMAN" "https://anyplot.ai/" '<div id="root">'

--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   bot-serving:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 4 checks x (--retry 2 -> up to 3 attempts x --max-time 30) can reach
+    # ~6 min worst-case; 10 leaves room to report a clean failure.
+    timeout-minutes: 10
     steps:
       - name: Crawler UAs must get 200 + per-route titles
         run: |
@@ -34,7 +36,9 @@ jobs:
           check() {
             local ua="$1" url="$2" expect="$3"
             local code
-            code=$(curl -sS --retry 2 --max-time 30 -A "$ua" -o body.html -w '%{http_code}' "$url" || echo "000")
+            # On curl failure REPLACE the code — a failing curl can still have
+            # printed a partial -w code; appending would yield e.g. "200000".
+            code=$(curl -sS --retry 2 --max-time 30 -A "$ua" -o body.html -w '%{http_code}' "$url") || code="000"
             if [ "$code" != "200" ]; then
               echo "::error::$url with UA '$ua' returned HTTP $code (expected 200)"
               fail=1

--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -1,0 +1,57 @@
+# Synthetic monitor for the nginx bot -> seo-proxy path.
+#
+# Humans get the SPA shell and never notice when the bot hop breaks: the site
+# looks healthy, Plausible shows normal traffic, CI is green — and every
+# crawler sees an error page. Exactly that happened between 2026-06-12 and
+# 2026-07-09: the @seo_proxy upstream TLS verification failed (default
+# proxy_ssl_verify_depth 1 vs a 4-deep Let's Encrypt chain) and every bot UA
+# received HTTP 502 on every page, undetected for ~4 weeks. This check is the
+# alarm that was missing.
+
+name: Bot Serving Check
+
+on:
+  schedule:
+    - cron: "23 6 * * *" # daily 06:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bot-serving:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Crawler UAs must get 200 + per-route titles
+        run: |
+          set -uo pipefail
+          GOOGLEBOT="Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+          TWITTERBOT="Twitterbot/1.0"
+          HUMAN="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+          fail=0
+
+          check() {
+            local ua="$1" url="$2" expect="$3"
+            local code
+            code=$(curl -sS --retry 2 --max-time 30 -A "$ua" -o body.html -w '%{http_code}' "$url" || echo "000")
+            if [ "$code" != "200" ]; then
+              echo "::error::$url with UA '$ua' returned HTTP $code (expected 200)"
+              fail=1
+            elif ! grep -qF "$expect" body.html; then
+              echo "::error::$url with UA '$ua' returned 200 but the body is missing: $expect"
+              fail=1
+            else
+              echo "OK: $url ($ua)"
+            fi
+          }
+
+          # Bot path: prerendered per-route HTML from the seo-proxy
+          check "$GOOGLEBOT"  "https://anyplot.ai/"                                "<title>anyplot.ai</title>"
+          check "$GOOGLEBOT"  "https://anyplot.ai/scatter-basic"                   "Basic Scatter Plot | anyplot.ai"
+          check "$TWITTERBOT" "https://anyplot.ai/scatter-basic/python/matplotlib" "Basic Scatter Plot - matplotlib"
+
+          # Control: humans must still get the SPA shell
+          check "$HUMAN" "https://anyplot.ai/" '<div id="root">'
+
+          exit $fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 - **`bot-serving-check.yml` synthetic monitor** — daily scheduled workflow that curls
   production with Googlebot/Twitterbot UAs plus a human-UA control and fails on non-200 or
-  missing per-route titles, so the crawler-only serving path can never break silently again.
+  missing per-route titles, so the crawler-only serving path can never break silently again
+  (#9617).
 - **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
   workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
   headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and
@@ -74,7 +75,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `@seo_proxy` hop verifies the upstream TLS chain of `api.anyplot.ai`, which is 4 certificates
   deep (leaf → Let's Encrypt YE1 → ISRG Root YE cross-sign → ISRG Root X2), while nginx's
   default `proxy_ssl_verify_depth` is 1. Depth raised to 4 in both proxy locations — humans saw
-  a healthy site the whole time, making this a de-facto site-wide noindex.
+  a healthy site the whole time, making this a de-facto site-wide noindex (#9617).
 - **All react-refresh ESLint warnings resolved** — `PALETTE` / `snippet()` extracted from
   `PalettePage.tsx` into `PalettePage.helpers.ts` (following the `MapPage.helpers.ts` pattern),
   and the `react-refresh/only-export-components` rule scoped off for test modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Added
 
+- **`bot-serving-check.yml` synthetic monitor** — daily scheduled workflow that curls
+  production with Googlebot/Twitterbot UAs plus a human-UA control and fails on non-200 or
+  missing per-route titles, so the crawler-only serving path can never break silently again.
 - **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
   workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
   headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and
@@ -66,6 +69,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **Crawler 502 outage fixed** — since at least 2026-06-12, every crawler UA (googlebot,
+  bingbot, twitterbot, discord, whatsapp, …) received HTTP 502 on every page: the nginx
+  `@seo_proxy` hop verifies the upstream TLS chain of `api.anyplot.ai`, which is 4 certificates
+  deep (leaf → Let's Encrypt YE1 → ISRG Root YE cross-sign → ISRG Root X2), while nginx's
+  default `proxy_ssl_verify_depth` is 1. Depth raised to 4 in both proxy locations — humans saw
+  a healthy site the whole time, making this a de-facto site-wide noindex.
 - **All react-refresh ESLint warnings resolved** — `PALETTE` / `snippet()` extracted from
   `PalettePage.tsx` into `PalettePage.helpers.ts` (following the `MapPage.helpers.ts` pattern),
   and the `react-refresh/only-export-components` rule scoped off for test modules

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -9,7 +9,10 @@ map $http_user_agent $is_bot {
     default 0;
     # Search engines — historically excluded "because they render JS since 2019",
     # but in practice the prerendered HTML produces faster, more reliable
-    # indexing for a content-driven catalogue. Verify after rollout with
+    # indexing for a content-driven catalogue. This path is invisible to human
+    # traffic, so it is monitored continuously by
+    # .github/workflows/bot-serving-check.yml (daily curl with bot UAs); after
+    # any change here, also verify manually with
     # `curl -A "Googlebot" https://anyplot.ai/scatter-basic` — should return
     # the per-route title/canonical/og:url, not the empty SPA shell.
     ~*googlebot 1;
@@ -90,6 +93,10 @@ server {
         proxy_set_header Host api.anyplot.ai;
         proxy_ssl_server_name on;
         proxy_ssl_verify on;
+        # api.anyplot.ai serves a 4-deep Let's Encrypt chain (leaf -> YE1 ->
+        # ISRG Root YE cross-sign -> ISRG Root X2); nginx's default verify
+        # depth of 1 rejected it (SSL error 20) and every crawler got a 502.
+        proxy_ssl_verify_depth 4;
         proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
     }
 
@@ -203,6 +210,8 @@ server {
         proxy_set_header Host api.anyplot.ai;
         proxy_ssl_server_name on;
         proxy_ssl_verify on;
+        # Same 4-deep chain as @seo_proxy above — default depth 1 breaks it.
+        proxy_ssl_verify_depth 4;
         proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
     }
 

--- a/docs/workflows/overview.md
+++ b/docs/workflows/overview.md
@@ -174,6 +174,7 @@ Located in `.github/workflows/`:
 | `ci-lint.yml` | Ruff lint check on PRs |
 | `ci-tests.yml` | Unit + integration tests on PRs |
 | `notify-deployment.yml` | Records GitHub deployment events for `app` / `api` |
+| `bot-serving-check.yml` | Daily synthetic monitor: curls production with crawler UAs (Googlebot/Twitterbot) and fails on non-200 or missing per-route titles — the bot→seo-proxy path is invisible to human traffic and needs its own alarm |
 | `util-claude.yml` | On-demand `@claude` utility (issue/PR comments) |
 
 ---


### PR DESCRIPTION
## Summary
- **Fixes the critical audit finding**: since at least 2026-06-12 (30-day log retention boundary), every crawler UA — googlebot, bingbot, twitterbot, discordbot, whatsapp, … — received **HTTP 502 on every page**, a de-facto site-wide noindex plus dead social previews, while human traffic saw a healthy site.
- **Root cause** (fully diagnosed against production): nginx's `@seo_proxy` hop runs `proxy_ssl_verify on` against `https://api.anyplot.ai`, whose certificate chain is **4 deep** (leaf → Let's Encrypt YE1 → ISRG Root YE cross-sign → ISRG Root X2). nginx's default `proxy_ssl_verify_depth` is **1** → Cloud Run logs show `upstream SSL certificate verify error: (20:unable to get local issuer certificate)` for every Cloudflare upstream IP. Fix: `proxy_ssl_verify_depth 4;` in both `@seo_proxy` and `@seo_proxy_python`.
- **Adds `bot-serving-check.yml`**: daily synthetic monitor (plus `workflow_dispatch`) curling production with Googlebot/Twitterbot UAs and a human-UA control, failing on non-200 or missing per-route `<title>`. This serving path is invisible to humans, Plausible, and CI — which is exactly how the outage persisted ~4 weeks. Also institutionalizes the check in the nginx.conf comment and docs/workflows/overview.md.

## Evidence
- `curl -A Googlebot https://anyplot.ai/scatter-basic` → 502; normal UA → 200 (verified live, also directly against the Cloud Run origin bypassing Cloudflare)
- Upstream healthy: `https://api.anyplot.ai/seo-proxy/scatter-basic` → 200 with correct per-route HTML, even with a bot UA
- `openssl s_client` confirms the 4-deep chain; earliest matching log entry 2026-06-12T18:09Z

## Verification plan
- `nginx.conf` has no local verification loop (no docker in this environment) — `proxy_ssl_verify_depth` is a standard `http/server/location`-context directive; the change is two identical one-liners.
- The new monitor script was **dry-run against current production**: it correctly reports 3× FAIL (bot 502) + control OK, exit 1 — i.e. it detects the current outage.
- **After merge + Cloud Build deploy**: re-run the same three curls (must all be 200 with per-route titles) and trigger `bot-serving-check.yml` via `workflow_dispatch` (must be green). I will do both and report.

## Test plan
- [x] Workflow YAML validated; monitor logic dry-run against production (correctly red pre-fix)
- [x] CHANGELOG updated (Fixed + Added)
- [ ] Post-deploy: `curl -A Googlebot https://anyplot.ai/scatter-basic` → 200 with `Basic Scatter Plot | anyplot.ai`
- [ ] Post-deploy: `gh workflow run bot-serving-check.yml` → green