### PR TITLE
fix(workflows): restore CI Claude permissions broken by claude-code-action bump (pipeline generated nothing since July 5)

### DIFF
--- a/.github/workflows/daily-regen.yml
+++ b/.github/workflows/daily-regen.yml
@@ -230,7 +230,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model haiku'
+          claude_args: '--model haiku --settings ${{ github.workspace }}/.claude/settings.json'
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/spec-polish-claude.md` and follow those instructions.
@@ -246,7 +246,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model haiku'
+          claude_args: '--model haiku --settings ${{ github.workspace }}/.claude/settings.json'
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/impl-similarity-claude.md` and follow those instructions.

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -425,7 +425,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model ${{ steps.inputs.outputs.model }}"
+          claude_args: "--model ${{ steps.inputs.outputs.model }} --settings ${{ github.workspace }}/.claude/settings.json"
           # bulk-generate dispatches us from the github-actions bot; explicitly allow it.
           allowed_bots: '*'
           prompt: |
@@ -445,7 +445,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model ${{ steps.inputs.outputs.model }}"
+          claude_args: "--model ${{ steps.inputs.outputs.model }} --settings ${{ github.workspace }}/.claude/settings.json"
           # bulk-generate dispatches us from the github-actions bot; explicitly allow it.
           allowed_bots: '*'
           prompt: |
@@ -699,7 +699,7 @@ jobs:
               'specification_id': spec,
               'created': created_ts,
               'updated': ts,
-              # Reflects what claude_args=`--model {model}` actually runs: whatever
+              # Reflects what claude_args='--model {model}' actually runs: whatever
               # Claude Code's current alias for the chosen model resolves to.
               # Use the family name instead of a frozen version string so the
               # metadata doesn't go stale every model release.

