### PR TITLE
fix: remaining 2026-07-15 audit items (GIN tag search, XFF hardening, code-blob over-fetch, CoC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `ix_specs_tags` GIN index can never serve (sequential scan on every MCP tag search) and which
   let LIKE metacharacters in tag values wildcard-match; on PostgreSQL it now emits per-category
   JSONB containment (`tags @> …`), and the SQLite test fallback escapes LIKE metacharacters
-  (audit 2026-07-15 Medium#17).
+  (audit 2026-07-15 Medium#17) (#9644).
 - **Feedback rate limiting no longer trusts a spoofable header entry** — `/feedback` keyed its
   per-IP rate limit and duplicate suppression on the client-controlled *first* `x-forwarded-for`
   entry, so a caller could evade the limit or poison another user's bucket; it now prefers
   Cloudflare's `cf-connecting-ip` and otherwise uses the rightmost, infrastructure-appended
-  entry (audit 2026-07-15 Medium#20).
+  entry (audit 2026-07-15 Medium#20) (#9644).
 
 ### Changed
 
@@ -37,12 +37,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   full multi-MB code corpus through the DB per request; the MCP tools now resolve code
   *presence* via a lightweight id probe (`get_ids_with_code`) and the images endpoint fetches
   only its own library's code (`get_by_library_with_code`); the now-unused `get_all_with_code()`
-  was removed (audit 2026-07-15 Medium#5, issue #7696).
+  was removed (audit 2026-07-15 Medium#5, issue #7696) (#9644).
 
 ### Added
 
 - **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, linked from `docs/contributing.md`
-  (closes the last repo-health gap from audit 2026-07-15 Medium#29).
+  (closes the last repo-health gap from audit 2026-07-15 Medium#29) (#9644).
 
 - **Runaway impl-generate retry loop can no longer self-amplify** — the 3-attempt cap counted
   prior failures by paginating issue comments and fell back to "0 failures" whenever the count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 - **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, linked from `docs/contributing.md`
   (closes the last repo-health gap from audit 2026-07-15 Medium#29) (#9644).
 
+### Fixed
+
 - **Runaway impl-generate retry loop can no longer self-amplify** — the 3-attempt cap counted
   prior failures by paginating issue comments and fell back to "0 failures" whenever the count
   API call rate-limited, so every failure re-dispatched forever (issue #1010 flooded ~1,200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,117 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Added
+
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, linked from `docs/contributing.md`
+  (closes the last repo-health gap from audit 2026-07-15 Medium#29) (#9644).
+- **Bot-served pages got a real SEO surface** — `seo_home()` now emits the site-level JSON-LD
+  (`WebApplication`, `WebSite`+`SearchAction`, `Organization`) that previously only lived in the
+  SPA shell nginx never serves to bots, plus a descriptive title/meta and real body copy;
+  `/seo-proxy/plots` and `/seo-proxy/specs` render a server-side link to every spec hub, so
+  crawlers can reach all 324 hubs (they were orphans); `Google-InspectionTool`/`GoogleOther`
+  UAs are now routed to the bot pages like Googlebot (audit 2026-07-15 High#10/#11,
+  Medium#40/#41) (#9642).
+- **`core/palette.py` unit tests** — the last untested core module now has coverage: pool
+  contract, semantic anchors, theme-adaptive neutrals, lazy cmaps and the
+  matplotlib-free-import guarantee (audit 2026-07-15 Medium#28) (#9642).
+- **Impl check constraints exist as a migration** — `ck_quality_score_range` /
+  `ck_review_verdict_valid` lived only in the ORM; a new alembic migration adds them (with
+  pre-normalization of violating rows and a real downgrade) (audit 2026-07-15 Medium#18) (#9642).
+- **Repo health:** PR template with changelog/docs checklist and an `.editorconfig` mirroring
+  ruff + frontend conventions (audit 2026-07-15 Medium#29) (#9642).
+- **Full 2026-07-15 codebase audit report** — persisted output of a 16-auditor `/audit` run
+  with domain-routed cross-validation (`agentic/audits/2026-07-15-all.md`, mirrored to
+  `latest.md`). Health Score 30/100 with correctness (C, 60) as the weak pillar; headlines are a
+  live `heatmap-calendar` retry loop (#1010), 15-library pipeline/config drift, dark-mode
+  white-surface leaks, and 97 reviewer-rejected implementations live on main, plus an open-issue
+  triage with a recommended work queue. Report only, no source changes (#9641).
+- **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged
+  by Lighthouse's Agentic Browsing audit as non-conformant); now a spec-conformant file per
+  llmstxt.org (H1 + summary blockquote + H2 link sections) covering catalog, docs, the MCP
+  endpoint and the repo, served directly in nginx like robots.txt so mapped crawler UAs aren't
+  proxied into a `/seo-proxy/llms.txt` 404 (#9618).
+- **`bot-serving-check.yml` synthetic monitor** — daily scheduled workflow that curls the
+  Cloud Run origin with Googlebot/Twitterbot UAs plus a human-UA control (and an `llms.txt`
+  check) and fails on non-200 or missing per-route titles, so the crawler-only serving path can
+  never break silently again. Targets the origin because Cloudflare's bot management 403s
+  GitHub-runner IPs (#9617, #9619).
+- **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
+  workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
+  headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and
+  quality-score calibration drift (#9616).
+- **Legal page "other projects" block** — below the disclaimer, cross-linking the maintainer's
+  other projects kurrentschrift.ink and cite-citadel, tracked as `external_link` with
+  destinations `kurrentschrift` / `cite_citadel`; deliberately without `noreferrer` so the
+  target sites' analytics can attribute the traffic (#9616).
+
+- **Project skill layer under `.claude/skills/`** — six skills, ported from the kurrentschrift
+  and cite-citadel setups and adapted to anyplot: `verify-frontend` (browser-drive changed flows,
+  both viewports × both themes, cloud playwright-core fallback probe), `verify-api` (read sweep +
+  shared-prod-DB discipline), `verify-core` (pytest/ruff/mypy gates + registry smoke), `open-pr`
+  (gates → PR → CI watch → review-thread resolution with runnable GraphQL recipes),
+  `optimize-skills` (session-transcript retro mining), and `babysit-pipeline` (bulk-generate
+  monitoring with the battle-tested poller scripts promoted from gitignored local state).
+  CLAUDE.md gained a Self-Verification routing table wiring diff paths to the skills (#9615).
+- **`/dependabot` and `/catalog-status` commands** — batch-processing of Dependabot PRs with the
+  GITHUB_TOKEN/auto-merge gotchas encoded, and a reproducible catalog-status report (light/dark
+  migration counts, per-spec library coverage, open impl-PR classification). Both derived from a
+  13-session transcript retro; the same retro added working rules to CLAUDE.md (explicit
+  authorization for external writes, proactive progress reporting, absolute-path discipline)
+  (#9615).
+- **`CHANGELOG.md` introduced, with the v1.0.0–v3.0.0 history backfilled** from the GitHub
+  releases. The per-PR changelog contract is wired into `CLAUDE.md`,
+  `.github/copilot-instructions.md`, and `/pull_request`; a new `/release` command
+  (`agentic/commands/release.md`) codifies the version-bump → tag → GitHub-release flow (#9614).
+- **Design-sync inputs for the anyplot.ai Design System.** `.design-sync/` carries the app-shape
+  sync inputs so the Design System on claude.ai/design can be synced from `app/` via
+  `/design-sync`; MonoLisa is fetched from GCS and never committed (#9213).
+
+### Changed
+
+- **Hot listing paths stop fetching every code blob** — MCP `list_specs` /
+  `search_specs_by_tags` and `/libraries/{id}/images` used `get_all_with_code()`, dragging the
+  full multi-MB code corpus through the DB per request; the MCP tools now resolve code
+  *presence* via a lightweight id probe (`get_ids_with_code`) and the images endpoint fetches
+  only its own library's code (`get_by_library_with_code`); the now-unused `get_all_with_code()`
+  was removed (audit 2026-07-15 Medium#5, issue #7696) (#9644).
+- **Frontend a11y pass** — card actions reveal on `:focus-within` and stay visible on touch
+  devices instead of hover-only; the NavBar search button and nav links have `:focus-visible`
+  outlines; mobile nav/theme-toggle tap targets reach 44px; off-palette Tailwind green and a
+  rogue Python-blue were replaced with imprint palette hues; `AppDataProvider`/theme context
+  values are memoized so consumers stop re-rendering every frame (audit 2026-07-15
+  Medium#7/#10/#11/#12).
+- **Frontend production image builds on `node:22-alpine`** — `node:20` is EOL April 2026; 22
+  matches the JS render harness (audit 2026-07-15 Medium#16) (#9642).
+- **Spec-detail tabs are self-explanatory now** — the Code tab (Spec tab on hub pages) starts
+  open instead of everything collapsed, the selected tab shows a small caret signaling the
+  click-to-collapse toggle, the quality tab reads "Quality 91" (with an explanatory
+  `aria-label`) instead of a bare number, and tabs↔panels got standard `id`/`aria-controls`
+  wiring (audit 2026-07-08 High#5 + Low#1) (#9622).
+- **Bot-served pages now carry the site's actual content** — the crawler-facing HTML
+  (`/seo-proxy/*`, what Googlebot & social bots see) grows from a title+description shell to a
+  real document: spec hubs list and link every implementation, implementation pages embed the
+  full source in a `<pre>` block plus hub/sibling links, both carry the preview image and
+  JSON-LD (`BreadcrumbList`, `ItemList`, `SoftwareSourceCode`), and every bot page ends with a
+  site-wide nav. Display names derive from `core/constants.py`, never hand-maintained (audit
+  2026-07-08 High#6) (#9621).
+- **Gallery cold path prewarmed** — the startup cache prewarm now also computes the two
+  heaviest user-facing payloads, `/plots/filter` (`filter:all`) and `/specs/map`, so the first
+  visitor of a fresh Cloud Run instance no longer waits on the full DB roundtrip for the
+  gallery or the map page (audit 2026-07-08 Quick Win 2) (#9620).
+- **ECharts upgraded 5.5.1 → 6.1.0** — major bump of a rendered charting library; echarts
+  previews regenerate against the new major through the regular pipeline (#9609).
+- **Post-restructure `app/` cleanup:** dead components removed and stale doc paths fixed (#8630);
+  ECharts / MUI X labels shortened in the `/stats` library list (#8666).
+- **Dependencies:** grouped bumps across Python (starlette, cryptography, python-multipart,
+  sqlalchemy, uvicorn, 15-update python-minor group), npm (esbuild, undici), and GitHub Actions
+  (#8668, #8823, #8824, #8864, #8978, #8980, #9074, #9513, #9515).
+
+### Removed
+
+- **Catalog curation: 13 interactive-first specs removed** — plot types whose value is inherently
+  interactive don't fit a static-first catalog (#8645).
+
 ### Fixed
 
 - **Tag search uses the GIN index and stops treating `%`/`_` as wildcards** —
@@ -29,23 +140,6 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   entry, so a caller could evade the limit or poison another user's bucket; it now prefers
   Cloudflare's `cf-connecting-ip` and otherwise uses the rightmost, infrastructure-appended
   entry (audit 2026-07-15 Medium#20) (#9644).
-
-### Changed
-
-- **Hot listing paths stop fetching every code blob** — MCP `list_specs` /
-  `search_specs_by_tags` and `/libraries/{id}/images` used `get_all_with_code()`, dragging the
-  full multi-MB code corpus through the DB per request; the MCP tools now resolve code
-  *presence* via a lightweight id probe (`get_ids_with_code`) and the images endpoint fetches
-  only its own library's code (`get_by_library_with_code`); the now-unused `get_all_with_code()`
-  was removed (audit 2026-07-15 Medium#5, issue #7696) (#9644).
-
-### Added
-
-- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, linked from `docs/contributing.md`
-  (closes the last repo-health gap from audit 2026-07-15 Medium#29) (#9644).
-
-### Fixed
-
 - **Runaway impl-generate retry loop can no longer self-amplify** — the 3-attempt cap counted
   prior failures by paginating issue comments and fell back to "0 failures" whenever the count
   API call rate-limited, so every failure re-dispatched forever (issue #1010 flooded ~1,200
@@ -98,53 +192,6 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   only MCP transport (the SSE endpoint is gone); stale `plot.png` code examples are
   theme-aware; a leaked personal `file://` path was scrubbed from a palette doc
   (audit 2026-07-15 Medium#14/#24/#26/#27/#31/#32/#33) (#9642).
-
-### Security
-
-- **Issue templates no longer auto-apply workflow trigger labels** — `spec-request` /
-  `report-pending` previously flowed unauthenticated issue text straight into write-privileged
-  Claude agents; the labels must now be added by a maintainer (GitHub requires triage rights to
-  label), which puts a human review in front of every agent run (audit 2026-07-15 High#7) (#9642).
-- **Composite actions SHA-pinned** — `setup-node`/`setup-r`/`setup-julia` used floating tags
-  while every workflow pins to SHAs; all four `uses:` refs are now SHA-pinned and the
-  Dependabot `github-actions` entry covers the composite-action directories so the pins stay
-  fresh (audit 2026-07-15 Medium#13) (#9642).
-- **Frontend nginx ships security headers** — new `app/security-headers.conf` (CSP tuned to
-  Plausible/GCS/API needs, `nosniff`, `X-Frame-Options SAMEORIGIN`, `Referrer-Policy`, HSTS)
-  included in both server blocks and re-included in every `add_header` location
-  (audit 2026-07-15 Medium#21) (#9642).
-
-### Added
-
-- **Bot-served pages got a real SEO surface** — `seo_home()` now emits the site-level JSON-LD
-  (`WebApplication`, `WebSite`+`SearchAction`, `Organization`) that previously only lived in the
-  SPA shell nginx never serves to bots, plus a descriptive title/meta and real body copy;
-  `/seo-proxy/plots` and `/seo-proxy/specs` render a server-side link to every spec hub, so
-  crawlers can reach all 324 hubs (they were orphans); `Google-InspectionTool`/`GoogleOther`
-  UAs are now routed to the bot pages like Googlebot (audit 2026-07-15 High#10/#11,
-  Medium#40/#41) (#9642).
-- **`core/palette.py` unit tests** — the last untested core module now has coverage: pool
-  contract, semantic anchors, theme-adaptive neutrals, lazy cmaps and the
-  matplotlib-free-import guarantee (audit 2026-07-15 Medium#28) (#9642).
-- **Impl check constraints exist as a migration** — `ck_quality_score_range` /
-  `ck_review_verdict_valid` lived only in the ORM; a new alembic migration adds them (with
-  pre-normalization of violating rows and a real downgrade) (audit 2026-07-15 Medium#18) (#9642).
-- **Repo health:** PR template with changelog/docs checklist and an `.editorconfig` mirroring
-  ruff + frontend conventions (audit 2026-07-15 Medium#29) (#9642).
-
-### Changed
-
-- **Frontend a11y pass** — card actions reveal on `:focus-within` and stay visible on touch
-  devices instead of hover-only; the NavBar search button and nav links have `:focus-visible`
-  outlines; mobile nav/theme-toggle tap targets reach 44px; off-palette Tailwind green and a
-  rogue Python-blue were replaced with imprint palette hues; `AppDataProvider`/theme context
-  values are memoized so consumers stop re-rendering every frame (audit 2026-07-15
-  Medium#7/#10/#11/#12).
-- **Frontend production image builds on `node:22-alpine`** — `node:20` is EOL April 2026; 22
-  matches the JS render harness (audit 2026-07-15 Medium#16) (#9642).
-
-### Fixed
-
 - **Global keyboard shortcuts no longer hijack focused elements on `/plots`** — the
   window-level Space/Enter/Backspace handler now bails out when the keystroke targets an
   interactive element (button, link, focused card/chip/toggle), so keyboard-activating a card
@@ -188,92 +235,6 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   product: `/map` + `/debug` pages, `nav_map` source, the previously undocumented
   `library_filter` event with its `framework` prop, and the 15-library value list (audit
   2026-07-08 High#7 repo-side + Medium#10 + Low#12/#15) (#9625).
-
-### Changed
-
-- **Spec-detail tabs are self-explanatory now** — the Code tab (Spec tab on hub pages) starts
-  open instead of everything collapsed, the selected tab shows a small caret signaling the
-  click-to-collapse toggle, the quality tab reads "Quality 91" (with an explanatory
-  `aria-label`) instead of a bare number, and tabs↔panels got standard `id`/`aria-controls`
-  wiring (audit 2026-07-08 High#5 + Low#1) (#9622).
-- **Bot-served pages now carry the site's actual content** — the crawler-facing HTML
-  (`/seo-proxy/*`, what Googlebot & social bots see) grows from a title+description shell to a
-  real document: spec hubs list and link every implementation, implementation pages embed the
-  full source in a `<pre>` block plus hub/sibling links, both carry the preview image and
-  JSON-LD (`BreadcrumbList`, `ItemList`, `SoftwareSourceCode`), and every bot page ends with a
-  site-wide nav. Display names derive from `core/constants.py`, never hand-maintained (audit
-  2026-07-08 High#6) (#9621).
-- **Gallery cold path prewarmed** — the startup cache prewarm now also computes the two
-  heaviest user-facing payloads, `/plots/filter` (`filter:all`) and `/specs/map`, so the first
-  visitor of a fresh Cloud Run instance no longer waits on the full DB roundtrip for the
-  gallery or the map page (audit 2026-07-08 Quick Win 2) (#9620).
-
-### Added
-
-- **Full 2026-07-15 codebase audit report** — persisted output of a 16-auditor `/audit` run
-  with domain-routed cross-validation (`agentic/audits/2026-07-15-all.md`, mirrored to
-  `latest.md`). Health Score 30/100 with correctness (C, 60) as the weak pillar; headlines are a
-  live `heatmap-calendar` retry loop (#1010), 15-library pipeline/config drift, dark-mode
-  white-surface leaks, and 97 reviewer-rejected implementations live on main, plus an open-issue
-  triage with a recommended work queue. Report only, no source changes (#9641).
-- **`llms.txt` for AI agents** — `/llms.txt` previously fell through to the SPA shell (flagged
-  by Lighthouse's Agentic Browsing audit as non-conformant); now a spec-conformant file per
-  llmstxt.org (H1 + summary blockquote + H2 link sections) covering catalog, docs, the MCP
-  endpoint and the repo, served directly in nginx like robots.txt so mapped crawler UAs aren't
-  proxied into a `/seo-proxy/llms.txt` 404 (#9618).
-- **`bot-serving-check.yml` synthetic monitor** — daily scheduled workflow that curls the
-  Cloud Run origin with Googlebot/Twitterbot UAs plus a human-UA control (and an `llms.txt`
-  check) and fails on non-200 or missing per-route titles, so the crawler-only serving path can
-  never break silently again. Targets the origin because Cloudflare's bot management 403s
-  GitHub-runner IPs (#9617, #9619).
-- **Product/UX audit 2026-07-08** (`agentic/audits/2026-07-08-product-ux.md`) — 8-auditor
-  workflow run scoped to pipeline, rating criteria, tabs, and product qualities; Health Score 43,
-  headlined by a critical crawler outage (every bot UA gets 502 from the `@seo_proxy` hop) and
-  quality-score calibration drift (#9616).
-- **Legal page "other projects" block** — below the disclaimer, cross-linking the maintainer's
-  other projects kurrentschrift.ink and cite-citadel, tracked as `external_link` with
-  destinations `kurrentschrift` / `cite_citadel`; deliberately without `noreferrer` so the
-  target sites' analytics can attribute the traffic (#9616).
-
-- **Project skill layer under `.claude/skills/`** — six skills, ported from the kurrentschrift
-  and cite-citadel setups and adapted to anyplot: `verify-frontend` (browser-drive changed flows,
-  both viewports × both themes, cloud playwright-core fallback probe), `verify-api` (read sweep +
-  shared-prod-DB discipline), `verify-core` (pytest/ruff/mypy gates + registry smoke), `open-pr`
-  (gates → PR → CI watch → review-thread resolution with runnable GraphQL recipes),
-  `optimize-skills` (session-transcript retro mining), and `babysit-pipeline` (bulk-generate
-  monitoring with the battle-tested poller scripts promoted from gitignored local state).
-  CLAUDE.md gained a Self-Verification routing table wiring diff paths to the skills (#9615).
-- **`/dependabot` and `/catalog-status` commands** — batch-processing of Dependabot PRs with the
-  GITHUB_TOKEN/auto-merge gotchas encoded, and a reproducible catalog-status report (light/dark
-  migration counts, per-spec library coverage, open impl-PR classification). Both derived from a
-  13-session transcript retro; the same retro added working rules to CLAUDE.md (explicit
-  authorization for external writes, proactive progress reporting, absolute-path discipline)
-  (#9615).
-- **`CHANGELOG.md` introduced, with the v1.0.0–v3.0.0 history backfilled** from the GitHub
-  releases. The per-PR changelog contract is wired into `CLAUDE.md`,
-  `.github/copilot-instructions.md`, and `/pull_request`; a new `/release` command
-  (`agentic/commands/release.md`) codifies the version-bump → tag → GitHub-release flow (#9614).
-- **Design-sync inputs for the anyplot.ai Design System.** `.design-sync/` carries the app-shape
-  sync inputs so the Design System on claude.ai/design can be synced from `app/` via
-  `/design-sync`; MonoLisa is fetched from GCS and never committed (#9213).
-
-### Changed
-
-- **ECharts upgraded 5.5.1 → 6.1.0** — major bump of a rendered charting library; echarts
-  previews regenerate against the new major through the regular pipeline (#9609).
-- **Post-restructure `app/` cleanup:** dead components removed and stale doc paths fixed (#8630);
-  ECharts / MUI X labels shortened in the `/stats` library list (#8666).
-- **Dependencies:** grouped bumps across Python (starlette, cryptography, python-multipart,
-  sqlalchemy, uvicorn, 15-update python-minor group), npm (esbuild, undici), and GitHub Actions
-  (#8668, #8823, #8824, #8864, #8978, #8980, #9074, #9513, #9515).
-
-### Removed
-
-- **Catalog curation: 13 interactive-first specs removed** — plot types whose value is inherently
-  interactive don't fit a static-first catalog (#8645).
-
-### Fixed
-
 - **Crawler 502 outage fixed** — since at least 2026-06-12, every crawler UA (googlebot,
   bingbot, twitterbot, discord, whatsapp, …) received HTTP 502 on every page: the nginx
   `@seo_proxy` hop verifies the upstream TLS chain of `api.anyplot.ai`, which is 4 certificates
@@ -284,6 +245,21 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `PalettePage.tsx` into `PalettePage.helpers.ts` (following the `MapPage.helpers.ts` pattern),
   and the `react-refresh/only-export-components` rule scoped off for test modules
   (`*.test.{ts,tsx}`, `test-utils.tsx`), which never participate in Fast Refresh (#9616).
+
+### Security
+
+- **Issue templates no longer auto-apply workflow trigger labels** — `spec-request` /
+  `report-pending` previously flowed unauthenticated issue text straight into write-privileged
+  Claude agents; the labels must now be added by a maintainer (GitHub requires triage rights to
+  label), which puts a human review in front of every agent run (audit 2026-07-15 High#7) (#9642).
+- **Composite actions SHA-pinned** — `setup-node`/`setup-r`/`setup-julia` used floating tags
+  while every workflow pins to SHAs; all four `uses:` refs are now SHA-pinned and the
+  Dependabot `github-actions` entry covers the composite-action directories so the pins stay
+  fresh (audit 2026-07-15 Medium#13) (#9642).
+- **Frontend nginx ships security headers** — new `app/security-headers.conf` (CSP tuned to
+  Plausible/GCS/API needs, `nosniff`, `X-Frame-Options SAMEORIGIN`, `Referrer-Policy`, HSTS)
+  included in both server blocks and re-included in every `add_header` location
+  (audit 2026-07-15 Medium#21) (#9642).
 
 ## [3.0.0] — 2026-06-10 — Julia & JavaScript, 15 libraries & the Imprint palette
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,32 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **Tag search uses the GIN index and stops treating `%`/`_` as wildcards** —
+  `SpecRepository.search_by_tags` cast the JSONB `tags` column to text and ran LIKE, which the
+  `ix_specs_tags` GIN index can never serve (sequential scan on every MCP tag search) and which
+  let LIKE metacharacters in tag values wildcard-match; on PostgreSQL it now emits per-category
+  JSONB containment (`tags @> …`), and the SQLite test fallback escapes LIKE metacharacters
+  (audit 2026-07-15 Medium#17).
+- **Feedback rate limiting no longer trusts a spoofable header entry** — `/feedback` keyed its
+  per-IP rate limit and duplicate suppression on the client-controlled *first* `x-forwarded-for`
+  entry, so a caller could evade the limit or poison another user's bucket; it now prefers
+  Cloudflare's `cf-connecting-ip` and otherwise uses the rightmost, infrastructure-appended
+  entry (audit 2026-07-15 Medium#20).
+
+### Changed
+
+- **Hot listing paths stop fetching every code blob** — MCP `list_specs` /
+  `search_specs_by_tags` and `/libraries/{id}/images` used `get_all_with_code()`, dragging the
+  full multi-MB code corpus through the DB per request; the MCP tools now resolve code
+  *presence* via a lightweight id probe (`get_ids_with_code`) and the images endpoint fetches
+  only its own library's code (`get_by_library_with_code`); the now-unused `get_all_with_code()`
+  was removed (audit 2026-07-15 Medium#5, issue #7696).
+
+### Added
+
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, linked from `docs/contributing.md`
+  (closes the last repo-health gap from audit 2026-07-15 Medium#29).
+
 - **Runaway impl-generate retry loop can no longer self-amplify** — the 3-attempt cap counted
   prior failures by paginating issue comments and fell back to "0 failures" whenever the count
   API call rate-limited, so every failure re-dispatched forever (issue #1010 flooded ~1,200

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by opening an
+issue on this repository or via the contact options listed on
+[anyplot.ai](https://anyplot.ai). All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/inclusion

--- a/api/mcp/server.py
+++ b/api/mcp/server.py
@@ -90,9 +90,10 @@ async def list_specs(limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
     session = await get_mcp_db_session()
     try:
         repo = SpecRepository(session)
-        # `impl.code is not None` below requires the code column on every impl
-        # of every spec in the page — use the eager-loaded variant.
-        specs = await repo.get_all_with_code()
+        specs = await repo.get_all()
+        # `code` is deferred (multi-MB across the catalog); library_count only
+        # needs code *presence*, so probe the non-NULL ids instead of loading blobs.
+        ids_with_code = await ImplRepository(session).get_ids_with_code()
 
         # Apply pagination
         paginated_specs = specs[offset : offset + limit]
@@ -100,7 +101,7 @@ async def list_specs(limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
         # Convert to SpecListItem format
         result = []
         for spec in paginated_specs:
-            impl_count = len([impl for impl in spec.impls if impl.code is not None])
+            impl_count = len([impl for impl in spec.impls if impl.id in ids_with_code])
             item = SpecListItem(
                 id=spec.id, title=spec.title, description=spec.description, tags=spec.tags, library_count=impl_count
             )
@@ -179,10 +180,10 @@ async def search_specs_by_tags(
         # Flatten filter values into a single tag list for repository search
         tag_values: list[str] = [tag for tags in filters.values() for tag in tags]
 
-        # Search by spec-level tags. The fallback path (no tag filter) still
-        # iterates spec.impls below and reads impl.code, so use the
-        # eager-loaded variant — `search_by_tags` already undefers code.
-        specs = await repo.search_by_tags(tag_values) if tag_values else await repo.get_all_with_code()
+        # Search by spec-level tags. `code` stays deferred on both paths —
+        # the loops below only need code *presence*, probed via non-NULL ids.
+        specs = await repo.search_by_tags(tag_values) if tag_values else await repo.get_all()
+        ids_with_code = await ImplRepository(session).get_ids_with_code()
 
         # Apply impl-level filtering if needed
         if library or dependencies or techniques or patterns or dataprep or styling:
@@ -191,7 +192,7 @@ async def search_specs_by_tags(
                 # Check if spec has implementations matching impl-level filters
                 matching_impls = []
                 for impl in spec.impls:
-                    if impl.code is None:
+                    if impl.id not in ids_with_code:
                         continue
 
                     # Filter by library
@@ -228,7 +229,7 @@ async def search_specs_by_tags(
         # Convert to SpecListItem format
         result = []
         for spec in specs:
-            impl_count = len([impl for impl in spec.impls if impl.code is not None])
+            impl_count = len([impl for impl in spec.impls if impl.id in ids_with_code])
             item = SpecListItem(
                 id=spec.id, title=spec.title, description=spec.description, tags=spec.tags, library_count=impl_count
             )

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -38,11 +38,28 @@ DUPLICATE_LOOKBACK = timedelta(minutes=10)
 
 
 def _client_ip(request: Request) -> str:
-    """Resolve the client IP, preferring x-forwarded-for (Cloud Run + CF)."""
+    """Resolve the client IP for rate-limit / dup-suppression keying.
+
+    Trust order (client → Cloudflare → Cloud Run):
+    1. `cf-connecting-ip` — Cloudflare overwrites any client-supplied value on
+       proxied traffic, so browsers on anyplot.ai cannot spoof it.
+    2. Rightmost `x-forwarded-for` entry — appended by the trusted
+       infrastructure hop. The *leftmost* entry (used here previously) is
+       client-controlled: spoofing it evaded the rate limit and allowed
+       poisoning another user's bucket to lock them out.
+    3. `request.client.host` as the last resort.
+
+    A caller bypassing Cloudflare via the run.app URL can still forge
+    `cf-connecting-ip`, but that only scatters its *own* submissions across
+    buckets — no better than rotating source IPs, and it can no longer
+    impersonate a victim's bucket.
+    """
+    cf_ip = request.headers.get("cf-connecting-ip", "").strip()
+    if cf_ip:
+        return cf_ip
     forwarded = request.headers.get("x-forwarded-for", "")
     if forwarded:
-        # x-forwarded-for can be a comma-separated chain; the first entry is the original client.
-        return forwarded.split(",")[0].strip()
+        return forwarded.rsplit(",", 1)[-1].strip()
     return request.client.host if request.client else ""
 
 

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -43,10 +43,12 @@ def _client_ip(request: Request) -> str:
     Trust order (client → Cloudflare → Cloud Run):
     1. `cf-connecting-ip` — Cloudflare overwrites any client-supplied value on
        proxied traffic, so browsers on anyplot.ai cannot spoof it.
-    2. Rightmost `x-forwarded-for` entry — appended by the trusted
+    2. Rightmost non-empty `x-forwarded-for` entry — appended by the trusted
        infrastructure hop. The *leftmost* entry (used here previously) is
        client-controlled: spoofing it evaded the rate limit and allowed
-       poisoning another user's bucket to lock them out.
+       poisoning another user's bucket to lock them out. Empty entries from
+       malformed headers ("1.2.3.4, ") are skipped so a caller can't force
+       everyone into one shared empty-string bucket.
     3. `request.client.host` as the last resort.
 
     A caller bypassing Cloudflare via the run.app URL can still forge
@@ -58,8 +60,9 @@ def _client_ip(request: Request) -> str:
     if cf_ip:
         return cf_ip
     forwarded = request.headers.get("x-forwarded-for", "")
-    if forwarded:
-        return forwarded.rsplit(",", 1)[-1].strip()
+    for entry in reversed(forwarded.split(",")):
+        if entry.strip():
+            return entry.strip()
     return request.client.host if request.client else ""
 
 

--- a/api/routers/libraries.py
+++ b/api/routers/libraries.py
@@ -8,7 +8,7 @@ from api.dependencies import optional_db, require_db
 from api.exceptions import raise_not_found
 from core.config import settings
 from core.constants import LIBRARIES_METADATA, SUPPORTED_LIBRARIES
-from core.database import LibraryRepository, SpecRepository
+from core.database import ImplRepository, LibraryRepository
 from core.database.connection import get_db_context
 from core.utils import strip_noqa_comments
 
@@ -97,23 +97,23 @@ async def get_library_images(library_id: str, db: AsyncSession = Depends(require
     if cached:
         return cached
 
-    repo = SpecRepository(db)
-    specs = await repo.get_all_with_code()
+    # Single-library query with code undeferred — fetching all specs with
+    # code loaded every other library's blobs just to filter them out here.
+    repo = ImplRepository(db)
+    impls = await repo.get_by_library_with_code(library_id)
 
-    images = []
-    for spec in specs:
-        for impl in spec.impls:
-            if impl.library_id == library_id and impl.preview_url:
-                images.append(
-                    {
-                        "spec_id": spec.id,
-                        "library": impl.library_id,
-                        "language": impl.language_id,
-                        "url": impl.preview_url,
-                        "html": impl.preview_html,
-                        "code": strip_noqa_comments(impl.code),
-                    }
-                )
+    images = [
+        {
+            "spec_id": impl.spec_id,
+            "library": impl.library_id,
+            "language": impl.language_id,
+            "url": impl.preview_url,
+            "html": impl.preview_html,
+            "code": strip_noqa_comments(impl.code),
+        }
+        for impl in impls
+        if impl.preview_url
+    ]
 
     result = {"library": library_id, "images": images}
     set_cache(key, result)

--- a/core/database/repositories.py
+++ b/core/database/repositories.py
@@ -7,7 +7,8 @@ Provides abstraction layer between API and database models.
 from datetime import datetime, timezone
 from typing import Generic, TypeVar
 
-from sqlalchemy import String, cast, func, or_, select
+from sqlalchemy import ColumnElement, String, cast, func, or_, select, type_coerce
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, undefer
 
@@ -15,6 +16,35 @@ from core.database.models import Feedback, Impl, Language, Library, Spec
 
 
 T = TypeVar("T")
+
+# Spec-level tag categories — the keys of the `tags` JSON object
+# ({plot_type, data_type, domain, features}, see docs/reference/tagging-system.md).
+SPEC_TAG_CATEGORIES = ("plot_type", "data_type", "domain", "features")
+
+
+def _spec_tag_filters(tags: list[str], dialect_name: str) -> list[ColumnElement[bool]]:
+    """Build WHERE filters matching specs whose tags contain any of *tags*.
+
+    On PostgreSQL each (category, tag) pair becomes a JSONB containment
+    predicate (``tags @> '{"<category>": ["<tag>"]}'``) — the operator shape
+    the ``ix_specs_tags`` GIN index can serve. The previous cast-to-text +
+    LIKE forced a sequential scan and treated LIKE metacharacters in tag
+    values as wildcards.
+
+    Other dialects (SQLite in tests) keep the text fallback, with LIKE
+    metacharacters escaped via ``autoescape``.
+    """
+    filters: list[ColumnElement[bool]] = []
+    for tag in tags:
+        if dialect_name == "postgresql":
+            # type_coerce (not cast) keeps the left side a bare `tags` column
+            # in SQL, so the GIN index on `tags` stays applicable.
+            filters.extend(
+                type_coerce(Spec.tags, JSONB).contains({category: [tag]}) for category in SPEC_TAG_CATEGORIES
+            )
+        else:
+            filters.append(cast(Spec.tags, String).contains(f'"{tag}"', autoescape=True))
+    return filters
 
 
 # =============================================================================
@@ -159,26 +189,13 @@ class SpecRepository(BaseRepository[Spec]):
         Lightweight: `Impl.code` stays deferred. Most callers (specs/plots/
         seo/insights/stats/debug routers) only need the listing surface;
         eager-loading every code blob would be a multi-MB regression.
-        Callers that iterate `spec.impls` and read `impl.code` on an async
-        session must use `get_all_with_code()` to avoid MissingGreenlet.
+        Callers that need code must fetch it explicitly (`ImplRepository.get_code`
+        / `get_by_library_with_code`) or code presence via
+        `ImplRepository.get_ids_with_code()` — touching `impl.code` on these
+        results raises MissingGreenlet on AsyncSession.
         """
         impls_loader = selectinload(Spec.impls)
         result = await self.session.execute(select(Spec).options(impls_loader.selectinload(Impl.library)))
-        return list(result.scalars().all())
-
-    async def get_all_with_code(self) -> list[Spec]:
-        """Get all specs with implementations (code + library eager-loaded).
-
-        Use this for paths that read `impl.code` on every implementation —
-        currently only the MCP `list_specs` and `search_specs` tools.
-        Touching `impl.code` after `get_all()` raises MissingGreenlet on
-        AsyncSession because the column is deferred and the lazy-load would
-        emit a sync SELECT.
-        """
-        impls_loader = selectinload(Spec.impls)
-        result = await self.session.execute(
-            select(Spec).options(impls_loader.selectinload(Impl.library), impls_loader.undefer(Impl.code))
-        )
         return list(result.scalars().all())
 
     async def get_ids(self) -> list[str]:
@@ -196,21 +213,18 @@ class SpecRepository(BaseRepository[Spec]):
         return result.scalar_one() or 0
 
     async def search_by_tags(self, tags: list[str]) -> list[Spec]:
-        """Search specs by tags. Eager-loads impls + library + code.
+        """Search specs by tags (matched in any tag category). Eager-loads impls + library.
 
-        impl.library and impl.code are both required by MCP
-        search_specs_by_tags (server.py iterates impls and reads both); not
-        eager-loading them on an async session raises MissingGreenlet.
+        impl.library is required by MCP search_specs_by_tags (server.py reads
+        `impl.library.id` while filtering); not eager-loading it on an async
+        session raises MissingGreenlet. `Impl.code` stays deferred — the MCP
+        caller only needs code *presence*, resolved separately via
+        `ImplRepository.get_ids_with_code()`.
         """
-        filters = []
-        for tag in tags:
-            filters.append(cast(Spec.tags, String).contains(f'"{tag}"'))
-
+        filters = _spec_tag_filters(tags, self.session.get_bind().dialect.name)
         impls_loader = selectinload(Spec.impls)
         result = await self.session.execute(
-            select(Spec)
-            .where(or_(*filters))
-            .options(impls_loader.selectinload(Impl.library), impls_loader.undefer(Impl.code))
+            select(Spec).where(or_(*filters)).options(impls_loader.selectinload(Impl.library))
         )
         return list(result.scalars().all())
 
@@ -334,6 +348,28 @@ class ImplRepository(BaseRepository[Impl]):
             select(Impl).where(Impl.library_id == library_id).options(selectinload(Impl.spec)).order_by(Impl.spec_id)
         )
         return list(result.scalars().all())
+
+    async def get_by_library_with_code(self, library_id: str) -> list[Impl]:
+        """Get all implementations for one library with `code` undeferred.
+
+        Serves /libraries/{id}/images, which renders the code of a single
+        library — undeferring code on an all-specs query would drag every
+        other library's multi-MB blobs along.
+        """
+        result = await self.session.execute(
+            select(Impl).where(Impl.library_id == library_id).options(undefer(Impl.code)).order_by(Impl.spec_id)
+        )
+        return list(result.scalars().all())
+
+    async def get_ids_with_code(self) -> set[str]:
+        """IDs of implementations whose `code` column is non-NULL.
+
+        Lightweight presence probe (id column only, code is never detoasted)
+        for listing surfaces that count or filter "real" implementations —
+        MCP list_specs / search_specs_by_tags — without undeferring blobs.
+        """
+        result = await self.session.execute(select(Impl.id).where(Impl.code.isnot(None)))
+        return {row[0] for row in result.all()}
 
     async def get_code(self, spec_id: str, library_id: str, language_id: str = "python") -> Impl | None:
         """Get a specific implementation with only the code field undeferred."""

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,6 +15,8 @@ anyplot is a specification-driven platform where **AI generates all plot impleme
 
 All contributions go through GitHub Issues with AI-powered validation and processing.
 
+By participating, you agree to our [Code of Conduct](../CODE_OF_CONDUCT.md).
+
 ---
 
 ## Request a New Plot

--- a/tests/unit/api/mcp/test_tools.py
+++ b/tests/unit/api/mcp/test_tools.py
@@ -4,6 +4,7 @@ Unit tests for MCP server tools.
 Tests all 6 MCP tools with mocked database sessions.
 """
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,6 +19,23 @@ from api.mcp.server import (
     list_specs,
     search_specs_by_tags,
 )
+
+
+@contextmanager
+def _repo_patches(mock_spec_repo, *specs):
+    """Patch SpecRepository and ImplRepository in api.mcp.server.
+
+    `get_ids_with_code` mirrors the SQL presence probe: it returns the ids of
+    every impl (across *specs*) whose mocked `code` is non-None.
+    """
+    mock_impl_repo = MagicMock()
+    ids = {impl.id for spec in specs for impl in spec.impls if impl.code is not None}
+    mock_impl_repo.get_ids_with_code = AsyncMock(return_value=ids)
+    with (
+        patch("api.mcp.server.SpecRepository", return_value=mock_spec_repo),
+        patch("api.mcp.server.ImplRepository", return_value=mock_impl_repo),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -84,10 +102,9 @@ def mock_spec():
 async def test_list_specs(mock_db_context, mock_spec):
     """Test list_specs tool."""
     mock_repo = MagicMock()
-    # list_specs reads impl.code on every spec → eager-loaded variant.
-    mock_repo.get_all_with_code = AsyncMock(return_value=[mock_spec])
+    mock_repo.get_all = AsyncMock(return_value=[mock_spec])
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, mock_spec):
         result = await list_specs(limit=10, offset=0)
 
     assert len(result) == 1
@@ -102,9 +119,9 @@ async def test_list_specs_pagination(mock_db_context):
     specs = [MagicMock(id=f"spec-{i}", title=f"Spec {i}", description="", tags={}, impls=[]) for i in range(5)]
 
     mock_repo = MagicMock()
-    mock_repo.get_all_with_code = AsyncMock(return_value=specs)
+    mock_repo.get_all = AsyncMock(return_value=specs)
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, *specs):
         result = await list_specs(limit=2, offset=1)
 
     assert len(result) == 2
@@ -113,12 +130,29 @@ async def test_list_specs_pagination(mock_db_context):
 
 
 @pytest.mark.asyncio
+async def test_list_specs_excludes_codeless_impls(mock_db_context, mock_spec):
+    """library_count counts only impls whose code column is non-NULL."""
+    codeless = MagicMock()
+    codeless.code = None
+    mock_spec.impls = [mock_spec.impls[0], codeless]
+
+    mock_repo = MagicMock()
+    mock_repo.get_all = AsyncMock(return_value=[mock_spec])
+
+    with _repo_patches(mock_repo, mock_spec):
+        result = await list_specs(limit=10, offset=0)
+
+    assert len(result) == 1
+    assert result[0]["library_count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_search_specs_by_tags_spec_level(mock_db_context, mock_spec):
     """Test search_specs_by_tags with spec-level filters."""
     mock_repo = MagicMock()
     mock_repo.search_by_tags = AsyncMock(return_value=[mock_spec])
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, mock_spec):
         result = await search_specs_by_tags(plot_type=["scatter"], domain=["statistics"])
 
     # Verify repository called with flattened list (order may vary)
@@ -132,11 +166,11 @@ async def test_search_specs_by_tags_spec_level(mock_db_context, mock_spec):
 async def test_search_specs_by_tags_impl_level(mock_db_context, mock_spec):
     """Test search_specs_by_tags with impl-level filters."""
     mock_repo = MagicMock()
-    # No spec-level tag filter → search_specs falls back to get_all_with_code
-    # because the impl-level filter loop reads `impl.code`.
-    mock_repo.get_all_with_code = AsyncMock(return_value=[mock_spec])
+    # No spec-level tag filter → search_specs falls back to get_all; the
+    # impl-level filter loop checks code presence via get_ids_with_code.
+    mock_repo.get_all = AsyncMock(return_value=[mock_spec])
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, mock_spec):
         result = await search_specs_by_tags(library=["matplotlib"], patterns=["data-generation"])
 
     assert len(result) == 1
@@ -147,9 +181,9 @@ async def test_search_specs_by_tags_impl_level(mock_db_context, mock_spec):
 async def test_search_specs_by_tags_no_matches(mock_db_context, mock_spec):
     """Test search_specs_by_tags filtering out non-matching impls."""
     mock_repo = MagicMock()
-    mock_repo.get_all_with_code = AsyncMock(return_value=[mock_spec])
+    mock_repo.get_all = AsyncMock(return_value=[mock_spec])
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, mock_spec):
         result = await search_specs_by_tags(library=["seaborn"])  # matplotlib impl, not seaborn
 
     assert len(result) == 0
@@ -161,9 +195,9 @@ async def test_search_specs_by_tags_null_impl_tags(mock_db_context, mock_spec):
     mock_spec.impls[0].impl_tags = None
 
     mock_repo = MagicMock()
-    mock_repo.get_all_with_code = AsyncMock(return_value=[mock_spec])
+    mock_repo.get_all = AsyncMock(return_value=[mock_spec])
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, mock_spec):
         # Library filter alone does not read impl_tags — still matches
         result = await search_specs_by_tags(library=["matplotlib"])
         assert len(result) == 1
@@ -180,9 +214,9 @@ async def test_search_specs_by_tags_null_impl_tags(mock_db_context, mock_spec):
 async def test_search_specs_by_tags_dataprep_styling(mock_db_context, mock_spec):
     """Test search_specs_by_tags with dataprep and styling filters."""
     mock_repo = MagicMock()
-    mock_repo.get_all_with_code = AsyncMock(return_value=[mock_spec])
+    mock_repo.get_all = AsyncMock(return_value=[mock_spec])
 
-    with patch("api.mcp.server.SpecRepository", return_value=mock_repo):
+    with _repo_patches(mock_repo, mock_spec):
         # Test dataprep filter - should not match (mock_spec has no dataprep tags)
         result = await search_specs_by_tags(dataprep=["normalization"])
         assert len(result) == 0

--- a/tests/unit/api/test_feedback_router.py
+++ b/tests/unit/api/test_feedback_router.py
@@ -5,13 +5,14 @@ from the database. Integration coverage (real persistence, rate limiting against
 SQLite) lives in tests/integration/api/test_api_endpoints.py.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from api.cache import clear_cache
 from api.main import app, fastapi_app
+from api.routers.feedback import _client_ip
 from core.database import get_db
 
 
@@ -150,3 +151,36 @@ class TestFeedbackRouter:
 
         assert response.status_code == 429
         instance.create.assert_not_awaited()
+
+
+class TestClientIpResolution:
+    """_client_ip must never key rate limiting on client-controlled header entries."""
+
+    @staticmethod
+    def _request(headers: dict[str, str], client_host: str | None = "10.0.0.1"):
+        request = MagicMock()
+        request.headers = headers
+        request.client = MagicMock(host=client_host) if client_host else None
+        return request
+
+    def test_prefers_cf_connecting_ip(self):
+        request = self._request(
+            {"cf-connecting-ip": "203.0.113.9", "x-forwarded-for": "6.6.6.6, 203.0.113.9, 172.68.0.1"}
+        )
+        assert _client_ip(request) == "203.0.113.9"
+
+    def test_ignores_spoofable_leftmost_xff_entry(self):
+        # The leftmost entry is attacker-supplied; only the rightmost was
+        # appended by the trusted infrastructure hop.
+        request = self._request({"x-forwarded-for": "6.6.6.6, 198.51.100.7"})
+        assert _client_ip(request) == "198.51.100.7"
+
+    def test_single_xff_entry(self):
+        request = self._request({"x-forwarded-for": "198.51.100.7"})
+        assert _client_ip(request) == "198.51.100.7"
+
+    def test_falls_back_to_client_host(self):
+        assert _client_ip(self._request({})) == "10.0.0.1"
+
+    def test_no_headers_no_client(self):
+        assert _client_ip(self._request({}, client_host=None)) == ""

--- a/tests/unit/api/test_feedback_router.py
+++ b/tests/unit/api/test_feedback_router.py
@@ -179,6 +179,15 @@ class TestClientIpResolution:
         request = self._request({"x-forwarded-for": "198.51.100.7"})
         assert _client_ip(request) == "198.51.100.7"
 
+    def test_skips_empty_trailing_xff_entry(self):
+        # Malformed "ip, " must not key everyone into one empty-string bucket.
+        request = self._request({"x-forwarded-for": "198.51.100.7, "})
+        assert _client_ip(request) == "198.51.100.7"
+
+    def test_whitespace_only_xff_falls_back_to_client_host(self):
+        request = self._request({"x-forwarded-for": " , "})
+        assert _client_ip(request) == "10.0.0.1"
+
     def test_falls_back_to_client_host(self):
         assert _client_ip(self._request({})) == "10.0.0.1"
 

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -277,17 +277,19 @@ class TestLibrariesRouter:
 
     def test_library_images_invalid_library(self, client: TestClient) -> None:
         """Library images should return 404 for invalid library."""
-        mock_spec_repo = MagicMock()
-        mock_spec_repo.get_all = AsyncMock(return_value=[])
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_by_library_with_code = AsyncMock(return_value=[])
 
         with (
             patch(DB_CONFIG_PATCH, return_value=True),
             patch("api.routers.libraries.get_cache", return_value=None),
             patch("api.routers.libraries.set_cache"),
-            patch("api.routers.libraries.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.libraries.ImplRepository", return_value=mock_impl_repo),
         ):
             response = client.get("/libraries/invalid_lib/images")
             assert response.status_code == 404
+            # The invalid id must be rejected before any DB round-trip.
+            mock_impl_repo.get_by_library_with_code.assert_not_awaited()
 
     def test_libraries_with_db(self, db_client, mock_lib) -> None:
         """Libraries should return data from DB when configured."""
@@ -323,16 +325,24 @@ class TestLibrariesRouter:
             assert data["libraries"][0]["id"] == "cached_lib"
 
     def test_library_images_with_db(self, db_client, mock_spec) -> None:
-        """Library images should return images from DB."""
+        """Library images should return images from the single-library impl query."""
         client, _ = db_client
 
-        mock_spec_repo = MagicMock()
-        mock_spec_repo.get_all_with_code = AsyncMock(return_value=[mock_spec])
+        mock_impl = mock_spec.impls[0]
+        mock_impl.spec_id = "scatter-basic"
+        mock_impl.language_id = "python"
+
+        # A preview-less impl must be filtered out of the response.
+        no_preview_impl = MagicMock()
+        no_preview_impl.preview_url = None
+
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_by_library_with_code = AsyncMock(return_value=[mock_impl, no_preview_impl])
 
         with (
             patch("api.routers.libraries.get_cache", return_value=None),
             patch("api.routers.libraries.set_cache"),
-            patch("api.routers.libraries.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.libraries.ImplRepository", return_value=mock_impl_repo),
         ):
             response = client.get("/libraries/matplotlib/images")
             assert response.status_code == 200
@@ -340,6 +350,7 @@ class TestLibrariesRouter:
             assert data["library"] == "matplotlib"
             assert len(data["images"]) == 1
             assert data["images"][0]["spec_id"] == "scatter-basic"
+            mock_impl_repo.get_by_library_with_code.assert_awaited_once_with("matplotlib")
 
     def test_library_images_cache_hit(self, db_client) -> None:
         """Library images should return cached data when available."""

--- a/tests/unit/core/database/test_repositories.py
+++ b/tests/unit/core/database/test_repositories.py
@@ -5,6 +5,7 @@ Uses in-memory SQLite to test repository operations.
 """
 
 import pytest
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.database.models import Library, Spec
@@ -12,11 +13,13 @@ from core.database.repositories import (
     IMPL_UPDATABLE_FIELDS,
     LANGUAGE_UPDATABLE_FIELDS,
     LIBRARY_UPDATABLE_FIELDS,
+    SPEC_TAG_CATEGORIES,
     SPEC_UPDATABLE_FIELDS,
     ImplRepository,
     LanguageRepository,
     LibraryRepository,
     SpecRepository,
+    _spec_tag_filters,
 )
 
 
@@ -147,6 +150,25 @@ class TestSpecRepository:
         await repo.create({"id": "s1", "title": "To Delete"})
         assert await repo.delete("s1") is True
         assert await repo.get_by_id("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_search_by_tags_sqlite_fallback(self, test_session: AsyncSession) -> None:
+        repo = SpecRepository(test_session)
+        await repo.create({"id": "scatter-basic", "title": "Basic Scatter", "tags": {"plot_type": ["scatter"]}})
+        await repo.create({"id": "bar-basic", "title": "Basic Bar", "tags": {"plot_type": ["bar"]}})
+
+        specs = await repo.search_by_tags(["scatter"])
+        assert [s.id for s in specs] == ["scatter-basic"]
+
+    @pytest.mark.asyncio
+    async def test_search_by_tags_escapes_like_metachars(self, test_session: AsyncSession) -> None:
+        """LIKE metacharacters in a tag value must match literally, not as wildcards."""
+        repo = SpecRepository(test_session)
+        await repo.create({"id": "pct-basic", "title": "Percent", "tags": {"features": ["100%_stacked"]}})
+        await repo.create({"id": "other", "title": "Other", "tags": {"features": ["100x_stacked"]}})
+
+        specs = await repo.search_by_tags(["100%_stacked"])
+        assert [s.id for s in specs] == ["pct-basic"]
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent(self, test_session: AsyncSession) -> None:
@@ -328,3 +350,46 @@ class TestImplRepository:
         loc = await repo.get_loc_per_impl()
         assert len(loc) == 1
         assert loc[0] == ("matplotlib", 2)
+
+    @pytest.mark.asyncio
+    async def test_get_by_library_with_code(self, setup_data: AsyncSession) -> None:
+        repo = ImplRepository(setup_data)
+        await repo.upsert("scatter-basic", "matplotlib", {"code": "import matplotlib"})
+        impls = await repo.get_by_library_with_code("matplotlib")
+        assert len(impls) == 1
+        assert impls[0].spec_id == "scatter-basic"
+        assert impls[0].code == "import matplotlib"
+
+        assert await repo.get_by_library_with_code("seaborn") == []
+
+    @pytest.mark.asyncio
+    async def test_get_ids_with_code(self, setup_data: AsyncSession) -> None:
+        repo = ImplRepository(setup_data)
+        with_code = await repo.upsert("scatter-basic", "matplotlib", {"code": "import matplotlib"})
+        setup_data.add(Spec(id="bar-basic", title="Basic Bar"))
+        await setup_data.commit()
+        codeless = await repo.upsert("bar-basic", "matplotlib", {"code": None})
+
+        ids = await repo.get_ids_with_code()
+        assert with_code.id in ids
+        assert codeless.id not in ids
+
+
+class TestSpecTagFilters:
+    """SQL shape of the tag-search filters per dialect."""
+
+    def test_postgresql_uses_jsonb_containment(self) -> None:
+        filters = _spec_tag_filters(["scatter"], "postgresql")
+        assert len(filters) == len(SPEC_TAG_CATEGORIES)
+        sql = str(filters[0].compile(dialect=postgresql.dialect()))
+        # `tags @> <bind>` with a bare left-hand column — the only shape the
+        # ix_specs_tags GIN index can serve. A CAST on the column would work
+        # too (jsonb→jsonb is a no-op) but this asserts the intent exactly.
+        assert "@>" in sql
+        assert sql.startswith("specs.tags")
+
+    def test_sqlite_falls_back_to_text_like(self) -> None:
+        filters = _spec_tag_filters(["scatter"], "sqlite")
+        assert len(filters) == 1
+        sql = str(filters[0].compile())
+        assert "LIKE" in sql


### PR DESCRIPTION
## Summary

- **Tag search finally uses the GIN index** — `SpecRepository.search_by_tags` cast the JSONB `tags` column to text and ran LIKE, which `ix_specs_tags` can never serve (seq scan on every MCP tag search) and which let `%`/`_` in tag values wildcard-match. On PostgreSQL it now emits per-category JSONB containment (`tags @> '{"<category>": ["<tag>"]}'` via `type_coerce`, keeping the left side a bare column so the index stays applicable); the SQLite test fallback escapes LIKE metacharacters via `autoescape` (audit 2026-07-15 Medium#17).
- **Hot listing paths stop dragging the full code corpus through the DB** — MCP `list_specs` / `search_specs_by_tags` and `/libraries/{id}/images` all called `get_all_with_code()` (every code blob of ~3,240 impls per request). The MCP tools now resolve code *presence* with a lightweight id probe (`ImplRepository.get_ids_with_code`), the images endpoint fetches only its own library's code (`get_by_library_with_code`), and the now caller-less `get_all_with_code()` is removed (audit Medium#5, issue #7696).
- **Feedback rate limiting no longer trusts a client-controlled header entry** — `/feedback` keyed its per-IP limit and duplicate suppression on the *first* `x-forwarded-for` entry, so a caller could evade the limit or poison a victim's bucket (5 spoofed posts = victim locked out). `_client_ip` now prefers Cloudflare's `cf-connecting-ip` and otherwise takes the rightmost, infrastructure-appended XFF entry (audit Medium#20).
- **`CODE_OF_CONDUCT.md`** (Contributor Covenant 2.1) added and linked from `docs/contributing.md` — closes the last repo-health gap after #9642 shipped the PR template and `.editorconfig` (audit Medium#29).

Also done outside this diff (session action, user-authorized): reconciled the ~50 contradictory `impl:*` labels on issue #1010 down to the 32 that match the filesystem state (8 `done`, 7 `failed`, watchdog history kept) so babysit-pipeline reads true state.

## Test plan

- [x] `uv run ruff check .` + `ruff format --check .` clean (148 files)
- [x] `uv run --extra typecheck mypy api core` clean
- [x] `uv run --extra test pytest tests/unit tests/integration` — 1650 passed
- [x] New tests: PG filters compile to `specs.tags @> …` (no CAST on the column), SQLite fallback matches literally with `%`/`_` in tag values, `get_ids_with_code` excludes NULL-code impls, `get_by_library_with_code` scopes to one library, `_client_ip` trust-order matrix (cf-connecting-ip > rightmost XFF > client.host)
- [ ] PostgreSQL query plan not verified against prod (no DB in sandbox); after deploy, `EXPLAIN` an MCP tag search should show a Bitmap Index Scan on `ix_specs_tags`

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]` (Keep-a-Changelog categories, bold-titled bullets; PR ref to be appended)
- [x] Related documentation updated (`docs/contributing.md` links the new Code of Conduct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kWZJgpARSK68RtfeHMEsK

---
_Generated by [Claude Code](https://claude.ai/code/session_015kWZJgpARSK68RtfeHMEsK)_