### PR TITLE
feat: spec-conformant llms.txt for AI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   by Lighthouse's Agentic Browsing audit as non-conformant); now a spec-conformant file per
   llmstxt.org (H1 + summary blockquote + H2 link sections) covering catalog, docs, the MCP
   endpoint and the repo, served directly in nginx like robots.txt so mapped crawler UAs aren't
-  proxied into a `/seo-proxy/llms.txt` 404.
+  proxied into a `/seo-proxy/llms.txt` 404 (#9618).
 - **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
   workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
   headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Added
 
+- **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged
+  by Lighthouse's Agentic Browsing audit as non-conformant); now a spec-conformant file per
+  llmstxt.org (H1 + summary blockquote + H2 link sections) covering catalog, docs, the MCP
+  endpoint and the repo, served directly in nginx like robots.txt so mapped crawler UAs aren't
+  proxied into a `/seo-proxy/llms.txt` 404.
 - **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
   workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
   headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -217,7 +217,10 @@ server {
         try_files $uri =404;
     }
 
-    # Same as the main server block: llms.txt consumers are bots.
+    # Unlike the main server block this is not strictly required (this block's
+    # `location /` fallback has no bot proxy and the spec-route regexes don't
+    # match dotted paths) — kept as an explicit exact match so llms.txt serving
+    # stays guaranteed even if a bot catch-all is added here later.
     location = /llms.txt {
         try_files $uri =404;
     }

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -98,6 +98,13 @@ server {
         try_files $uri =404;
     }
 
+    # Serve llms.txt directly — its consumers ARE bots, so without this exact
+    # match a mapped crawler UA would be proxied to /seo-proxy/llms.txt (404)
+    # instead of getting the file.
+    location = /llms.txt {
+        try_files $uri =404;
+    }
+
     # SPA routing - serve index.html for all routes
     # Social media bots get redirected to backend for proper og:tags
     location / {
@@ -207,6 +214,11 @@ server {
     }
 
     location = /robots.txt {
+        try_files $uri =404;
+    }
+
+    # Same as the main server block: llms.txt consumers are bots.
+    location = /llms.txt {
         try_files $uri =404;
     }
 

--- a/app/public/llms.txt
+++ b/app/public/llms.txt
@@ -1,0 +1,28 @@
+# anyplot
+
+> the open plot catalogue — every plot begins as a library-agnostic markdown spec; ai generates
+> and reviews implementations across fifteen libraries in python, r, julia and javascript.
+> browse, copy, adapt — colorblind-safe by default.
+
+every plot page carries the runnable source code (MIT-licensed). catalog pages are also served
+as prerendered HTML to crawler user agents, so fetching a page URL directly returns the
+per-route title, description and content without executing JavaScript.
+
+## Catalog
+
+- [Plot gallery](https://anyplot.ai/plots): every rendered implementation, filterable by library, language and tags
+- [Specifications](https://anyplot.ai/specs): the library-agnostic plot specs the implementations are generated from
+- [Libraries](https://anyplot.ai/libraries): the fifteen supported plotting libraries across four languages
+- [Sitemap](https://anyplot.ai/sitemap.xml): every spec hub and implementation page
+
+## Docs
+
+- [About](https://anyplot.ai/about): what anyplot is and how the ai pipeline works (idea → spec → code → review)
+- [Palette](https://anyplot.ai/palette): imprint, the colorblind-safe palette, with copy-paste snippets for python, r, julia and javascript
+- [MCP server](https://anyplot.ai/mcp): connect an ai agent to the catalog via Model Context Protocol — HTTP transport at https://api.anyplot.ai/mcp/
+- [Legal & transparency](https://anyplot.ai/legal): operator, privacy policy, tech stack and hosting costs
+
+## Optional
+
+- [GitHub repository](https://github.com/MarkusNeusinger/anyplot): full source — specs, pipeline, api and frontend
+- [Stats](https://anyplot.ai/stats): catalog and usage statistics


### PR DESCRIPTION
## Summary
- `/llms.txt` previously fell through to SPA routing and returned the index.html shell — Lighthouse's new **Agentic Browsing** audit flagged it as a non-conformant llms.txt ("missing required H1", "contains no links"). There was in fact no llms.txt at all.
- Adds `app/public/llms.txt` following the [llmstxt.org](https://llmstxt.org) format: H1 title, summary blockquote, context paragraph, and H2 sections (`Catalog`, `Docs`, `Optional`) with described links — catalog pages, sitemap, palette, the MCP endpoint (`https://api.anyplot.ai/mcp/`) and the GitHub repo.
- Adds exact-match `location = /llms.txt { try_files $uri =404; }` to **both** nginx server blocks (same pattern as robots.txt): llms.txt consumers are bots, and any UA in the `$is_bot` map would otherwise be proxied to `/seo-proxy/llms.txt` and 404.

## Notes
- Copy avoids stale counts where possible; "fifteen libraries across four languages" matches the current About-page copy.
- Related follow-ups NOT in this PR (need decisions): the Cloudflare-managed robots.txt currently `Disallow: /` for ClaudeBot/GPTBot/CCBot (audit finding — dashboard setting, undermines llms.txt for those crawlers), and the `$is_bot` map doesn't include AI-agent UAs (GPTBot, ClaudeBot, PerplexityBot, …), so they get the SPA shell instead of prerendered HTML.

## Plan
N/A (direct request — Lighthouse Agentic Browsing finding)

## Test plan
- [x] `yarn build` → `dist/llms.txt` present with correct content
- [x] File satisfies the flagged checks: H1 heading + links present, valid Markdown
- [ ] Post-deploy: `curl https://anyplot.ai/llms.txt` returns the file (human UA) and `curl -A Googlebot https://anyplot.ai/llms.txt` returns the file too (not a seo-proxy 404)