--- a/.github/workflows/impl-repair.yml
+++ b/.github/workflows/impl-repair.yml
@@ -163,7 +163,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model ${{ inputs.model || 'sonnet' }}"
+          claude_args: "--model ${{ inputs.model || 'sonnet' }} --settings ${{ github.workspace }}/.claude/settings.json"
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/impl-repair-claude.md` and follow those instructions.
@@ -183,7 +183,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model ${{ inputs.model || 'sonnet' }}"
+          claude_args: "--model ${{ inputs.model || 'sonnet' }} --settings ${{ github.workspace }}/.claude/settings.json"
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/impl-repair-claude.md` and follow those instructions.

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -317,7 +317,7 @@ jobs:
           ATTEMPT: ${{ steps.attempts.outputs.display }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model ${{ steps.pr.outputs.model }}"
+          claude_args: "--model ${{ steps.pr.outputs.model }} --settings ${{ github.workspace }}/.claude/settings.json"
           allowed_bots: '*'
           prompt: |
             Read `prompts/workflow-prompts/ai-quality-review.md` and follow those instructions.

--- a/.github/workflows/report-validate.yml
+++ b/.github/workflows/report-validate.yml
@@ -66,7 +66,7 @@ jobs:
           ISSUE_USER: ${{ github.event.issue.user.login }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model opus --settings ${{ github.workspace }}/.claude/settings.json"
           prompt: |
             ## Task: Validate Issue Report
 

--- a/.github/workflows/spec-create.yml
+++ b/.github/workflows/spec-create.yml
@@ -77,7 +77,7 @@ jobs:
           ISSUE_USER: ${{ github.event.issue.user.login }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model opus --settings ${{ github.workspace }}/.claude/settings.json"
           prompt: |
             ## Task: Create New Specification
 
@@ -186,7 +186,7 @@ jobs:
           ISSUE_USER: ${{ github.event.issue.user.login }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model opus --settings ${{ github.workspace }}/.claude/settings.json"
           prompt: |
             ## Task: Create New Specification
 

--- a/.github/workflows/util-claude.yml
+++ b/.github/workflows/util-claude.yml
@@ -44,7 +44,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model opus --settings ${{ github.workspace }}/.claude/settings.json"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -56,7 +56,7 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model opus"
+          claude_args: "--model opus --settings ${{ github.workspace }}/.claude/settings.json"
 
           additional_permissions: |
             actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,9 +130,9 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 ### Fixed
 
 - **The whole Claude pipeline generates again — CI runs pass the repo's permission allowlist
-  explicitly** — since the July 5 `claude-code-action` bump (CLI 2.1.170 → 2.1.211), Claude Code
-  ignores `permissions.allow` from `.claude/settings.json` in untrusted workspaces, and a CI
-  checkout is never trusted; every impl-generate/repair, spec-create, polish and similarity run
+  explicitly** — since the July 5 `claude-code-action` bump (bundled CLI 2.1.170 → 2.1.195, by
+  now 2.1.211), Claude Code ignores `permissions.allow` from a committed `.claude/settings.json`
+  in untrusted workspaces, and a CI checkout is never trusted; every impl-generate/repair, spec-create, polish and similarity run
   had its Write/Edit/Bash calls silently denied (19–20 denials per run, zero files produced,
   zero implementations generated repo-wide since July 1). All 12 `claude-code-action` steps now
   pass `--settings .claude/settings.json` in `claude_args`, which the trust gate honors as an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,11 +136,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   had its Write/Edit/Bash calls silently denied (19–20 denials per run, zero files produced,
   zero implementations generated repo-wide since July 1). All 12 `claude-code-action` steps now
   pass `--settings .claude/settings.json` in `claude_args`, which the trust gate honors as an
-  explicit opt-in.
+  explicit opt-in (#9651).
 - **Metadata step no longer executes a comment as a command** — a backtick-quoted fragment
   inside the double-quoted Python heredoc of impl-generate's "Create library metadata file"
   step was command-substituted by bash (`--model: command not found` in every run log); the
-  comment now uses single quotes.
+  comment now uses single quotes (#9651).
 - **Tag search uses the GIN index and stops treating `%`/`_` as wildcards** —
   `SpecRepository.search_by_tags` cast the JSONB `tags` column to text and ran LIKE, which the
   `ix_specs_tags` GIN index can never serve (sequential scan on every MCP tag search) and which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,18 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The whole Claude pipeline generates again — CI runs pass the repo's permission allowlist
+  explicitly** — since the July 5 `claude-code-action` bump (CLI 2.1.170 → 2.1.211), Claude Code
+  ignores `permissions.allow` from `.claude/settings.json` in untrusted workspaces, and a CI
+  checkout is never trusted; every impl-generate/repair, spec-create, polish and similarity run
+  had its Write/Edit/Bash calls silently denied (19–20 denials per run, zero files produced,
+  zero implementations generated repo-wide since July 1). All 12 `claude-code-action` steps now
+  pass `--settings .claude/settings.json` in `claude_args`, which the trust gate honors as an
+  explicit opt-in.
+- **Metadata step no longer executes a comment as a command** — a backtick-quoted fragment
+  inside the double-quoted Python heredoc of impl-generate's "Create library metadata file"
+  step was command-substituted by bash (`--model: command not found` in every run log); the
+  comment now uses single quotes.
 - **Tag search uses the GIN index and stops treating `%`/`_` as wildcards** —
   `SpecRepository.search_by_tags` cast the JSONB `tags` column to text and ran LIKE, which the
   `ix_specs_tags` GIN index can never serve (sequential scan on every MCP tag search) and which


### PR DESCRIPTION
## Problem

**No implementation has been generated repo-wide since July 1.** Every `impl-generate` run since the July 5 Dependabot bump of `anthropics/claude-code-action` (#9513, again #9643) shows the same signature: the Claude step reports `is_error: false` after ~30 turns (~$1.5-2.0 spent), but `permission_denials_count: 18-20` and neither the implementation file nor `plot-light.png`/`plot-dark.png` exist afterwards. The `daily-regen` preflight steps (spec polish, similarity audit) show the same denials (1 and 7 per run). Because failures never advance the metadata `updated` timestamp, daily-regen re-picks the same oldest spec (`heatmap-calendar`) every tick and burns 15 failing runs per cycle.

## Root cause

The action bump carried a Claude Code CLI bump: **2.1.170 → 2.1.211**. Newer CLIs ignore `permissions.allow` entries from `.claude/settings.json` when the workspace has not been trusted (interactive trust dialog / `hasTrustDialogAccepted` in `~/.claude.json`) — and a fresh CI runner is never trusted. So the repo's allowlist (`Write`, `Edit`, `Bash`, …) was silently dropped and headless mode denied every write-capable tool call. Claude "finished" politely after being denied ~19 times, the action reported success, and the workflow failed later at the metadata/image steps.

Reproduced locally on CLI 2.1.218 with the repo's exact allowlist in a scratch project:

```
Ignoring 7 permissions.allow entries from .claude/settings.json: this workspace
has not been trusted. Run Claude Code interactively here once and accept the
trust dialog, or set projects["…"].hasTrustDialogAccepted: true in ~/.claude.json.
```

→ `Write` denied, no file created (turns=2, exactly the CI pattern).

## Fix

Pass the repo's settings file **explicitly** — the trust gate honors an explicit `--settings` flag as opt-in. Verified locally: same prompt, same allowlist, with `--settings .claude/settings.json` the file is written with **0 denials**.

Applied to **all 12 `claude-code-action` steps across 7 workflows** (`impl-generate` ×2, `impl-repair` ×2, `spec-create` ×2, `daily-regen` ×2, `util-claude` ×2, `impl-review`, `report-validate`):

```yaml
claude_args: "--model … --settings ${{ github.workspace }}/.claude/settings.json"
```

Also fixed while in the file: a backtick fragment in the metadata step's Python-heredoc comment was command-substituted by bash on every run (`--model: command not found` in all run logs) — now single-quoted.

## Why there is no green branch-CI proof

Branch-side validation of any change to these workflows is structurally impossible: the action's OAuth token exchange rejects runs whose workflow file differs from the default branch (`401 Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.`). This was verified with a dispatch of a pinned test variant — Claude never even started. The local reproduction above is the validation.

## Post-merge confirmation run

After merge, dispatch a single real generation and confirm it produces files:

```bash
gh workflow run impl-generate.yml -f specification_id=heatmap-calendar -f library=matplotlib -f model=sonnet
```

Expected: `permission_denials_count: 0`, implementation + both PNGs committed, run green through metadata/image steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Upstream context (source/changelog audit of the action + CLI)

- Version mapping: `11ba6048` = action v1.0.142 (bundled CLI **2.1.170**, worked) → Dependabot #9513 (July 5) = v1.0.159 (CLI **2.1.195**, first broken) → #9643 (July 20) = v1.0.175 (CLI **2.1.211**, still broken). The action's agent-mode permission plumbing is identical across all three refs — the only variable is the bundled CLI.
- The trust hardening is deliberate upstream direction: CLI 2.1.196 stopped honoring repo **self**-approval via committed `.claude/settings.json` (MCP), and 2.1.207 documents that only **user, `--settings`, and managed settings** remain trusted sources. That is why the explicit `--settings` flag is the upstream-blessed mechanism, not a workaround.
- **No action version fixes this**: audited through the latest release v1.0.181 (CLI 2.1.218) — the action never establishes workspace trust, so future Dependabot bumps stay broken without this flag. Keep `--settings` in `claude_args` permanently.
- Deliberately **not** chosen: `--permission-mode bypassPermissions` (works, but drops the allowlist semantics and any future `deny` rules) and pinning the action back to v1.0.142 (forgoes the v1.0.175 CI-correctness fixes: `is_error` → real failure, PR-trigger iterator hang, Bun tsconfig crash).
