### PR TITLE
fix: /plots keyboard-shortcut guard + gallery cold-path prewarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,14 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 - **Global keyboard shortcuts no longer hijack focused elements on `/plots`** — the
   window-level Space/Enter/Backspace handler now bails out when the keystroke targets an
   interactive element (button, link, focused card/chip/toggle), so keyboard-activating a card
-  no longer double-fires with a random-plot jump (audit 2026-07-08 Quick Win 1).
+  no longer double-fires with a random-plot jump (audit 2026-07-08 Quick Win 1) (#9620).
 
 ### Changed
 
 - **Gallery cold path prewarmed** — the startup cache prewarm now also computes the two
   heaviest user-facing payloads, `/plots/filter` (`filter:all`) and `/specs/map`, so the first
   visitor of a fresh Cloud Run instance no longer waits on the full DB roundtrip for the
-  gallery or the map page (audit 2026-07-08 Quick Win 2).
+  gallery or the map page (audit 2026-07-08 Quick Win 2) (#9620).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Fixed
+
+- **Global keyboard shortcuts no longer hijack focused elements on `/plots`** — the
+  window-level Space/Enter/Backspace handler now bails out when the keystroke targets an
+  interactive element (button, link, focused card/chip/toggle), so keyboard-activating a card
+  no longer double-fires with a random-plot jump (audit 2026-07-08 Quick Win 1).
+
+### Changed
+
+- **Gallery cold path prewarmed** — the startup cache prewarm now also computes the two
+  heaviest user-facing payloads, `/plots/filter` (`filter:all`) and `/specs/map`, so the first
+  visitor of a fresh Cloud Run instance no longer waits on the full DB roundtrip for the
+  gallery or the map page (audit 2026-07-08 Quick Win 2).
+
 ### Added
 
 - **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged

--- a/api/main.py
+++ b/api/main.py
@@ -41,7 +41,8 @@ from api.routers import (  # noqa: E402
 )
 from api.routers.languages import _refresh_languages  # noqa: E402
 from api.routers.libraries import _refresh_libraries  # noqa: E402
-from api.routers.specs import _refresh_specs_list  # noqa: E402
+from api.routers.plots import _refresh_filter_all  # noqa: E402
+from api.routers.specs import _refresh_specs_list, _refresh_specs_map  # noqa: E402
 from api.routers.stats import _refresh_stats  # noqa: E402
 from core.database import close_db, init_db, is_db_configured  # noqa: E402
 
@@ -56,9 +57,12 @@ mcp_http_app = mcp_server.http_app(path="/")
 
 
 async def _prewarm_cache() -> None:
-    """Populate the in-memory cache for the four metadata endpoints that the
-    frontend's AppDataProvider fires on every page load (/stats, /libraries,
-    /languages, /specs).
+    """Populate the in-memory cache for the endpoints the frontend hits on
+    page load: the four AppDataProvider metadata calls (/stats, /libraries,
+    /languages, /specs) plus the two heaviest user-facing payloads — the
+    unfiltered gallery (/plots/filter → `filter:all`) and the /map page
+    (/specs/map) — which would otherwise take the full cold-cache DB
+    roundtrip for the first visitor of every new instance.
 
     The cache lives per Cloud Run instance, so every new instance that comes
     up from autoscale or a cold start would otherwise force its first user
@@ -70,11 +74,15 @@ async def _prewarm_cache() -> None:
     means the first user request takes the cold-cache path it would have
     taken without this hook.
     """
+    # Ordered lightest-first so the cheap metadata endpoints are warm even
+    # while the two heavy payloads are still being computed.
     refreshers = (
         ("stats", _refresh_stats),
         ("libraries", _refresh_libraries),
         ("languages", _refresh_languages),
         ("specs_list", _refresh_specs_list),
+        ("specs_map", _refresh_specs_map),
+        ("filter:all", _refresh_filter_all),
     )
     for key, factory in refreshers:
         try:

--- a/api/routers/plots.py
+++ b/api/routers/plots.py
@@ -404,7 +404,7 @@ async def _build_filtered_plots(db: AsyncSession, filter_groups: list[dict]) -> 
         repo = SpecRepository(db)
         all_specs = await repo.get_all()
     except SQLAlchemyError as e:
-        logger.error("Database query failed in get_filtered_plots: %s", e)
+        logger.error("Database query failed while building the /plots/filter response: %s", e)
         raise DatabaseQueryError("fetch_specs", str(e)) from e
 
     spec_lookup = _build_spec_lookup(all_specs)

--- a/api/routers/plots.py
+++ b/api/routers/plots.py
@@ -12,6 +12,7 @@ from api.dependencies import require_db
 from api.exceptions import DatabaseQueryError
 from api.schemas import FilteredPlotsResponse
 from core.database import SpecRepository
+from core.database.connection import get_db_context
 
 
 logger = logging.getLogger(__name__)
@@ -397,6 +398,64 @@ def _filter_images(
     ]
 
 
+async def _build_filtered_plots(db: AsyncSession, filter_groups: list[dict]) -> FilteredPlotsResponse:
+    """Compute the (unpaginated) filter response for a set of filter groups."""
+    try:
+        repo = SpecRepository(db)
+        all_specs = await repo.get_all()
+    except SQLAlchemyError as e:
+        logger.error("Database query failed in get_filtered_plots: %s", e)
+        raise DatabaseQueryError("fetch_specs", str(e)) from e
+
+    spec_lookup = _build_spec_lookup(all_specs)
+    impl_lookup = _build_impl_lookup(all_specs)
+    all_images = _collect_all_images(all_specs)
+    spec_titles = {spec_id: data["spec"].title for spec_id, data in spec_lookup.items() if data["spec"].title}
+
+    global_counts = _calculate_global_counts(all_specs)
+
+    # Fast path for the unfiltered request (e.g. the /specs page list and
+    # the initial /plots load). With no filter groups, `filtered_images`
+    # equals `all_images`, `counts` equals `global_counts`, and `or_counts`
+    # is empty — so skip the two O(images × categories) recomputations
+    # that would otherwise dominate the cold-cache `filter:all` response.
+    if not filter_groups:
+        return FilteredPlotsResponse(
+            total=len(all_images),
+            images=all_images,
+            counts=global_counts,
+            globalCounts=global_counts,
+            orCounts=[],
+            specTitles=spec_titles,
+        )
+
+    spec_id_to_tags = {spec_id: spec_data["tags"] for spec_id, spec_data in spec_lookup.items()}
+
+    filtered_images = _filter_images(all_images, filter_groups, spec_lookup, impl_lookup)
+
+    counts = _calculate_contextual_counts(filtered_images, spec_id_to_tags, impl_lookup)
+    or_counts = _calculate_or_counts(filter_groups, all_images, spec_id_to_tags, spec_lookup, impl_lookup)
+
+    return FilteredPlotsResponse(
+        total=len(filtered_images),
+        images=filtered_images,
+        counts=counts,
+        globalCounts=global_counts,
+        orCounts=or_counts,
+        specTitles=spec_titles,
+    )
+
+
+async def _refresh_filter_all() -> FilteredPlotsResponse:
+    """Standalone factory for startup prewarm of the unfiltered `filter:all` payload.
+
+    Creates its own DB session so it can be invoked outside the request
+    cycle (e.g. by the lifespan prewarm hook in api/main.py).
+    """
+    async with get_db_context() as fresh_db:
+        return await _build_filtered_plots(fresh_db, [])
+
+
 @router.get("/plots/filter", response_model=FilteredPlotsResponse)
 async def get_filtered_plots(
     request: Request,
@@ -434,50 +493,7 @@ async def get_filtered_plots(
     cache_k = _build_cache_key(filter_groups)
 
     async def _fetch_filtered() -> FilteredPlotsResponse:
-        try:
-            repo = SpecRepository(db)
-            all_specs = await repo.get_all()
-        except SQLAlchemyError as e:
-            logger.error("Database query failed in get_filtered_plots: %s", e)
-            raise DatabaseQueryError("fetch_specs", str(e)) from e
-
-        spec_lookup = _build_spec_lookup(all_specs)
-        impl_lookup = _build_impl_lookup(all_specs)
-        all_images = _collect_all_images(all_specs)
-        spec_titles = {spec_id: data["spec"].title for spec_id, data in spec_lookup.items() if data["spec"].title}
-
-        global_counts = _calculate_global_counts(all_specs)
-
-        # Fast path for the unfiltered request (e.g. the /specs page list and
-        # the initial /plots load). With no filter groups, `filtered_images`
-        # equals `all_images`, `counts` equals `global_counts`, and `or_counts`
-        # is empty — so skip the two O(images × categories) recomputations
-        # that would otherwise dominate the cold-cache `filter:all` response.
-        if not filter_groups:
-            return FilteredPlotsResponse(
-                total=len(all_images),
-                images=all_images,
-                counts=global_counts,
-                globalCounts=global_counts,
-                orCounts=[],
-                specTitles=spec_titles,
-            )
-
-        spec_id_to_tags = {spec_id: spec_data["tags"] for spec_id, spec_data in spec_lookup.items()}
-
-        filtered_images = _filter_images(all_images, filter_groups, spec_lookup, impl_lookup)
-
-        counts = _calculate_contextual_counts(filtered_images, spec_id_to_tags, impl_lookup)
-        or_counts = _calculate_or_counts(filter_groups, all_images, spec_id_to_tags, spec_lookup, impl_lookup)
-
-        return FilteredPlotsResponse(
-            total=len(filtered_images),
-            images=filtered_images,
-            counts=counts,
-            globalCounts=global_counts,
-            orCounts=or_counts,
-            specTitles=spec_titles,
-        )
+        return await _build_filtered_plots(db, filter_groups)
 
     # get_or_set_cache provides stampede lock (no refresh_after — too many filter key variants)
     cached = await get_or_set_cache(cache_k, _fetch_filtered)

--- a/app/src/pages/PlotsPage.test.tsx
+++ b/app/src/pages/PlotsPage.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { render, screen } from 'src/test-utils';
+import { fireEvent, render, screen } from 'src/test-utils';
+
+const { mockHandleRandom } = vi.hoisted(() => ({ mockHandleRandom: vi.fn() }));
 
 vi.mock('src/hooks', () => ({
   useAnalytics: () => ({ trackPageview: vi.fn(), trackEvent: vi.fn() }),
@@ -22,7 +24,7 @@ vi.mock('src/hooks', () => ({
     handleAddValueToGroup: vi.fn(),
     handleRemoveFilter: vi.fn(),
     handleRemoveGroup: vi.fn(),
-    handleRandom: vi.fn(),
+    handleRandom: mockHandleRandom,
     randomAnimation: null,
   }),
   isFiltersEmpty: (f: unknown[]) => !f || f.length === 0,
@@ -70,6 +72,34 @@ describe('PlotsPage', () => {
   it('renders Helmet for SEO', () => {
     render(<PlotsPage />);
     expect(screen.getByTestId('helmet')).toBeInTheDocument();
+  });
+
+  describe('global keyboard shortcuts', () => {
+    it('triggers random navigation on Space when nothing interactive is focused', () => {
+      render(<PlotsPage />);
+      fireEvent.keyDown(document.body, { key: ' ' });
+      expect(mockHandleRandom).toHaveBeenCalledWith('space');
+    });
+
+    it('does not fire when a focusable card owns the keystroke', () => {
+      render(<PlotsPage />);
+      const card = document.createElement('div');
+      card.setAttribute('role', 'button');
+      card.tabIndex = 0;
+      document.body.appendChild(card);
+      fireEvent.keyDown(card, { key: ' ' });
+      expect(mockHandleRandom).not.toHaveBeenCalled();
+      card.remove();
+    });
+
+    it('does not fire when a native button owns the keystroke', () => {
+      render(<PlotsPage />);
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+      fireEvent.keyDown(button, { key: ' ' });
+      expect(mockHandleRandom).not.toHaveBeenCalled();
+      button.remove();
+    });
   });
 
   describe('scrollRestoration', () => {

--- a/app/src/pages/PlotsPage.test.tsx
+++ b/app/src/pages/PlotsPage.test.tsx
@@ -87,18 +87,24 @@ describe('PlotsPage', () => {
       card.setAttribute('role', 'button');
       card.tabIndex = 0;
       document.body.appendChild(card);
-      fireEvent.keyDown(card, { key: ' ' });
-      expect(mockHandleRandom).not.toHaveBeenCalled();
-      card.remove();
+      try {
+        fireEvent.keyDown(card, { key: ' ' });
+        expect(mockHandleRandom).not.toHaveBeenCalled();
+      } finally {
+        card.remove();
+      }
     });
 
     it('does not fire when a native button owns the keystroke', () => {
       render(<PlotsPage />);
       const button = document.createElement('button');
       document.body.appendChild(button);
-      fireEvent.keyDown(button, { key: ' ' });
-      expect(mockHandleRandom).not.toHaveBeenCalled();
-      button.remove();
+      try {
+        fireEvent.keyDown(button, { key: ' ' });
+        expect(mockHandleRandom).not.toHaveBeenCalled();
+      } finally {
+        button.remove();
+      }
     });
   });
 

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -149,11 +149,13 @@ export function PlotsPage() {
   // Global keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
       // A focused interactive element owns the keystroke — without this
       // guard, Space/Enter on a focused card, chip, or toggle fires both
       // the element's own handler and these global shortcuts.
-      if (target.closest?.('input, textarea, select, button, a, [role="button"], [tabindex]'))
+      if (
+        e.target instanceof Element &&
+        e.target.closest('input, textarea, select, button, a, [role="button"], [tabindex]')
+      )
         return;
 
       if (e.key === ' ') {

--- a/app/src/pages/PlotsPage.tsx
+++ b/app/src/pages/PlotsPage.tsx
@@ -150,7 +150,11 @@ export function PlotsPage() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+      // A focused interactive element owns the keystroke — without this
+      // guard, Space/Enter on a focused card, chip, or toggle fires both
+      // the element's own handler and these global shortcuts.
+      if (target.closest?.('input, textarea, select, button, a, [role="button"], [tabindex]'))
+        return;
 
       if (e.key === ' ') {
         e.preventDefault();

--- a/tests/unit/api/test_main.py
+++ b/tests/unit/api/test_main.py
@@ -369,10 +369,12 @@ class TestPrewarmCache:
     Each Cloud Run instance has its own in-memory cache; without prewarm,
     the first request to a fresh instance pays the full DB roundtrip and
     the user-visible NumbersStrip + /specs page sit on placeholders. The
-    hook populates the four metadata caches before the app starts serving.
+    hook populates the four metadata caches plus the two heavy user-facing
+    payloads (unfiltered gallery `filter:all` and /specs/map) before the
+    app starts serving.
     """
 
-    async def test_prewarm_populates_all_four_caches(self) -> None:
+    async def test_prewarm_populates_all_caches(self) -> None:
         from api.main import _prewarm_cache
 
         with (
@@ -380,6 +382,8 @@ class TestPrewarmCache:
             patch("api.main._refresh_libraries", new=AsyncMock(return_value="LIBS")) as m_libs,
             patch("api.main._refresh_languages", new=AsyncMock(return_value="LANGS")) as m_langs,
             patch("api.main._refresh_specs_list", new=AsyncMock(return_value="SPECS")) as m_specs,
+            patch("api.main._refresh_specs_map", new=AsyncMock(return_value="MAP")) as m_map,
+            patch("api.main._refresh_filter_all", new=AsyncMock(return_value="FILTER")) as m_filter,
             patch("api.main.set_cache") as m_set,
         ):
             await _prewarm_cache()
@@ -388,9 +392,11 @@ class TestPrewarmCache:
         m_libs.assert_awaited_once()
         m_langs.assert_awaited_once()
         m_specs.assert_awaited_once()
+        m_map.assert_awaited_once()
+        m_filter.assert_awaited_once()
 
         cached_keys = {call.args[0] for call in m_set.call_args_list}
-        assert cached_keys == {"stats", "libraries", "languages", "specs_list"}
+        assert cached_keys == {"stats", "libraries", "languages", "specs_list", "specs_map", "filter:all"}
 
     async def test_prewarm_swallows_one_failure_and_continues(self) -> None:
         """A failing factory must not abort the remaining prewarms — those
@@ -402,6 +408,8 @@ class TestPrewarmCache:
             patch("api.main._refresh_libraries", new=AsyncMock(return_value="LIBS")) as m_libs,
             patch("api.main._refresh_languages", new=AsyncMock(return_value="LANGS")) as m_langs,
             patch("api.main._refresh_specs_list", new=AsyncMock(return_value="SPECS")) as m_specs,
+            patch("api.main._refresh_specs_map", new=AsyncMock(return_value="MAP")) as m_map,
+            patch("api.main._refresh_filter_all", new=AsyncMock(return_value="FILTER")) as m_filter,
             patch("api.main.set_cache") as m_set,
         ):
             await _prewarm_cache()  # must not raise
@@ -409,5 +417,15 @@ class TestPrewarmCache:
         m_libs.assert_awaited_once()
         m_langs.assert_awaited_once()
         m_specs.assert_awaited_once()
+        m_map.assert_awaited_once()
+        m_filter.assert_awaited_once()
         cached_keys = {call.args[0] for call in m_set.call_args_list}
-        assert cached_keys == {"libraries", "languages", "specs_list"}
+        assert cached_keys == {"libraries", "languages", "specs_list", "specs_map", "filter:all"}
+
+    async def test_prewarm_filter_all_key_matches_endpoint_cache_key(self) -> None:
+        """The prewarm must write the exact key the /plots/filter endpoint
+        reads for the unfiltered request — a drifted key would silently
+        turn the prewarm into dead work."""
+        from api.routers.plots import _build_cache_key
+
+        assert _build_cache_key([]) == "filter:all"


### PR DESCRIPTION
## Summary
- **Keyboard-shortcut guard on `/plots`** (audit 2026-07-08 Quick Win 1 / High#1): the window-level Space/Enter/Backspace handler now bails out when the keystroke targets an interactive element (`input, textarea, select, button, a, [role="button"], [tabindex]`). Previously, Space on a focused card/toggle double-fired the element's own handler *and* the random-plot shortcut, and Enter on a focused card hijacked focus into the search input instead of activating the card.
- **Gallery cold path prewarmed** (audit 2026-07-08 Quick Win 2 / High#2): the startup `_prewarm_cache()` hook now also computes `/plots/filter` (`filter:all`) and `/specs/map` — the two heaviest user-facing payloads — so the first visitor of a fresh Cloud Run instance no longer pays the full DB roundtrip. The filter fetch logic is extracted from the endpoint closure into `_build_filtered_plots()` + a standalone `_refresh_filter_all()` factory with its own DB session (same pattern as `_refresh_specs_list`).
- Extended the prewarm unit tests to the six-entry refresher tuple and added a guard test asserting the prewarm key matches the endpoint's `_build_cache_key([])`, plus three new PlotsPage tests covering the shortcut guard.

## Plan
agentic/audits/2026-07-08-product-ux.md (Quick Wins 1+2)

## Test plan
- [x] `yarn test` (PlotsPage suite 7/7), `yarn type-check`, `yarn lint`, `yarn fm:check`, `yarn build` — green
- [x] `uv run ruff check` + `format --check`, `mypy api core`, `pytest tests/unit tests/integration` (1578 passed) — green
- [x] Live API: startup log shows all six `Cache prewarm: … OK` entries; warm `/plots/filter` answers in ~40 ms (2.3 MB), `/specs/map` in ~7 ms; filtered request (`?lib=matplotlib`) payload shape unchanged
- [x] Browser (dev server): Space on body → random filter fires; Backspace → filter group removed; Space on focused size-toggle → only the toggle switches, no random jump; Enter on focused card → navigates to that card's spec page