### PR TITLE
fix: analytics hygiene — bot shield, /plots pageviews, doc sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   and `/debug` fires a pageview at all. `docs/reference/plausible.md` caught up with the shipped
   product: `/map` + `/debug` pages, `nav_map` source, the previously undocumented
   `library_filter` event with its `framework` prop, and the 15-library value list (audit
-  2026-07-08 High#7 repo-side + Medium#10 + Low#12/#15).
+  2026-07-08 High#7 repo-side + Medium#10 + Low#12/#15) (#9625).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Fixed
+
+- **Analytics hygiene: bots out, /plots visible, docs in sync** — nginx's `/api/event`
+  Plausible proxy now returns 202 (without forwarding) for crawler UAs and headless/automation
+  clients (HeadlessChrome, puppeteer/playwright/selenium, scripted HTTP libraries, empty UA) —
+  the unfiltered synthetic waves inflated visitor counts ~40% and broke trend lines. Pageview
+  URLs keep the real pathname for reserved pages, so `/plots` no longer records as `/` (the
+  site's #2 page was invisible in Plausible; filter paths move from `/lib/x` to `/plots/lib/x`),
+  and `/debug` fires a pageview at all. `docs/reference/plausible.md` caught up with the shipped
+  product: `/map` + `/debug` pages, `nav_map` source, the previously undocumented
+  `library_filter` event with its `framework` prop, and the 15-library value list (audit
+  2026-07-08 High#7 repo-side + Medium#10 + Low#12/#15).
+
 ### Added
 
 - **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -47,6 +47,29 @@ map $http_user_agent $is_bot {
     ~*showyoubot 1;
 }
 
+# Headless/automation clients for the analytics shield below. Distinct from
+# $is_bot (which routes crawlers to prerendered HTML): these are the
+# unfiltered synthetic waves — headless Chrome farms, scraper libraries —
+# that fired real Plausible events and inflated visitor counts ~40%
+# (audit 2026-07-08 High#7). An empty UA is never a real browser.
+map $http_user_agent $is_headless_client {
+    default 0;
+    "" 1;
+    ~*headlesschrome 1;
+    ~*phantomjs 1;
+    ~*puppeteer 1;
+    ~*playwright 1;
+    ~*selenium 1;
+    ~*electron 1;
+    ~*python-requests 1;
+    ~*python-httpx 1;
+    ~*aiohttp 1;
+    ~*go-http-client 1;
+    ~*okhttp 1;
+    ~*(^|\s)curl/ 1;
+    ~*wget/ 1;
+}
+
 server {
     listen 8080 default_server;
     server_name _;
@@ -147,6 +170,12 @@ server {
     }
 
     location = /api/event {
+        # Analytics shield: crawler and headless/automation UAs never reach
+        # Plausible — they inflated visitors ~40% and broke trend lines
+        # (audit 2026-07-08 High#7). 202 mirrors Plausible's accepted
+        # response so clients don't retry.
+        if ($is_bot) { return 202; }
+        if ($is_headless_client) { return 202; }
         proxy_pass https://plausible.io/api/event;
         proxy_set_header Host plausible.io;
         proxy_ssl_server_name on;
@@ -280,6 +309,12 @@ server {
     }
 
     location = /api/event {
+        # Analytics shield: crawler and headless/automation UAs never reach
+        # Plausible — they inflated visitors ~40% and broke trend lines
+        # (audit 2026-07-08 High#7). 202 mirrors Plausible's accepted
+        # response so clients don't retry.
+        if ($is_bot) { return 202; }
+        if ($is_headless_client) { return 202; }
         proxy_pass https://plausible.io/api/event;
         proxy_set_header Host plausible.io;
         proxy_ssl_server_name on;

--- a/app/src/hooks/useAnalytics.test.ts
+++ b/app/src/hooks/useAnalytics.test.ts
@@ -171,10 +171,10 @@ describe('useAnalytics', () => {
       expect(window.plausible).toHaveBeenCalled();
     });
 
-    it('converts ?lang=python on /plots to a /lang/python path segment for Plausible', () => {
-      // `/plots` is a reserved top-level route so the path prefix is stripped
-      // and filter segments are appended directly to the domain — matching
-      // how the other `/plots?lib=…` filters are already tracked.
+    it('keeps the /plots prefix when converting ?lang=python to path segments', () => {
+      // `/plots` is a real page — the prefix must survive so Plausible
+      // attributes the pageview to /plots, not to "/". (Dropping the
+      // reserved prefix made the site's #2 page invisible in analytics.)
       Object.defineProperty(window, 'location', {
         value: {
           ...originalLocation,
@@ -193,7 +193,30 @@ describe('useAnalytics', () => {
       });
 
       expect(window.plausible).toHaveBeenCalledWith('pageview', {
-        url: 'https://anyplot.ai/lang/python',
+        url: 'https://anyplot.ai/plots/lang/python',
+      });
+    });
+
+    it('records a filterless /plots visit as /plots, not as the root page', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...originalLocation,
+          hostname: 'anyplot.ai',
+          pathname: '/plots',
+          search: '',
+        },
+        writable: true,
+        configurable: true,
+      });
+      const { result } = renderHook(() => useAnalytics());
+
+      act(() => {
+        result.current.trackPageview();
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(window.plausible).toHaveBeenCalledWith('pageview', {
+        url: 'https://anyplot.ai/plots',
       });
     });
 

--- a/app/src/hooks/useAnalytics.ts
+++ b/app/src/hooks/useAnalytics.ts
@@ -1,7 +1,5 @@
 import { useCallback, useMemo, useRef } from 'react';
 
-import { RESERVED_TOP_LEVEL } from 'src/routes/paths';
-
 interface EventProps {
   [key: string]: string | undefined;
 }
@@ -42,13 +40,13 @@ function buildPlausibleUrl(): string {
   const params = new URLSearchParams(window.location.search);
   const segments: string[] = [];
 
-  // Preserve the current spec/language/library path prefix if present.
-  // For routes like /:specId/:language[/:library] we keep the full pathname so
-  // filter segments are appended after it. Reserved top-level routes use no prefix.
+  // Preserve the full current pathname so filter segments are appended after
+  // it — for spec routes (/:specId/:language[/:library]) AND for real reserved
+  // pages like /plots. Dropping the reserved prefix recorded every filterless
+  // /plots visit as "/" and made the site's #2 page invisible in Plausible.
   const pathname = window.location.pathname;
   const parts = pathname.split('/').filter(Boolean);
-  const pathPrefix =
-    parts.length > 0 && !RESERVED_TOP_LEVEL.has(parts[0]) ? `/${parts.join('/')}` : '';
+  const pathPrefix = parts.length > 0 ? `/${parts.join('/')}` : '';
 
   // Definierte Reihenfolge der Filter-Kategorien (inkl. impl-level tags).
   // - `language` covers the spec-hub carousel scope (`/{spec}?language=python`)

--- a/app/src/pages/DebugPage.tsx
+++ b/app/src/pages/DebugPage.tsx
@@ -12,7 +12,7 @@ import Typography from '@mui/material/Typography';
 
 import { SectionHeader } from 'src/components/SectionHeader';
 import { DEBUG_API_URL, LIB_ABBREV, LIB_TO_LANG, LIBRARIES } from 'src/constants';
-import { useCopyCode } from 'src/hooks';
+import { useAnalytics, useCopyCode } from 'src/hooks';
 import { fetchWithAuth } from 'src/lib/api';
 import { specPath } from 'src/routes/paths';
 import { colors, fontSize, semanticColors, typography } from 'src/theme';
@@ -238,6 +238,11 @@ const clearAdminToken = (): void => {
 };
 
 export function DebugPage() {
+  const { trackPageview } = useAnalytics();
+  useEffect(() => {
+    trackPageview('/debug');
+  }, [trackPageview]);
+
   const [data, setData] = useState<DebugStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -85,6 +85,8 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `/legal` | Legal notice, privacy policy, transparency |
 | `/mcp` | MCP server documentation (AI assistant integration) |
 | `/stats` | Platform statistics (library scores, coverage, tags, top implementations) |
+| `/map` | Network map of specs clustered by visual similarity |
+| `/debug` | Pipeline status dashboard (spec coverage, feedback, ping) |
 | `/{spec_id}` | Cross-language spec hub (all implementations across all languages) |
 | `/{spec_id}/{language}` | Language overview (all libraries for that language) |
 | `/{spec_id}/{language}/{library}` | Implementation detail (preview ↔ interactive toggle) |
@@ -134,6 +136,7 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `potd_dismiss` | `spec`, `library` | PlotOfTheDay.tsx | User dismisses the plot-of-the-day banner |
 | `view_mode_change` | `mode`, `library` | SpecDetailView.tsx | User toggles preview ↔ interactive view inside a spec detail. `mode` ∈ `preview`, `interactive`. Fires on every toggle in either direction (cf. `open_interactive`, which only fires when the interactive HTML is opened in a new tab). |
 | `library_click` | `source`, `library` | LibrariesPage.tsx | User clicks a library card on `/libraries` to navigate to its filtered plots view. `source` is `libraries_page` from this entry point. |
+| `library_filter` | `source`, `framework` | LibrariesPage.tsx | User clicks a language/framework filter chip on `/libraries` (`framework` carries the chip id; register the prop in the dashboard for breakdowns) |
 | `stats_top_impl_click` | `spec`, `library` | StatsPage.tsx | User clicks a "top implementation" thumbnail on `/stats` to jump into its spec detail. |
 | `map_node_click` | `spec` | MapPage.tsx | User clicks a node on `/map` (or, on touch, second tap on an already-pinned node) to navigate to its spec detail. |
 | `map_node_pin` | `spec` | MapPage.tsx | Touch device only: first tap on a node opens the preview panel + pin marker without navigating. A second tap on the same node fires `map_node_click` and navigates. |
@@ -151,7 +154,7 @@ carry `spec`, `library`, or `value` for richer breakdowns.
 
 | `source` value | Where | Target |
 |----------------|-------|--------|
-| `nav_specs` / `nav_plots` / `nav_libraries` / `nav_stats` / `nav_palette` / `nav_mcp` | NavBar.tsx | top-level menu bar |
+| `nav_specs` / `nav_plots` / `nav_map` / `nav_libraries` / `nav_stats` / `nav_palette` / `nav_mcp` | NavBar.tsx | top-level menu bar |
 | `nav_logo` | NavBar.tsx | logo → `/` |
 | `nav_search` | NavBar.tsx | `plots.search()` button → `/plots?focus=search` |
 | `masthead_logo` / `masthead_branch` / `masthead_release` | MastheadRule.tsx | masthead `~/anyplot.ai · main · v1.x.x` |
@@ -301,7 +304,7 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | Property | Description | Used By Events |
 |----------|-------------|----------------|
 | `spec` | Plot specification ID | `copy_code`, `download_image`, `plot_rotate`, `external_link`, `internal_link`, `open_interactive`, `report_issue`, `tag_click`, `og_image_view` |
-| `language` | Language slug (`python`, `r`, `julia`; future: `matlab`) | `og_image_view` |
+| `language` | Language slug (`python`, `r`, `julia`, `javascript`) | `og_image_view` |
 | `library` | Library name (matplotlib, seaborn, etc.) | `copy_code`, `download_image`, `external_link`, `internal_link`, `open_interactive`, `tab_toggle`, `og_image_view` |
 | `method` | Action method (card, image, tab, click, space, doubletap) | `copy_code`, `random_filter` |
 | `page` | Page context (home, plots, spec_overview, spec_detail) | `copy_code`, `download_image`, `og_image_view` |
@@ -315,6 +318,7 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | `size` | Grid size (normal, compact) | `grid_resize` |
 | `param` | URL parameter name for tag | `tag_click` |
 | `source` | Source UI element / page context | `tag_click`, `nav_click` |
+| `framework` | Library id clicked in the libraries-page filter (needs dashboard registration to appear in breakdowns) | `library_filter` |
 | `target` | Click destination (route or external label) | `nav_click` |
 | `to` | New mode after toggle (`system` / `light` / `dark`) | `theme_toggle` |
 | `mode` | Spec detail view mode (`preview` / `interactive`) | `view_mode_change` |
@@ -483,8 +487,10 @@ Any valid specification ID (e.g., `scatter-basic`, `heatmap-correlation`, `bar-g
 
 ### `library` Values
 ```
-matplotlib | seaborn | plotly | bokeh | altair | plotnine | pygal | highcharts | letsplot
+matplotlib | seaborn | plotly | bokeh | altair | plotnine | pygal | letsplot
+ggplot2 | makie | chartjs | d3 | echarts | highcharts | muix
 ```
+(Canonical source: `LIBRARIES_METADATA` in `core/constants.py`.)
 
 ### `method` Values
 ```
@@ -660,5 +666,5 @@ window.plausible = function(...args) { console.log('Plausible:', args); };
 
 ---
 
-**Last Updated**: 2026-04-25
+**Last Updated**: 2026-07-10
 **Status**: Production-ready with full journey tracking, Core Web Vitals, server-side og:image analytics, landing-page nav tracking, and theme analytics

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -364,6 +364,7 @@ To see event properties in Plausible dashboard, you **MUST** register them as cu
 | `potd_dismiss` | Custom Event | Track plot-of-the-day banner dismissals |
 | `view_mode_change` | Custom Event | Track preview ↔ interactive toggles in spec detail |
 | `library_click` | Custom Event | Track library-card clicks on the libraries page |
+| `library_filter` | Custom Event | Track language/framework filter-chip clicks on the libraries page |
 | `stats_top_impl_click` | Custom Event | Track clicks on top-quality implementation thumbnails on /stats |
 | `map_node_click` | Custom Event | Track navigation clicks from `/map` into a spec detail |
 | `map_node_pin` | Custom Event | Track touch users opening the preview panel on `/map` (first tap) |
@@ -460,6 +461,7 @@ User lands on anyplot.ai
 | `potd_dismiss` | `spec`, `library` | PlotOfTheDay.tsx |
 | `view_mode_change` | `mode`, `library` | SpecDetailView.tsx |
 | `library_click` | `source`, `library` | LibrariesPage.tsx |
+| `library_filter` | `source`, `framework` | LibrariesPage.tsx |
 | `stats_top_impl_click` | `spec`, `library` | StatsPage.tsx |
 | `map_node_click` | `spec` | MapPage.tsx |
 | `map_node_pin` | `spec` | MapPage.tsx |
@@ -471,7 +473,7 @@ User lands on anyplot.ai
 | `TTFB` | `value`, `rating` | reportWebVitals.ts |
 | `og_image_view` | `page`, `platform`, `spec`?, `language`?, `library`?, `filter_*`? | api/analytics.py (server-side) |
 
-**Total: 30 client-side + 1 server-side = 31 events**
+**Total: 31 client-side + 1 server-side = 32 events**
 
 > Every pageview and event additionally carries a `theme` ambient prop (`dark` /
 > `light`). Set in `RootLayout` via `setAnalyticsAmbientProps` whenever the user


### PR DESCRIPTION
## Summary
- **Bot shield on the Plausible proxy** (audit 2026-07-08 High#7, repo half): both nginx `/api/event` locations (anyplot.ai + python.anyplot.ai) now `return 202` — mirroring Plausible's accepted response so clients don't retry — for the existing `$is_bot` crawler map plus a new `$is_headless_client` map (HeadlessChrome, phantomjs, puppeteer, playwright, selenium, electron, python-requests/httpx, aiohttp, go-http-client, okhttp, curl/wget, empty UA). ~40–45% of recorded visitors were unfiltered synthetic traffic (CN headless-Chrome waves firing CWV without pageviews). The Plausible-dashboard half (country exclusions, custom-prop registration) remains a manual action.
- **`/plots` becomes visible in analytics** (Medium#10): `buildPlausibleUrl` keeps the real pathname for reserved pages instead of stripping it — filterless `/plots` visits recorded as `/` (47 visitors, 0 pageviews in 30d). Note the deliberate history break: filter pageviews move from `/lib/matplotlib` to `/plots/lib/matplotlib`. `/debug` now fires a pageview (was fully untracked).
- **`docs/reference/plausible.md` synced with the shipped product** (Low#12 + Low#15): `/map` + `/debug` in the pages table, `nav_map` nav source, the previously undocumented `library_filter` event with its `framework` prop (dashboard registration still needed for breakdowns), `language` values incl. julia/javascript, 15-library value list pointing at `core/constants.py`, Last Updated bumped.

## Verification limits
nginx.conf has no local runtime loop — the config was parsed clean with crossplane (nginx's own parser library) and the new map/`if(){return}` constructs follow the exact pattern of the existing `$is_bot` usage. After the frontend Cloud Build deploys, verify: `curl -X POST -A "HeadlessChrome/120" https://anyplot.ai/api/event` → 202 without a Plausible hit, and a normal browser still lands events; expect the visitor count to drop noticeably (that's the fix working, not a traffic loss).

## Plan
agentic/audits/2026-07-08-product-ux.md (High#7, Medium#10, Low#12, Low#15)

## Test plan
- [x] `yarn test` (68 files green; /plots-prefix behavior covered by two updated/new useAnalytics tests), `yarn type-check`, `yarn lint`, `yarn fm:check`, `yarn build` — green
- [x] nginx.conf parses (crossplane, both server blocks patched identically)
- [ ] Post-deploy: headless-UA POST to `/api/event` returns 202; Plausible visitor trend drops to human baseline