### PR TITLE
fix: bot-serving monitor must target the Cloud Run origin (Cloudflare 403s runner IPs)

### DIFF
--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -7,6 +7,13 @@
 # proxy_ssl_verify_depth 1 vs a 4-deep Let's Encrypt chain) and every bot UA
 # received HTTP 502 on every page, undetected for ~4 weeks. This check is the
 # alarm that was missing.
+#
+# The checks target the Cloud Run ORIGIN, not https://anyplot.ai: Cloudflare's
+# bot management 403s GitHub-runner (datacenter) IPs — including UA-spoofed
+# "Googlebot", which only passes verified-bot checks from real Google IPs —
+# verified on the first dispatched run. The origin is also exactly the layer
+# that broke in the incident above; Cloudflare-edge issues are out of this
+# monitor's reach by design.
 
 name: Bot Serving Check
 
@@ -21,13 +28,16 @@ permissions:
 jobs:
   bot-serving:
     runs-on: ubuntu-latest
-    # 4 checks x (--retry 2 -> up to 3 attempts x --max-time 30) can reach
-    # ~6 min worst-case; 10 leaves room to report a clean failure.
+    # 5 checks x (--retry 2 -> up to 3 attempts x --max-time 30) can reach
+    # ~7.5 min worst-case; 10 leaves room to report a clean failure.
     timeout-minutes: 10
     steps:
       - name: Crawler UAs must get 200 + per-route titles
         run: |
           set -uo pipefail
+          # Cloud Run origin of the anyplot-app service (see header comment
+          # for why not https://anyplot.ai).
+          ORIGIN="https://anyplot-app-r3tvmejsmq-ez.a.run.app"
           GOOGLEBOT="Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
           TWITTERBOT="Twitterbot/1.0"
           HUMAN="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
@@ -51,11 +61,14 @@ jobs:
           }
 
           # Bot path: prerendered per-route HTML from the seo-proxy
-          check "$GOOGLEBOT"  "https://anyplot.ai/"                                "<title>anyplot.ai</title>"
-          check "$GOOGLEBOT"  "https://anyplot.ai/scatter-basic"                   "<title>Basic Scatter Plot | anyplot.ai</title>"
-          check "$TWITTERBOT" "https://anyplot.ai/scatter-basic/python/matplotlib" "<title>Basic Scatter Plot - matplotlib | anyplot.ai</title>"
+          check "$GOOGLEBOT"  "$ORIGIN/"                                "<title>anyplot.ai</title>"
+          check "$GOOGLEBOT"  "$ORIGIN/scatter-basic"                   "<title>Basic Scatter Plot | anyplot.ai</title>"
+          check "$TWITTERBOT" "$ORIGIN/scatter-basic/python/matplotlib" "<title>Basic Scatter Plot - matplotlib | anyplot.ai</title>"
+
+          # llms.txt must be served directly, never proxied to the seo backend
+          check "$GOOGLEBOT" "$ORIGIN/llms.txt" "# anyplot"
 
           # Control: humans must still get the SPA shell
-          check "$HUMAN" "https://anyplot.ai/" '<div id="root">'
+          check "$HUMAN" "$ORIGIN/" '<div id="root">'
 
           exit $fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   llmstxt.org (H1 + summary blockquote + H2 link sections) covering catalog, docs, the MCP
   endpoint and the repo, served directly in nginx like robots.txt so mapped crawler UAs aren't
   proxied into a `/seo-proxy/llms.txt` 404 (#9618).
-- **`bot-serving-check.yml` synthetic monitor** — daily scheduled workflow that curls
-  production with Googlebot/Twitterbot UAs plus a human-UA control and fails on non-200 or
-  missing per-route titles, so the crawler-only serving path can never break silently again
-  (#9617).
+- **`bot-serving-check.yml` synthetic monitor** — daily scheduled workflow that curls the
+  Cloud Run origin with Googlebot/Twitterbot UAs plus a human-UA control (and an `llms.txt`
+  check) and fails on non-200 or missing per-route titles, so the crawler-only serving path can
+  never break silently again. Targets the origin because Cloudflare's bot management 403s
+  GitHub-runner IPs (#9617, #9619).
 - **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
   workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
   headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and


### PR DESCRIPTION
## Summary
- The first dispatched `bot-serving-check.yml` run failed with **403 on all four checks — including the human-UA control**: Cloudflare's bot management blocks GitHub-runner (datacenter) IPs, and a UA-spoofed "Googlebot" only passes verified-bot checks when coming from real Google IPs. The monitor was structurally unable to run from Actions against the proxied domain.
- Switch all checks to the Cloud Run origin (`anyplot-app-…-ez.a.run.app`) — exactly the layer that broke in the 2026-06/07 incident, so this is also the more precise probe. Cloudflare-edge issues are explicitly out of this monitor's reach (documented in the header comment).
- Adds an `llms.txt` check (Googlebot UA must get the file, never a seo-proxy 404) — guards the exact-match nginx location from #9618.

## Verification
- Dispatched run 28981172030 documented the failure mode (4× 403).
- The updated script was dry-run against the live origin: **5/5 OK, exit 0**.
- After merge I will dispatch the workflow once — expected green.

## Test plan
- [x] YAML valid; script dry-run against live origin passes 5/5
- [ ] Post-merge `workflow_dispatch` run is green