### PR TITLE
fix: 15-library drift sweep — registry-derived names and copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Fixed
+
+- **15-library drift sweep across secondary surfaces** — four independent audit findings traced
+  to the same root cause: the library expansion never propagated beyond the pipeline.
+  `core/constants.py` now derives `LIBRARY_NAMES`/`LANGUAGE_NAMES` from the canonical registry
+  and `insights.py`/`debug.py` import them instead of hand-written maps (the `/debug` page
+  showed raw ids for all four JS libraries), `app/index.html` meta/OG/Twitter/JSON-LD copy and
+  the landing tagline no longer say "9 python libraries" (now 15 libraries across Python, R,
+  Julia & JavaScript; JSON-LD keywords refreshed, stale okabe-ito reference replaced by the
+  Imprint palette), and `scripts/evaluate-plot.py` dropped its dead Python-era highcharts
+  pattern block and derives the AR-07 static-library set from the registry (audit 2026-07-08
+  Medium#5 + Medium#6 + Low#8).
+
 ### Added
 
 - **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   Julia & JavaScript; JSON-LD keywords refreshed, stale okabe-ito reference replaced by the
   Imprint palette), and `scripts/evaluate-plot.py` dropped its dead Python-era highcharts
   pattern block and derives the AR-07 static-library set from the registry (audit 2026-07-08
-  Medium#5 + Medium#6 + Low#8).
+  Medium#5 + Medium#6 + Low#8) (#9624).
 
 ### Added
 

--- a/api/routers/debug.py
+++ b/api/routers/debug.py
@@ -18,7 +18,7 @@ from api.cache import clear_cache, get_cache_stats
 from api.dependencies import require_db
 from api.exceptions import raise_validation_error
 from core.config import settings
-from core.constants import SUPPORTED_LIBRARIES
+from core.constants import LIBRARY_NAMES, SUPPORTED_LIBRARIES
 from core.database import FEEDBACK_REACTIONS, FEEDBACK_STATUSES, FeedbackRepository, SpecRepository
 
 
@@ -333,27 +333,13 @@ async def get_debug_status(request: Request, db: AsyncSession = Depends(require_
     # Library Statistics
     # ========================================================================
 
-    library_names = {
-        "altair": "Altair",
-        "bokeh": "Bokeh",
-        "ggplot2": "ggplot2",
-        "highcharts": "Highcharts",
-        "letsplot": "lets-plot",
-        "makie": "Makie.jl",
-        "matplotlib": "Matplotlib",
-        "plotly": "Plotly",
-        "plotnine": "plotnine",
-        "pygal": "Pygal",
-        "seaborn": "Seaborn",
-    }
-
     lib_stats: list[LibraryStats] = []
     for lib_id in sorted(SUPPORTED_LIBRARIES):
         scores = library_scores[lib_id]
         lib_stats.append(
             LibraryStats(
                 id=lib_id,
-                name=library_names.get(lib_id, lib_id),
+                name=LIBRARY_NAMES.get(lib_id, lib_id),
                 impl_count=library_counts[lib_id],
                 avg_score=round(sum(scores) / len(scores), 1) if scores else None,
                 min_score=round(min(scores), 1) if scores else None,

--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.cache import cache_key, get_or_set_cache
 from api.dependencies import require_db
 from core.config import settings
-from core.constants import SUPPORTED_LIBRARIES
+from core.constants import LIBRARY_NAMES, SUPPORTED_LIBRARIES
 from core.database import ImplRepository, Spec, SpecRepository
 from core.database.connection import get_db_context
 from core.utils import strip_noqa_comments
@@ -176,24 +176,6 @@ class RelatedSpecsResponse(BaseModel):
 # =============================================================================
 # Shared helpers
 # =============================================================================
-
-LIBRARY_NAMES = {
-    "altair": "Altair",
-    "bokeh": "Bokeh",
-    "chartjs": "Chart.js",
-    "d3": "D3.js",
-    "echarts": "Apache ECharts",
-    "ggplot2": "ggplot2",
-    "highcharts": "Highcharts",
-    "letsplot": "lets-plot",
-    "makie": "Makie.jl",
-    "matplotlib": "Matplotlib",
-    "muix": "MUI X Charts",
-    "plotly": "Plotly",
-    "plotnine": "plotnine",
-    "pygal": "Pygal",
-    "seaborn": "Seaborn",
-}
 
 
 def _score_bucket(score: float) -> str:

--- a/app/index.html
+++ b/app/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript. browse, copy, adapt — colorblind-safe by default." />
-    <meta name="keywords" content="python, plotting, matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot, data visualization, charts, graphs, ai-generated, code examples, colorblind-safe, okabe-ito" />
+    <meta name="description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia &amp; javascript. browse, copy, adapt — colorblind-safe by default." />
+    <meta name="keywords" content="python, r, julia, javascript, plotting, matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, letsplot, ggplot2, makie, chart.js, d3, echarts, highcharts, mui x charts, data visualization, charts, graphs, ai-generated, code examples, colorblind-safe, imprint palette" />
     <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0E0E10" media="(prefers-color-scheme: dark)" />
     <title>any.plot() — any library.</title>
@@ -45,7 +45,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://anyplot.ai/" />
     <meta property="og:title" content="any.plot() — any library." />
-    <meta property="og:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript." />
+    <meta property="og:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia &amp; javascript." />
     <meta property="og:image" content="https://anyplot.ai/og-image.png" />
     <meta property="og:site_name" content="anyplot.ai" />
     <meta property="og:locale" content="en_US" />
@@ -53,7 +53,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="any.plot() — any library." />
-    <meta name="twitter:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript." />
+    <meta name="twitter:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia &amp; javascript." />
     <meta name="twitter:image" content="https://anyplot.ai/og-image.png" />
     <!-- Preconnect to GCS for font loading -->
     <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries. browse, copy, adapt — colorblind-safe by default." />
+    <meta name="description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript. browse, copy, adapt — colorblind-safe by default." />
     <meta name="keywords" content="python, plotting, matplotlib, seaborn, plotly, bokeh, altair, plotnine, pygal, highcharts, letsplot, data visualization, charts, graphs, ai-generated, code examples, colorblind-safe, okabe-ito" />
     <meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0E0E10" media="(prefers-color-scheme: dark)" />
@@ -45,7 +45,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://anyplot.ai/" />
     <meta property="og:title" content="any.plot() — any library." />
-    <meta property="og:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries." />
+    <meta property="og:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript." />
     <meta property="og:image" content="https://anyplot.ai/og-image.png" />
     <meta property="og:site_name" content="anyplot.ai" />
     <meta property="og:locale" content="en_US" />
@@ -53,7 +53,7 @@
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="any.plot() — any library." />
-    <meta name="twitter:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries." />
+    <meta name="twitter:description" content="the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript." />
     <meta name="twitter:image" content="https://anyplot.ai/og-image.png" />
     <!-- Preconnect to GCS for font loading -->
     <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
@@ -74,7 +74,7 @@
       "@type": "WebApplication",
       "name": "anyplot.ai",
       "url": "https://anyplot.ai",
-      "description": "the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 9 python libraries.",
+      "description": "the open plot catalogue. every plot begins as a library-agnostic spec; ai drafts implementations across 15 libraries in python, r, julia & javascript.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Any",
       "offers": {
@@ -87,7 +87,7 @@
         "name": "Markus Neusinger",
         "url": "https://www.linkedin.com/in/markus-neusinger/"
       },
-      "keywords": ["python", "plotting", "matplotlib", "seaborn", "plotly", "bokeh", "altair", "plotnine", "pygal", "highcharts", "letsplot", "data visualization", "code examples", "colorblind-safe", "okabe-ito"],
+      "keywords": ["python", "r", "julia", "javascript", "plotting", "matplotlib", "seaborn", "plotly", "bokeh", "altair", "plotnine", "pygal", "letsplot", "ggplot2", "makie", "chart.js", "d3", "echarts", "highcharts", "mui x charts", "data visualization", "code examples", "colorblind-safe", "imprint palette"],
       "isAccessibleForFree": true
     }
     </script>
@@ -118,7 +118,7 @@
       "name": "anyplot",
       "url": "https://anyplot.ai",
       "logo": "https://anyplot.ai/og-image.png",
-      "description": "Open plot catalogue with AI-generated implementations across 9 Python libraries.",
+      "description": "Open plot catalogue with AI-generated implementations across 15 libraries in Python, R, Julia, and JavaScript.",
       "sameAs": [
         "https://github.com/MarkusNeusinger/anyplot",
         "https://www.linkedin.com/in/markus-neusinger/"

--- a/app/src/pages/LandingPage.tsx
+++ b/app/src/pages/LandingPage.tsx
@@ -41,7 +41,7 @@ export function LandingPage() {
         <title>any.plot() — any library.</title>
         <meta
           name="description"
-          content="any library. get inspired. grab the code. make it yours. human ideas, ai builds the rest. 9 python plotting libraries, colorblind-safe, open source."
+          content="any library. get inspired. grab the code. make it yours. human ideas, ai builds the rest. 15 plotting libraries across python, r, julia & javascript, colorblind-safe, open source."
         />
         <link rel="canonical" href="https://anyplot.ai/" />
       </Helmet>

--- a/core/constants.py
+++ b/core/constants.py
@@ -258,6 +258,13 @@ LIBRARY_FILE_EXTENSION_OVERRIDES = {
     lib["id"]: lib["file_extension"] for lib in LIBRARIES_METADATA if lib.get("file_extension")
 }
 
+# Display names for UI/API surfaces, derived from the canonical registries
+# above. Routers and scripts must import these instead of hand-maintaining
+# name maps — hand-written copies are how the 9-library-era drift happened
+# (audit 2026-07-08: /debug showed raw ids for every JS library).
+LANGUAGE_NAMES = {lang["id"]: str(lang["name"]) for lang in LANGUAGES_METADATA}
+LIBRARY_NAMES = {lib["id"]: str(lib["name"]) for lib in LIBRARIES_METADATA}
+
 # Interactive libraries that generate HTML previews (not just PNG). The
 # browser-rendered JS libraries (Chart.js, D3, ECharts, Highcharts, and the
 # React MUI X entry) render in a browser; the harness emits both a static PNG

--- a/scripts/evaluate-plot.py
+++ b/scripts/evaluate-plot.py
@@ -290,7 +290,7 @@ def check_ar07_format(impl_path: Path, library: str) -> AutoRejectResult:
     # Static libraries must produce .png; interactive ones may also emit HTML.
     # Derived from the registry so a new Python library can't silently drift
     # (this Python-only evaluator never reaches AR-07 for non-Python libs).
-    static_libraries = sorted(set(SUPPORTED_LIBRARIES) - INTERACTIVE_LIBRARIES)
+    static_libraries = set(SUPPORTED_LIBRARIES) - INTERACTIVE_LIBRARIES
 
     plot_png = impl_path.parent / "plot.png"
     plot_html = impl_path.parent / "plot.html"

--- a/scripts/evaluate-plot.py
+++ b/scripts/evaluate-plot.py
@@ -35,11 +35,11 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # Local imports must come AFTER sys.path is patched so the script remains
 # runnable from any working directory (Copilot review: PR #5414).
 from core.config import settings  # noqa: E402
-from core.constants import LANGUAGE_FILE_EXTENSIONS, LIBRARIES_METADATA  # noqa: E402
+from core.constants import INTERACTIVE_LIBRARIES, LANGUAGE_FILE_EXTENSIONS, LIBRARIES_METADATA  # noqa: E402
 
 # This local evaluator only supports Python AST + python-script execution.
-# Non-Python libraries (currently just ggplot2) skip in main() with a clear
-# pointer at the CI workflow.
+# Non-Python libraries (R, Julia, and the browser-rendered JavaScript libs)
+# skip in main() with a clear pointer at the CI workflow.
 SUPPORTED_LIBRARIES = [lib["id"] for lib in LIBRARIES_METADATA if lib["language_id"] == "python"]
 
 # Reverse lookup: library_id -> language_id, used for path resolution and the
@@ -105,14 +105,6 @@ LIBRARY_PATTERNS = {
             "pygal.Bar", "pygal.Line", "pygal.Pie", "pygal.Histogram",
             "pygal.XY", "pygal.Dot", "pygal.Radar", "pygal.Box",
             "pygal.Treemap", "pygal.Gauge", "pygal.StackedBar",
-        ],
-        "style_only": [],
-    },
-    "highcharts": {
-        "import": ["from highcharts", "import highcharts"],
-        "plot_functions": [
-            "Chart(", "Highcharts", "highcharts.Chart",
-            "HighchartsStockChart", "HighchartsMapsChart",
         ],
         "style_only": [],
     },
@@ -295,10 +287,10 @@ def check_ar05_library(impl_path: Path, library: str) -> AutoRejectResult:
 
 def check_ar07_format(impl_path: Path, library: str) -> AutoRejectResult:
     """AR-07: Check if output format is correct."""
-    # Static libraries should produce .png
-    static_libraries = ["matplotlib", "seaborn", "plotnine"]
-    # Interactive libraries can produce .png or .html
-    interactive_libraries = ["plotly", "bokeh", "altair", "pygal", "highcharts", "letsplot"]
+    # Static libraries must produce .png; interactive ones may also emit HTML.
+    # Derived from the registry so a new Python library can't silently drift
+    # (this Python-only evaluator never reaches AR-07 for non-Python libs).
+    static_libraries = sorted(set(SUPPORTED_LIBRARIES) - INTERACTIVE_LIBRARIES)
 
     plot_png = impl_path.parent / "plot.png"
     plot_html = impl_path.parent / "plot.html"


### PR DESCRIPTION
## Summary
- **One sweep closes the audit's cross-auditor theme** ("the 15-library expansion never propagated to secondary surfaces", found independently by four auditors — audit 2026-07-08 Medium#5, Medium#6, Low#8):
  - `core/constants.py` gains `LIBRARY_NAMES` / `LANGUAGE_NAMES`, derived from `LIBRARIES_METADATA` / `LANGUAGES_METADATA`. `api/routers/insights.py` (15-entry hand-written map) and `api/routers/debug.py` (11-entry map missing all four JS libs — `/debug` showed raw ids) now import them. Values are byte-identical to the old insights map, so no payload change for existing entries; `/debug` gains proper names for chartjs/d3/echarts/muix.
  - `app/index.html`: all five "9 python libraries" occurrences (meta description, og:description, twitter:description, WebApplication + Organization JSON-LD) now read "15 libraries in python, r, julia & javascript"; JSON-LD keywords refreshed (adds r/julia/javascript/ggplot2/makie/chart.js/d3/echarts/mui x charts, replaces stale `okabe-ito` with `imprint palette`). `LandingPage.tsx` tagline updated the same way.
  - `scripts/evaluate-plot.py`: the Python-era highcharts pattern block (`from highcharts` imports — dead since the Phase-2 JS migration, and a guaranteed AR-05 false-reject if ever hit) is deleted; the AR-07 static-library set derives from the registry instead of a hardcoded 3-entry list; stale "currently just ggplot2" comment fixed. The evaluator remains deliberately Python-only (non-Python libs skip in `main()`).
- Not touched here: `api/routers/seo.py`'s local name maps from #9621 — switching them to the shared constants is a small follow-up once both PRs are merged (avoids a cross-PR conflict). The Helmet append-vs-replace half of Medium#6 is deferred to the react-helmet removal (Medium#15).

## Plan
agentic/audits/2026-07-08-product-ux.md (Medium#5, Medium#6, Low#8, cross-auditor theme #1)

## Test plan
- [x] `uv run pytest tests/unit` (1510 passed), ruff + mypy clean, `yarn build` + LandingPage tests green
- [x] Live API against prod DB: `/insights/dashboard` payload carries "Apache ECharts", "MUI X Charts", "Chart.js", "Makie.jl"
- [x] Built `dist/index.html`: 4× new copy string, 0× "9 python" anywhere in app/
- [x] `evaluate-plot.py --help` runs; AR-07 static set resolves to {matplotlib, plotnine, seaborn}