### PR TITLE
feat: enrich bot-served HTML with code, JSON-LD, and internal links

### DIFF
--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -63,7 +63,7 @@ jobs:
           # Bot path: prerendered per-route HTML from the seo-proxy
           check "$GOOGLEBOT"  "$ORIGIN/"                                "<title>anyplot.ai</title>"
           check "$GOOGLEBOT"  "$ORIGIN/scatter-basic"                   "<title>Basic Scatter Plot | anyplot.ai</title>"
-          check "$TWITTERBOT" "$ORIGIN/scatter-basic/python/matplotlib" "<title>Basic Scatter Plot - matplotlib | anyplot.ai</title>"
+          check "$TWITTERBOT" "$ORIGIN/scatter-basic/python/matplotlib" "<title>Basic Scatter Plot - Matplotlib | anyplot.ai</title>"
 
           # llms.txt must be served directly, never proxied to the seo backend
           check "$GOOGLEBOT" "$ORIGIN/llms.txt" "# anyplot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Changed
+
+- **Bot-served pages now carry the site's actual content** — the crawler-facing HTML
+  (`/seo-proxy/*`, what Googlebot & social bots see) grows from a title+description shell to a
+  real document: spec hubs list and link every implementation, implementation pages embed the
+  full source in a `<pre>` block plus hub/sibling links, both carry the preview image and
+  JSON-LD (`BreadcrumbList`, `ItemList`, `SoftwareSourceCode`), and every bot page ends with a
+  site-wide nav. Display names derive from `core/constants.py`, never hand-maintained (audit
+  2026-07-08 High#6).
+
 ### Added
 
 - **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   full source in a `<pre>` block plus hub/sibling links, both carry the preview image and
   JSON-LD (`BreadcrumbList`, `ItemList`, `SoftwareSourceCode`), and every bot page ends with a
   site-wide nav. Display names derive from `core/constants.py`, never hand-maintained (audit
-  2026-07-08 High#6).
+  2026-07-08 High#6) (#9621).
 
 ### Added
 

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -1,6 +1,7 @@
 """SEO endpoints (sitemap, bot-optimized pages)."""
 
 import html
+import json
 import re
 from datetime import datetime
 from urllib.parse import quote, urlparse
@@ -12,8 +13,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.cache import cache_key, get_cache, get_or_set_cache, set_cache
 from api.dependencies import optional_db
 from core.config import settings
-from core.database import SpecRepository
+from core.constants import LANGUAGES_METADATA, LIBRARIES_METADATA
+from core.database import ImplRepository, SpecRepository
 from core.database.connection import get_db_context
+from core.utils import strip_noqa_comments
 
 
 router = APIRouter(tags=["seo"])
@@ -85,7 +88,9 @@ async def _refresh_sitemap() -> str:
     return _build_sitemap_xml(specs)
 
 
-# Minimal HTML template for social media bots (meta tags are what matters)
+# HTML template for search/social crawlers. Meta tags drive social previews;
+# the {body} slot carries what search engines index (headings, code, links,
+# JSON-LD) — an empty body reads as a thin page and wastes the crawl.
 BOT_HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -102,15 +107,206 @@ BOT_HTML_TEMPLATE = """<!DOCTYPE html>
     <meta name="twitter:title" content="{title}" />
     <meta name="twitter:description" content="{description}" />
     <meta name="twitter:image" content="{image}" />
-    <link rel="canonical" href="{url}" />
+    <link rel="canonical" href="{url}" />{jsonld}
 </head>
-<body><h1>{title}</h1><p>{description}</p></body>
+<body>
+{body}
+</body>
 </html>"""
 
 # Route through API for tracking (was: anyplot.ai/og-image.png)
 DEFAULT_HOME_IMAGE = "https://api.anyplot.ai/og/home.png"
 DEFAULT_PLOTS_IMAGE = "https://api.anyplot.ai/og/plots.png"
 DEFAULT_DESCRIPTION = "library-agnostic, ai-powered plotting."
+
+# Display names derived from the canonical registry — never hand-maintain
+# name maps in routers (that is how the 9-library-era drift happened).
+_LANGUAGE_NAMES = {lang["id"]: str(lang["name"]) for lang in LANGUAGES_METADATA}
+_LIBRARY_NAMES = {lib["id"]: str(lib["name"]) for lib in LIBRARIES_METADATA}
+
+# Site-wide footer nav on every bot page: crawlers that land deep on an impl
+# page can reach the hub surfaces without executing the SPA.
+_BOT_NAV_HTML = (
+    "<nav>"
+    '<a href="https://anyplot.ai/">anyplot.ai</a> · '
+    '<a href="https://anyplot.ai/plots">plots</a> · '
+    '<a href="https://anyplot.ai/specs">specs</a> · '
+    '<a href="https://anyplot.ai/libraries">libraries</a> · '
+    '<a href="https://anyplot.ai/map">map</a> · '
+    '<a href="https://anyplot.ai/palette">palette</a> · '
+    '<a href="https://anyplot.ai/mcp">mcp</a> · '
+    '<a href="https://anyplot.ai/stats">stats</a> · '
+    '<a href="https://anyplot.ai/about">about</a>'
+    "</nav>"
+)
+
+
+def _jsonld_script(payload: dict) -> str:
+    """Serialize a JSON-LD payload into a <script> element for the template head.
+
+    `</` is emitted as `\\u003c/` so DB-sourced text (titles, descriptions)
+    can never close the script element early; the escape is plain JSON and
+    parses back to the identical string.
+    """
+    body = json.dumps(payload, ensure_ascii=False).replace("</", "\\u003c/")
+    return f'\n    <script type="application/ld+json">{body}</script>'
+
+
+def _render_bot_html(
+    *, title: str, description: str, image: str, url: str, body: str = "", jsonld: dict | None = None
+) -> str:
+    """Render a bot-serving page.
+
+    ``title``, ``description``, ``url`` and ``body`` must arrive HTML-escaped
+    (same contract the bare template had); ``jsonld`` takes raw values —
+    ``json.dumps`` handles its quoting.
+    """
+    return BOT_HTML_TEMPLATE.format(
+        title=title,
+        description=description,
+        image=image,
+        url=url,
+        jsonld=_jsonld_script(jsonld) if jsonld else "",
+        body=f"{body or f'<h1>{title}</h1><p>{description}</p>'}\n{_BOT_NAV_HTML}",
+    )
+
+
+def _impl_display_names(impl) -> tuple[str, str]:
+    """(library display name, language display name) for an impl, falling back to raw ids."""
+    language_id = impl.library.language if impl.library else ""
+    return _LIBRARY_NAMES.get(impl.library_id, impl.library_id), _LANGUAGE_NAMES.get(language_id, language_id)
+
+
+def _sorted_impls(spec) -> list:
+    """Impls with a loaded library relation, in stable (language, library) order."""
+    return sorted((i for i in spec.impls if i.library), key=lambda i: (i.library.language, i.library_id))
+
+
+def _build_spec_hub_html(spec, image: str) -> str:
+    """Full bot page for the cross-language spec hub /{spec_id}.
+
+    Body carries the preview image and one link per implementation page;
+    JSON-LD carries BreadcrumbList + ItemList so the hub↔impl structure is
+    machine-readable.
+    """
+    spec_id_esc = html.escape(spec.id)
+    title_esc = html.escape(spec.title)
+    desc_esc = html.escape(spec.description or DEFAULT_DESCRIPTION)
+    image_esc = html.escape(image, quote=True)
+    hub_url = f"https://anyplot.ai/{spec.id}"
+
+    impl_links = []
+    impl_list_items = []
+    for position, impl in enumerate(_sorted_impls(spec), start=1):
+        lib_name, lang_name = _impl_display_names(impl)
+        impl_url = f"{hub_url}/{impl.library.language}/{impl.library_id}"
+        impl_links.append(
+            f'<li><a href="{html.escape(impl_url, quote=True)}">'
+            f"{title_esc} in {html.escape(lib_name)} ({html.escape(lang_name)})</a></li>"
+        )
+        impl_list_items.append(
+            {"@type": "ListItem", "position": position, "name": f"{spec.title} — {lib_name}", "url": impl_url}
+        )
+
+    body = (
+        f"<h1>{title_esc}</h1>"
+        f"<p>{desc_esc}</p>"
+        f'<img src="{image_esc}" alt="{title_esc}" width="1200" height="630" />'
+        + (f"<h2>Implementations</h2><ul>{''.join(impl_links)}</ul>" if impl_links else "")
+    )
+    jsonld = {
+        "@context": "https://schema.org",
+        "@graph": [
+            {
+                "@type": "BreadcrumbList",
+                "itemListElement": [
+                    {"@type": "ListItem", "position": 1, "name": "anyplot.ai", "item": "https://anyplot.ai/"},
+                    {"@type": "ListItem", "position": 2, "name": spec.title, "item": hub_url},
+                ],
+            },
+            {"@type": "ItemList", "name": spec.title, "itemListElement": impl_list_items},
+        ],
+    }
+    return _render_bot_html(
+        title=f"{title_esc} | anyplot.ai",
+        description=desc_esc,
+        image=image_esc,
+        url=f"https://anyplot.ai/{spec_id_esc}",
+        body=body,
+        jsonld=jsonld,
+    )
+
+
+def _build_impl_html(spec, impl, code: str | None, image: str) -> str:
+    """Full bot page for an implementation detail /{spec_id}/{language}/{library}.
+
+    Body carries the preview image, the implementation source in a <pre>
+    block, and hub + sibling links; JSON-LD carries BreadcrumbList +
+    SoftwareSourceCode.
+    """
+    language_id = impl.library.language
+    lib_name, lang_name = _impl_display_names(impl)
+    title_esc = html.escape(spec.title)
+    lib_name_esc = html.escape(lib_name)
+    desc_esc = html.escape(spec.description or DEFAULT_DESCRIPTION)
+    image_esc = html.escape(image, quote=True)
+    hub_url = f"https://anyplot.ai/{spec.id}"
+    page_url = f"{hub_url}/{language_id}/{impl.library_id}"
+
+    sibling_links = []
+    for sibling in _sorted_impls(spec):
+        if sibling.library_id == impl.library_id and sibling.library.language == language_id:
+            continue
+        sib_lib_name, sib_lang_name = _impl_display_names(sibling)
+        sibling_url = f"{hub_url}/{sibling.library.language}/{sibling.library_id}"
+        sibling_links.append(
+            f'<li><a href="{html.escape(sibling_url, quote=True)}">'
+            f"{title_esc} in {html.escape(sib_lib_name)} ({html.escape(sib_lang_name)})</a></li>"
+        )
+
+    body = (
+        f"<h1>{title_esc} — {lib_name_esc}</h1>"
+        f"<p>{desc_esc}</p>"
+        f'<img src="{image_esc}" alt="{title_esc} rendered with {lib_name_esc}" width="1200" height="630" />'
+        + (
+            f"<h2>{html.escape(lang_name)} source ({lib_name_esc})</h2><pre><code>{html.escape(code)}</code></pre>"
+            if code
+            else ""
+        )
+        + f'<p>Part of <a href="{html.escape(hub_url, quote=True)}">{title_esc}</a> on anyplot.ai.</p>'
+        + (f"<h2>Other implementations</h2><ul>{''.join(sibling_links)}</ul>" if sibling_links else "")
+    )
+    jsonld = {
+        "@context": "https://schema.org",
+        "@graph": [
+            {
+                "@type": "BreadcrumbList",
+                "itemListElement": [
+                    {"@type": "ListItem", "position": 1, "name": "anyplot.ai", "item": "https://anyplot.ai/"},
+                    {"@type": "ListItem", "position": 2, "name": spec.title, "item": hub_url},
+                    {"@type": "ListItem", "position": 3, "name": lib_name, "item": page_url},
+                ],
+            },
+            {
+                "@type": "SoftwareSourceCode",
+                "name": f"{spec.title} — {lib_name}",
+                "description": spec.description or DEFAULT_DESCRIPTION,
+                "programmingLanguage": lang_name,
+                "runtimePlatform": lib_name,
+                "codeSampleType": "full solution",
+                "url": page_url,
+                "image": image,
+            },
+        ],
+    }
+    return _render_bot_html(
+        title=f"{title_esc} - {lib_name_esc} | anyplot.ai",
+        description=desc_esc,
+        image=image_esc,
+        url=html.escape(page_url, quote=True),
+        body=body,
+        jsonld=jsonld,
+    )
 
 
 @router.get("/robots.txt")
@@ -165,7 +361,7 @@ async def seo_home(request: Request):
     page_url = f"https://anyplot.ai/?{query_string}" if query_string else "https://anyplot.ai/"
 
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(title="anyplot.ai", description=DEFAULT_DESCRIPTION, image=image_url, url=page_url)
+        _render_bot_html(title="anyplot.ai", description=DEFAULT_DESCRIPTION, image=image_url, url=page_url)
     )
 
 
@@ -173,7 +369,7 @@ async def seo_home(request: Request):
 async def seo_plots():
     """Bot-optimized plots page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="plots | anyplot.ai",
             description="Browse and filter visualization examples across 15 libraries in Python, R, Julia, and JavaScript: matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, lets-plot, ggplot2, Makie.jl, Chart.js, D3.js, ECharts, Highcharts, MUI X Charts.",
             image=DEFAULT_PLOTS_IMAGE,
@@ -186,7 +382,7 @@ async def seo_plots():
 async def seo_specs():
     """Bot-optimized specs page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="specs | anyplot.ai",
             description="Browse all Python plotting specifications alphabetically.",
             image=DEFAULT_PLOTS_IMAGE,
@@ -199,7 +395,7 @@ async def seo_specs():
 async def seo_libraries():
     """Bot-optimized libraries page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="libraries | anyplot.ai",
             description="All supported plotting libraries across languages.",
             image=DEFAULT_PLOTS_IMAGE,
@@ -212,7 +408,7 @@ async def seo_libraries():
 async def seo_legal():
     """Bot-optimized legal page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="Legal | anyplot.ai",
             description="Legal notice, privacy policy, and transparency information for anyplot.ai",
             image=DEFAULT_HOME_IMAGE,
@@ -225,7 +421,7 @@ async def seo_legal():
 async def seo_mcp():
     """Bot-optimized MCP page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="MCP Server | anyplot.ai",
             description="Connect your AI assistant to anyplot via the Model Context Protocol (MCP).",
             image=DEFAULT_HOME_IMAGE,
@@ -238,7 +434,7 @@ async def seo_mcp():
 async def seo_about():
     """Bot-optimized about page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="About | anyplot.ai",
             description="About anyplot.ai — library-agnostic, AI-powered plotting.",
             image=DEFAULT_HOME_IMAGE,
@@ -251,7 +447,7 @@ async def seo_about():
 async def seo_palette():
     """Bot-optimized palette page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="imprint palette | anyplot.ai",
             description="Imprint — a colorblind-safe categorical palette of 8 hues plus 3 semantic anchors (amber, neutral, muted). Tuned for warm-paper rendering, validated against deuteranopia / protanopia / tritanopia. The palette every plot on anyplot.ai uses.",
             image=DEFAULT_HOME_IMAGE,
@@ -264,7 +460,7 @@ async def seo_palette():
 async def seo_map():
     """Bot-optimized network map page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="Network Map | anyplot.ai",
             description=(
                 "Interactive network map of plot specifications grouped by visual similarity — "
@@ -280,7 +476,7 @@ async def seo_map():
 async def seo_stats():
     """Bot-optimized stats page with correct og:tags."""
     return HTMLResponse(
-        BOT_HTML_TEMPLATE.format(
+        _render_bot_html(
             title="Stats | anyplot.ai",
             description="Platform statistics: library scores, coverage, tags, and top implementations.",
             image=DEFAULT_HOME_IMAGE,
@@ -299,7 +495,7 @@ async def seo_spec_hub(spec_id: str, db: AsyncSession | None = Depends(optional_
     """Bot-optimized cross-language spec hub."""
     if db is None:
         return HTMLResponse(
-            BOT_HTML_TEMPLATE.format(
+            _render_bot_html(
                 title=f"{html.escape(spec_id)} | anyplot.ai",
                 description=DEFAULT_DESCRIPTION,
                 image=DEFAULT_HOME_IMAGE,
@@ -320,12 +516,7 @@ async def seo_spec_hub(spec_id: str, db: AsyncSession | None = Depends(optional_
     has_previews = any(i.preview_url for i in spec.impls)
     image = f"https://api.anyplot.ai/og/{spec_id}.png" if has_previews else DEFAULT_HOME_IMAGE
 
-    result = BOT_HTML_TEMPLATE.format(
-        title=f"{html.escape(spec.title)} | anyplot.ai",
-        description=html.escape(spec.description or DEFAULT_DESCRIPTION),
-        image=html.escape(image, quote=True),
-        url=f"https://anyplot.ai/{html.escape(spec_id)}",
-    )
+    result = _build_spec_hub_html(spec, image)
     set_cache(key, result)
     return HTMLResponse(result)
 
@@ -365,7 +556,7 @@ async def seo_spec_implementation(
     """Bot-optimized implementation detail."""
     if db is None:
         return HTMLResponse(
-            BOT_HTML_TEMPLATE.format(
+            _render_bot_html(
                 title=f"{html.escape(spec_id)} - {html.escape(library)} | anyplot.ai",
                 description=DEFAULT_DESCRIPTION,
                 image=DEFAULT_HOME_IMAGE,
@@ -392,11 +583,18 @@ async def seo_spec_implementation(
         else DEFAULT_HOME_IMAGE
     )
 
-    result = BOT_HTML_TEMPLATE.format(
-        title=f"{html.escape(spec.title)} - {html.escape(library)} | anyplot.ai",
-        description=html.escape(spec.description or DEFAULT_DESCRIPTION),
-        image=html.escape(image, quote=True),
-        url=f"https://anyplot.ai/{html.escape(spec_id)}/{html.escape(language)}/{html.escape(library)}",
-    )
+    if impl:
+        code_impl = await ImplRepository(db).get_code(spec_id, library, language)
+        code = strip_noqa_comments(code_impl.code) if code_impl and code_impl.code else None
+        result = _build_impl_html(spec, impl, code, image)
+    else:
+        # Unknown language/library combination for a real spec: keep serving
+        # the minimal meta-only page (bots may hold stale URLs after regens).
+        result = _render_bot_html(
+            title=f"{html.escape(spec.title)} - {html.escape(library)} | anyplot.ai",
+            description=html.escape(spec.description or DEFAULT_DESCRIPTION),
+            image=html.escape(image, quote=True),
+            url=f"https://anyplot.ai/{html.escape(spec_id)}/{html.escape(language)}/{html.escape(library)}",
+        )
     set_cache(key, result)
     return HTMLResponse(result)

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -157,9 +157,14 @@ def _render_bot_html(
 ) -> str:
     """Render a bot-serving page.
 
-    ``title``, ``description``, ``url`` and ``body`` must arrive HTML-escaped
-    (same contract the bare template had); ``jsonld`` takes raw values —
-    ``json.dumps`` handles its quoting.
+    Contract per argument:
+    - ``title``, ``description``, ``image``, ``url``: text/URL values that
+      must arrive HTML-escaped (same contract the bare template had).
+    - ``body``: a trusted, fully-built HTML fragment inserted verbatim (plus
+      the site nav). Callers must escape any DB-sourced text BEFORE
+      interpolating it into the fragment.
+    - ``jsonld``: raw (unescaped) values; ``json.dumps`` handles quoting and
+      ``_jsonld_script`` neutralizes ``</``.
     """
     return BOT_HTML_TEMPLATE.format(
         title=title,

--- a/docs/reference/seo.md
+++ b/docs/reference/seo.md
@@ -145,7 +145,11 @@ Backend endpoints that serve HTML with correct meta tags for bots.
 
 ### HTML Template
 
-All SEO proxy endpoints return minimal HTML with meta tags:
+All SEO proxy endpoints share one template (`BOT_HTML_TEMPLATE` + `_render_bot_html()`):
+the `<head>` carries the meta/OG/Twitter tags plus an optional JSON-LD script, and the
+`<body>` carries what search engines actually index. Every page ends with a site-wide
+`<nav>` (home, plots, specs, libraries, map, palette, mcp, stats, about) so crawlers
+landing deep can walk the site without executing the SPA.
 
 ```html
 <!DOCTYPE html>
@@ -165,10 +169,25 @@ All SEO proxy endpoints return minimal HTML with meta tags:
     <meta name="twitter:description" content="{description}" />
     <meta name="twitter:image" content="{image}" />
     <link rel="canonical" href="{url}" />
+    {jsonld}
 </head>
-<body><h1>{title}</h1><p>{description}</p></body>
+<body>
+{body}
+</body>
 </html>
 ```
+
+Per-page body content:
+
+| Page | Body | JSON-LD |
+|------|------|---------|
+| Static pages (`/`, `/plots`, …) | `<h1>` + description + nav | — |
+| Spec hub `/{spec_id}` | description, preview `<img>`, one link per implementation page | `BreadcrumbList` + `ItemList` |
+| Implementation `/{spec_id}/{language}/{library}` | description, preview `<img>`, full source in `<pre><code>` (noqa-stripped, HTML-escaped), hub link, sibling-implementation links | `BreadcrumbList` + `SoftwareSourceCode` |
+
+Display names (Matplotlib, Makie.jl, Apache ECharts, …) are derived from
+`core/constants.py` (`LANGUAGES_METADATA` / `LIBRARIES_METADATA`) — never
+hand-maintained in the router.
 
 ## Branded OG Images
 

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -740,8 +740,15 @@ class TestSeoProxyRouter:
 
         mock_spec_repo = MagicMock()
         mock_spec_repo.get_by_id = AsyncMock(return_value=mock_spec)
+        mock_code_impl = MagicMock()
+        mock_code_impl.code = "import matplotlib.pyplot as plt"
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_code = AsyncMock(return_value=mock_code_impl)
 
-        with patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo):
+        with (
+            patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.seo.ImplRepository", return_value=mock_impl_repo),
+        ):
             response = client.get("/seo-proxy/scatter-basic/python/matplotlib")
             assert response.status_code == 200
             assert "Basic Scatter Plot" in response.text
@@ -750,6 +757,8 @@ class TestSeoProxyRouter:
             assert "https://anyplot.ai/scatter-basic/python/matplotlib" in response.text
             # Branded OG image URL includes language segment
             assert "api.anyplot.ai/og/scatter-basic/python/matplotlib.png" in response.text
+            # Enriched body carries the implementation source for crawlers
+            assert "<pre><code>import matplotlib.pyplot as plt</code></pre>" in response.text
 
     def test_seo_spec_implementation_not_found(self, db_client) -> None:
         """SEO spec implementation should return 404 when spec not found."""
@@ -782,11 +791,18 @@ class TestSeoProxyRouter:
 
         mock_spec_repo = MagicMock()
         mock_spec_repo.get_by_id = AsyncMock(return_value=mock_spec_no_preview)
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_code = AsyncMock(return_value=None)
 
-        with patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo):
+        with (
+            patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.seo.ImplRepository", return_value=mock_impl_repo),
+        ):
             response = client.get("/seo-proxy/scatter-basic/python/seaborn")
             assert response.status_code == 200
             assert "api.anyplot.ai/og/home.png" in response.text  # Default image via API
+            # No stored code -> no <pre> block, page still renders
+            assert "<pre>" not in response.text
 
     def test_seo_about(self, client: TestClient) -> None:
         """SEO about page should return HTML with og:tags."""

--- a/tests/unit/api/test_seo_helpers.py
+++ b/tests/unit/api/test_seo_helpers.py
@@ -4,10 +4,45 @@ Tests for SEO helper functions.
 Directly tests the pure helper functions in api/routers/seo.py.
 """
 
+import json
+import re
 from datetime import datetime
 from unittest.mock import MagicMock
 
-from api.routers.seo import BOT_HTML_TEMPLATE, _build_sitemap_xml, _lastmod
+from api.routers.seo import (
+    _build_impl_html,
+    _build_sitemap_xml,
+    _build_spec_hub_html,
+    _jsonld_script,
+    _lastmod,
+    _render_bot_html,
+)
+from core.constants import LANGUAGES_METADATA, LIBRARIES_METADATA
+
+
+def _extract_jsonld(page: str) -> dict:
+    """Pull the JSON-LD payload back out of a rendered bot page."""
+    match = re.search(r'<script type="application/ld\+json">(.*?)</script>', page, re.S)
+    assert match, "page has no JSON-LD script"
+    return json.loads(match.group(1))
+
+
+def _mock_impl(library_id: str, language: str, preview: str | None = "https://gcs/preview.png") -> MagicMock:
+    impl = MagicMock()
+    impl.library_id = library_id
+    impl.library = MagicMock()
+    impl.library.language = language
+    impl.preview_url = preview
+    return impl
+
+
+def _mock_spec(impls: list) -> MagicMock:
+    spec = MagicMock()
+    spec.id = "scatter-basic"
+    spec.title = "Basic Scatter Plot"
+    spec.description = "Points on <axes> & friends"
+    spec.impls = impls
+    return spec
 
 
 class TestLastmod:
@@ -183,11 +218,11 @@ class TestBuildSitemapXml:
         assert "<loc>https://anyplot.ai/scatter-basic</loc></url>" in result
 
 
-class TestBotHtmlTemplate:
-    """Tests for the BOT_HTML_TEMPLATE."""
+class TestRenderBotHtml:
+    """Tests for _render_bot_html (the template wrapper every bot route uses)."""
 
-    def test_template_has_required_meta_tags(self) -> None:
-        result = BOT_HTML_TEMPLATE.format(
+    def test_has_required_meta_tags(self) -> None:
+        result = _render_bot_html(
             title="Test Title",
             description="Test Description",
             image="https://example.com/image.png",
@@ -202,8 +237,126 @@ class TestBotHtmlTemplate:
         assert "Test Title" in result
         assert "Test Description" in result
 
-    def test_template_has_canonical(self) -> None:
+    def test_has_canonical(self) -> None:
         url = "https://anyplot.ai/"
-        result = BOT_HTML_TEMPLATE.format(title="t", description="d", image="i", url=url)
+        result = _render_bot_html(title="t", description="d", image="i", url=url)
         assert 'rel="canonical"' in result
         assert url in result
+
+    def test_default_body_and_nav(self) -> None:
+        result = _render_bot_html(title="t", description="d", image="i", url="u")
+        assert "<h1>t</h1><p>d</p>" in result
+        assert '<a href="https://anyplot.ai/plots">plots</a>' in result
+
+    def test_custom_body_replaces_default(self) -> None:
+        result = _render_bot_html(title="t", description="d", image="i", url="u", body="<h1>custom</h1>")
+        assert "<h1>custom</h1>" in result
+        assert "<h1>t</h1>" not in result
+        # nav is still appended after custom bodies
+        assert "<nav>" in result
+
+    def test_body_with_braces_survives_format(self) -> None:
+        """Code bodies contain {braces}; they must not be treated as format fields."""
+        result = _render_bot_html(title="t", description="d", image="i", url="u", body="<pre>d = {'a': 1}</pre>")
+        assert "d = {'a': 1}" in result
+
+    def test_no_jsonld_by_default(self) -> None:
+        result = _render_bot_html(title="t", description="d", image="i", url="u")
+        assert "application/ld+json" not in result
+
+
+class TestJsonldScript:
+    """Tests for _jsonld_script."""
+
+    def test_round_trips_payload(self) -> None:
+        payload = {"@type": "Thing", "name": "scatter"}
+        script = _jsonld_script(payload)
+        assert script.strip().startswith('<script type="application/ld+json">')
+        inner = re.search(r">(.*)</script>", script, re.S).group(1)  # type: ignore[union-attr]
+        assert json.loads(inner) == payload
+
+    def test_script_breakout_is_escaped(self) -> None:
+        """DB-sourced text containing </script> must not close the element early."""
+        payload = {"name": "evil</script><script>alert(1)</script>"}
+        script = _jsonld_script(payload)
+        # the only literal "</" left is the script tag's own closer
+        assert script.count("</") == 1
+        inner = re.search(r">(.*)</script>", script, re.S).group(1)  # type: ignore[union-attr]
+        assert json.loads(inner) == payload
+
+
+class TestBuildSpecHubHtml:
+    """Tests for the enriched cross-language hub page."""
+
+    def test_links_every_impl_and_carries_jsonld(self) -> None:
+        spec = _mock_spec([_mock_impl("matplotlib", "python"), _mock_impl("ggplot2", "r")])
+        page = _build_spec_hub_html(spec, "https://api.anyplot.ai/og/scatter-basic.png")
+
+        assert '<a href="https://anyplot.ai/scatter-basic/python/matplotlib">' in page
+        assert '<a href="https://anyplot.ai/scatter-basic/r/ggplot2">' in page
+        # display names from core.constants, not raw ids
+        assert "in Matplotlib (Python)" in page
+        assert "in ggplot2 (R)" in page
+        # preview image in the body
+        assert '<img src="https://api.anyplot.ai/og/scatter-basic.png"' in page
+        # description is escaped
+        assert "&lt;axes&gt; &amp; friends" in page
+
+        jsonld = _extract_jsonld(page)
+        breadcrumb, item_list = jsonld["@graph"]
+        assert breadcrumb["@type"] == "BreadcrumbList"
+        assert breadcrumb["itemListElement"][1]["item"] == "https://anyplot.ai/scatter-basic"
+        assert item_list["@type"] == "ItemList"
+        assert [i["url"] for i in item_list["itemListElement"]] == [
+            "https://anyplot.ai/scatter-basic/python/matplotlib",
+            "https://anyplot.ai/scatter-basic/r/ggplot2",
+        ]
+
+
+class TestBuildImplHtml:
+    """Tests for the enriched implementation page."""
+
+    def _page(self, code: str | None = "plt.scatter(x, y)  # x < y") -> str:
+        impl = _mock_impl("matplotlib", "python")
+        spec = _mock_spec([impl, _mock_impl("seaborn", "python"), _mock_impl("makie", "julia")])
+        return _build_impl_html(spec, impl, code, "https://api.anyplot.ai/og/scatter-basic/python/matplotlib.png")
+
+    def test_code_block_is_escaped(self) -> None:
+        page = self._page("if x < 2:\n    plot()</script>")
+        assert "<pre><code>if x &lt; 2:\n    plot()&lt;/script&gt;</code></pre>" in page
+
+    def test_links_hub_and_siblings_but_not_self(self) -> None:
+        page = self._page()
+        assert '<a href="https://anyplot.ai/scatter-basic">' in page
+        assert '<a href="https://anyplot.ai/scatter-basic/python/seaborn">' in page
+        assert '<a href="https://anyplot.ai/scatter-basic/julia/makie">' in page
+        assert "in Makie.jl (Julia)" in page
+        assert '<a href="https://anyplot.ai/scatter-basic/python/matplotlib">' not in page
+
+    def test_jsonld_software_source_code(self) -> None:
+        jsonld = _extract_jsonld(self._page())
+        breadcrumb, source = jsonld["@graph"]
+        assert [i["name"] for i in breadcrumb["itemListElement"]] == ["anyplot.ai", "Basic Scatter Plot", "Matplotlib"]
+        assert source["@type"] == "SoftwareSourceCode"
+        assert source["programmingLanguage"] == "Python"
+        assert source["url"] == "https://anyplot.ai/scatter-basic/python/matplotlib"
+
+    def test_no_code_no_pre_block(self) -> None:
+        page = self._page(code=None)
+        assert "<pre>" not in page
+        # page is still enriched otherwise
+        assert '<a href="https://anyplot.ai/scatter-basic">' in page
+
+
+class TestDisplayNameMaps:
+    """The registry-derived name maps must cover the full canonical registry."""
+
+    def test_language_names_cover_registry(self) -> None:
+        from api.routers.seo import _LANGUAGE_NAMES
+
+        assert set(_LANGUAGE_NAMES) == {lang["id"] for lang in LANGUAGES_METADATA}
+
+    def test_library_names_cover_registry(self) -> None:
+        from api.routers.seo import _LIBRARY_NAMES
+
+        assert set(_LIBRARY_NAMES) == {lib["id"] for lib in LIBRARIES_METADATA}


### PR DESCRIPTION
## Summary
- **Enriches the crawler-facing HTML** (audit 2026-07-08 High#6): after the 502 fix (#9617), bots reach the pages again — but `BOT_HTML_TEMPLATE` served only `<h1>{title}</h1><p>{description}</p>`, so the site's actual value (the code) never reached the index. The template gains `{jsonld}` (head) and `{body}` slots behind a `_render_bot_html()` wrapper; all bot routes now end with a site-wide `<nav>`.
- **Spec hubs** (`/seo-proxy/{spec_id}`) list and link every implementation page with registry display names, carry the preview `<img>`, and emit `BreadcrumbList` + `ItemList` JSON-LD.
- **Implementation pages** (`/seo-proxy/{spec_id}/{language}/{library}`) embed the full noqa-stripped source in an HTML-escaped `<pre><code>` block (via `ImplRepository.get_code`, the undeferred-code query), link back to the hub and to all sibling implementations, and emit `BreadcrumbList` + `SoftwareSourceCode` JSON-LD.
- Safety: JSON-LD serialization escapes `</` as `</` so DB-sourced text can never close the script element early; code and all DB text remain HTML-escaped; display names derive from `LANGUAGES_METADATA`/`LIBRARIES_METADATA` in `core/constants.py` — deliberately not another hand-maintained name map (the audit's 15-library-drift theme).
- Docs: `docs/reference/seo.md` template section updated; 20 new/updated unit tests (helpers are pure and directly tested).

## Plan
agentic/audits/2026-07-08-product-ux.md (High#6)

## Test plan
- [x] `uv run ruff check` + `format --check`, `mypy api core`, `pytest tests/unit tests/integration` (1590 passed) — green
- [x] Live API against prod DB: hub page `/seo-proxy/scatter-basic` renders 15 impl links, preview img, nav, parseable JSON-LD (BreadcrumbList + ItemList)
- [x] Live impl page `/seo-proxy/scatter-basic/python/matplotlib`: 9 KB (was ~1.5 KB shell), `<pre><code>` with escaped source, 14 sibling links + hub link, SoftwareSourceCode (`programmingLanguage: Python`)
- [x] Static pages (`/seo-proxy/`, `/seo-proxy/plots`) still render with meta tags + nav
- [ ] After merge: `bot-serving-check.yml` (daily) validates the bot path end-to-end in prod