### PR TITLE
fix(pipeline): retry the hand-off API calls that a GitHub brown-out killed

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -2,12 +2,17 @@ name: "Auto-update PR branches"
 run-name: "Auto-update PR branches after push to ${{ github.ref_name }}"
 
 # When `main` advances, update every open PR that has auto-merge enabled
-# and is BEHIND. Without this, the strict required-status-checks policy
-# (`strict_required_status_checks_policy: true` on the `main` ruleset)
-# blocks the auto-merge button forever — auto-merge fires only when checks
-# are green AND the head is up-to-date with the base, but it does not
-# update the branch on its own. This workflow closes that gap so polish /
-# impl PRs squash-merge themselves end-to-end.
+# and is BEHIND, so polish / impl PRs squash-merge themselves end-to-end
+# without manual "Update branch" clicks.
+#
+# NOTE (verified 2026-07-24): the `main` ruleset currently sets
+# `strict_required_status_checks_policy: false`, so an up-to-date head is
+# NOT actually required to merge. This file used to claim the opposite.
+# That means every update-branch call is optional work which also
+# invalidates the green checks on the previous head and forces a full CI
+# re-run. Retiring this workflow is worth evaluating — see #9675; it is
+# kept for now because the ruleset could be tightened again, and because
+# behaviour changes here affect every auto-merge PR in the repo.
 #
 # Why we don't use GitHub's native merge queue: this repository is
 # user-owned and merge_queue rules are not available on the account's
@@ -62,9 +67,41 @@ jobs:
             --limit 200 \
             --json number,title,headRefName,autoMergeRequest)
 
+          # Skip Dependabot branches. Updating them here is actively
+          # harmful: the update-branch merge commit is authored by
+          # github-actions[bot], and GitHub gates every workflow run
+          # triggered by that push behind manual approval
+          # ("action_required"). Because `main` advances every few minutes
+          # while the impl pipeline merges, the branch is re-updated long
+          # before anyone can approve — so CI never completes and
+          # auto-merge can never fire. PR #9674 accumulated 174 runs in
+          # 22 h that way: 162 action_required (github-actions[bot]) vs.
+          # only 4 green (dependabot[bot], from the original push).
+          #
+          # Leaving them alone is safe because the `main` ruleset is NOT
+          # strict (see the header) — a Dependabot PR merges while behind,
+          # so it never needs this update at all. It is explicitly NOT safe
+          # to assume Dependabot re-syncs them for us: Dependabot rebases on
+          # conflict / schedule / reopen, not on "merely behind", and it
+          # stops rebasing a PR entirely once a foreign commit is pushed to
+          # the branch. A branch already poisoned by such a commit stays
+          # stuck until someone comments `@dependabot recreate`.
           CANDIDATES=$(echo "$PRS" | jq -c '
-            [ .[] | select(.autoMergeRequest != null) ]
+            [ .[]
+              | select(.autoMergeRequest != null)
+              | select(.headRefName | startswith("dependabot/") | not)
+            ]
           ')
+
+          SKIPPED=$(echo "$PRS" | jq '
+            [ .[]
+              | select(.autoMergeRequest != null)
+              | select(.headRefName | startswith("dependabot/"))
+            ] | length
+          ')
+          if [[ "$SKIPPED" -gt 0 ]]; then
+            echo "::notice::Skipping $SKIPPED Dependabot PR(s) — Dependabot rebases those itself (see comment above)"
+          fi
 
           COUNT=$(echo "$CANDIDATES" | jq 'length')
           echo "::notice::Found $COUNT open PR(s) with auto-merge enabled"

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -10,7 +10,7 @@ run-name: "Auto-update PR branches after push to ${{ github.ref_name }}"
 # NOT actually required to merge. This file used to claim the opposite.
 # That means every update-branch call is optional work which also
 # invalidates the green checks on the previous head and forces a full CI
-# re-run. Retiring this workflow is worth evaluating — see #9675; it is
+# re-run. Retiring this workflow is worth evaluating — see #9772; it is
 # kept for now because the ruleset could be tightened again, and because
 # behaviour changes here affect every auto-merge PR in the repo.
 #

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -80,12 +80,13 @@ jobs:
           #
           # Leaving them alone is safe because the `main` ruleset is NOT
           # strict (see the header) — a Dependabot PR merges while behind,
-          # so it never needs this update at all. It is explicitly NOT safe
-          # to assume Dependabot re-syncs them for us: Dependabot rebases on
+          # so it never needs this update at all. Do NOT justify this by
+          # assuming Dependabot re-syncs them for us: it rebases on
           # conflict / schedule / reopen, not on "merely behind", and it
-          # stops rebasing a PR entirely once a foreign commit is pushed to
-          # the branch. A branch already poisoned by such a commit stays
-          # stuck until someone comments `@dependabot recreate`.
+          # stops rebasing a branch entirely once a foreign commit lands on
+          # it. The point is that the head now stays put, so a branch this
+          # workflow already touched needs its gated run approved exactly
+          # once instead of being re-gated every few minutes.
           CANDIDATES=$(echo "$PRS" | jq -c '
             [ .[]
               | select(.autoMergeRequest != null)

--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -101,7 +101,7 @@ jobs:
             ] | length
           ')
           if [[ "$SKIPPED" -gt 0 ]]; then
-            echo "::notice::Skipping $SKIPPED Dependabot PR(s) — Dependabot rebases those itself (see comment above)"
+            echo "::notice::Skipping $SKIPPED Dependabot PR(s) — updating them gates their CI behind manual approval, and the non-strict ruleset means being behind does not block the merge (see comment above)"
           fi
 
           COUNT=$(echo "$CANDIDATES" | jq 'length')

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -47,7 +47,26 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             PR_NUM="$INPUT_PR_NUMBER"
-            PR_DATA=$(gh pr view "$PR_NUM" --repo "$GH_REPO" --json headRefName,labels)
+            # Retry gh pr view — an unretried call here stranded an already
+            # ai-approved PR (#9742) when the GitHub GraphQL API returned
+            # HTTP 504 during the 2026-07-24 API brown-out. `bash -e` turned
+            # the blip into a permanently unmerged PR. Same 3x/linear-backoff
+            # shape as impl-review.yml's "Extract PR info".
+            PR_DATA=""
+            for attempt in 1 2 3; do
+              if gh pr view "$PR_NUM" --repo "$GH_REPO" --json headRefName,labels > /tmp/pr.json 2> /tmp/pr.err; then
+                PR_DATA=$(cat /tmp/pr.json)
+                break
+              fi
+              echo "::warning::gh pr view failed (attempt ${attempt}/3): $(cat /tmp/pr.err)"
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 5))
+              fi
+            done
+            if [ -z "$PR_DATA" ]; then
+              echo "::error::gh pr view failed after 3 attempts for PR #${PR_NUM}"
+              exit 1
+            fi
             BRANCH=$(echo "$PR_DATA" | jq -r '.headRefName')
             HAS_APPROVED=$(echo "$PR_DATA" | jq -r '[.labels[].name] | any(. == "ai-approved")')
           else
@@ -223,6 +242,21 @@ jobs:
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "::notice::Merge attempt $attempt/$MAX_ATTEMPTS"
+
+            # Re-read state first so a lost response is a no-op rather than a
+            # half-finished merge: `gh pr merge` can succeed server-side and
+            # still return 5xx, after which every later attempt fails with
+            # "already merged" and the step exits 1. Because all post-merge
+            # steps are gated on `should_run == 'true'` (implicit success()),
+            # that skipped GCS promotion, the impl:{lib}:done label, closing
+            # the issue and the Postgres sync — a merged PR with none of the
+            # bookkeeping, exactly the silent partial completion CLAUDE.md
+            # warns about for manually merged PRs.
+            STATE=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json state -q .state 2>/dev/null || echo "")
+            if [ "$STATE" = "MERGED" ]; then
+              echo "::notice::PR #${PR_NUM} is already merged — continuing to post-merge steps"
+              exit 0
+            fi
 
             # Update branch before merge attempt
             gh pr update-branch "$PR_NUM" --repo "$REPOSITORY" 2>/dev/null || true

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -296,14 +296,25 @@ jobs:
               --repo "$REPOSITORY" \
               --squash \
               --admin \
-              --delete-branch; then
+              --delete-branch 2> /tmp/merge.err; then
               echo "::notice::Merge successful on attempt $attempt"
+              exit 0
+            fi
+
+            # Second line of defence for the same lost-response case: if the
+            # state probe above is ALSO failing (same brown-out), the merge can
+            # already be done while every retry here reports "already merged"
+            # until the loop exits 1 and the post-merge bookkeeping is skipped.
+            # gh saying the PR is already merged IS the success signal.
+            MERR=$(head -c 500 /tmp/merge.err | tr '\n' ' ')
+            if grep -qiE 'already merged|pull request is (already )?(merged|closed)' /tmp/merge.err; then
+              echo "::notice::PR #${PR_NUM} reported as already merged — continuing to post-merge steps"
               exit 0
             fi
 
             if [ $attempt -lt $MAX_ATTEMPTS ]; then
               DELAY=$((attempt * 10))
-              echo "::warning::Merge failed, retrying in ${DELAY}s..."
+              echo "::warning::Merge failed (${MERR}), retrying in ${DELAY}s..."
               sleep $DELAY
             fi
           done

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -58,7 +58,10 @@ jobs:
                 PR_DATA=$(cat /tmp/pr.json)
                 break
               fi
-              echo "::warning::gh pr view failed (attempt ${attempt}/3): $(cat /tmp/pr.err)"
+              # Flattened: `::warning::` is line-oriented, and gh's HTTP errors
+              # are routinely multi-line — the tail would spill into the raw log.
+              PERR=$(tr '\n' ' ' < /tmp/pr.err | head -c 500)
+              echo "::warning::gh pr view failed (attempt ${attempt}/3): ${PERR}"
               if [ "$attempt" -lt 3 ]; then
                 sleep $((attempt * 5))
               fi
@@ -252,7 +255,25 @@ jobs:
             # the issue and the Postgres sync — a merged PR with none of the
             # bookkeeping, exactly the silent partial completion CLAUDE.md
             # warns about for manually merged PRs.
-            STATE=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json state -q .state 2>/dev/null || echo "")
+            # The state read is itself retried: a blip here would fall through
+            # to another `gh pr merge` on an already-merged PR and re-create the
+            # very failure mode this check exists to prevent — under exactly the
+            # brown-out conditions that motivate it.
+            STATE=""
+            for probe in 1 2 3; do
+              if STATE=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json state -q .state 2> /tmp/state.err); then
+                break
+              fi
+              SERR=$(tr '\n' ' ' < /tmp/state.err | head -c 500)
+              echo "::warning::gh pr view (state) failed (probe ${probe}/3): ${SERR}"
+              STATE=""
+              if [ "$probe" -lt 3 ]; then
+                sleep $((probe * 5))
+              fi
+            done
+            if [ -z "$STATE" ]; then
+              echo "::warning::Could not read state for PR #${PR_NUM} — proceeding to merge attempt $attempt"
+            fi
             if [ "$STATE" = "MERGED" ]; then
               echo "::notice::PR #${PR_NUM} is already merged — continuing to post-merge steps"
               exit 0

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -60,7 +60,7 @@ jobs:
               fi
               # Flattened: `::warning::` is line-oriented, and gh's HTTP errors
               # are routinely multi-line — the tail would spill into the raw log.
-              PERR=$(tr '\n' ' ' < /tmp/pr.err | head -c 500)
+              PERR=$(head -c 500 /tmp/pr.err | tr '\n' ' ')
               echo "::warning::gh pr view failed (attempt ${attempt}/3): ${PERR}"
               if [ "$attempt" -lt 3 ]; then
                 sleep $((attempt * 5))
@@ -264,7 +264,7 @@ jobs:
               if STATE=$(gh pr view "$PR_NUM" --repo "$REPOSITORY" --json state -q .state 2> /tmp/state.err); then
                 break
               fi
-              SERR=$(tr '\n' ' ' < /tmp/state.err | head -c 500)
+              SERR=$(head -c 500 /tmp/state.err | tr '\n' ' ')
               echo "::warning::gh pr view (state) failed (probe ${probe}/3): ${SERR}"
               STATE=""
               if [ "$probe" -lt 3 ]; then

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -62,7 +62,8 @@ jobs:
               PR_DATA=$(cat /tmp/pr.json)
               break
             fi
-            echo "::warning::gh pr view failed (attempt ${attempt}/3): $(cat /tmp/pr.err)"
+            PERR=$(head -c 500 /tmp/pr.err | tr '\n' ' ')
+            echo "::warning::gh pr view failed (attempt ${attempt}/3): ${PERR}"
             if [ "$attempt" -lt 3 ]; then
               sleep $((attempt * 5))
             fi
@@ -866,7 +867,7 @@ jobs:
               if "$@" 2> /tmp/gh_retry.err; then
                 return 0
               fi
-              err=$(tr '\n' ' ' < /tmp/gh_retry.err | head -c 500)
+              err=$(head -c 500 /tmp/gh_retry.err | tr '\n' ' ')
               echo "::warning::${what} failed (attempt ${attempt}/3): ${err}"
               if [ "$attempt" -lt 3 ]; then
                 sleep $((attempt * 5))
@@ -888,7 +889,7 @@ jobs:
               READ_OK=1
               break
             fi
-            LERR=$(tr '\n' ' ' < /tmp/labels.err | head -c 500)
+            LERR=$(head -c 500 /tmp/labels.err | tr '\n' ' ')
             echo "::warning::gh pr view (labels) failed (attempt ${attempt}/3): ${LERR}"
             if [ "$attempt" -lt 3 ]; then
               sleep $((attempt * 5))

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -850,12 +850,58 @@ jobs:
           THRESHOLD=$((90 - ATTEMPT_COUNT * 10))
           if [ "$THRESHOLD" -lt 50 ]; then THRESHOLD=50; fi
 
-          # Check if verdict label was already added by earlier step
-          CURRENT_LABELS=$(gh pr view "$PR_NUM" --json labels -q '.labels[].name' 2>/dev/null || echo "")
+          # This step is the pipeline's only hand-off point: every downstream
+          # workflow (merge, repair) starts from a call made right here. An
+          # unretried blip therefore does not just fail a step — it strands the
+          # PR forever with a verdict label and nothing listening. That is
+          # exactly what the 2026-07-24 GitHub API brown-out did to four
+          # radar-basic PRs (HTTP 502 on the dispatch endpoint, HTTP 504 on
+          # GraphQL). Every API call below is retried 3x with linear backoff.
+          # `::warning::` is line-oriented, so multi-line gh stderr would leak
+          # everything after the first newline into the raw log — flatten it.
+          gh_retry() {
+            local what="$1"; shift
+            local attempt err
+            for attempt in 1 2 3; do
+              if "$@" 2> /tmp/gh_retry.err; then
+                return 0
+              fi
+              err=$(tr '\n' ' ' < /tmp/gh_retry.err | head -c 500)
+              echo "::warning::${what} failed (attempt ${attempt}/3): ${err}"
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 5))
+              fi
+            done
+            echo "::error::${what} failed after 3 attempts for PR #${PR_NUM}"
+            return 1
+          }
+
+          # Check if verdict label was already added by earlier step.
+          # Track read success explicitly rather than inferring it from an
+          # empty result: a failed read and a genuinely label-less PR used to
+          # be indistinguishable, and both silently skipped the two branches
+          # below, dropping the PR out of the pipeline with no error at all.
+          CURRENT_LABELS=""
+          READ_OK=0
+          for attempt in 1 2 3; do
+            if CURRENT_LABELS=$(gh pr view "$PR_NUM" --json labels -q '.labels[].name' 2> /tmp/labels.err); then
+              READ_OK=1
+              break
+            fi
+            LERR=$(tr '\n' ' ' < /tmp/labels.err | head -c 500)
+            echo "::warning::gh pr view (labels) failed (attempt ${attempt}/3): ${LERR}"
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          if [ "$READ_OK" -ne 1 ]; then
+            echo "::error::Could not read labels for PR #${PR_NUM} after 3 attempts — refusing to decide blind"
+            exit 1
+          fi
 
           if echo "$CURRENT_LABELS" | grep -q "ai-approved"; then
             echo "::notice::ai-approved label already set (Score $SCORE >= $THRESHOLD), triggering merge"
-            gh workflow run impl-merge.yml -f pr_number="$PR_NUM"
+            gh_retry "impl-merge dispatch" gh workflow run impl-merge.yml -f pr_number="$PR_NUM"
             exit 0
           fi
 
@@ -863,19 +909,58 @@ jobs:
             # Still have repair attempts left? (Max 4 repairs = 5 reviews total)
             if [ "$ATTEMPT_COUNT" -lt 4 ]; then
               echo "::notice::ai-rejected label set (Score $SCORE < $THRESHOLD), triggering repair attempt $((ATTEMPT_COUNT + 1))"
-              gh pr edit "$PR_NUM" --add-label "ai-attempt-${ATTEMPT}" 2>/dev/null || true
-              gh workflow run impl-repair.yml \
+
+              # Dispatch BEFORE labelling, and never let the label gate the
+              # dispatch: impl-repair.yml is workflow_dispatch-only, so this
+              # call is the single thing that keeps the PR moving. Losing the
+              # attempt label costs one over-strict review; losing the dispatch
+              # costs the whole PR.
+              DISPATCHED=0
+              if gh_retry "impl-repair dispatch" gh workflow run impl-repair.yml \
                 -f pr_number="$PR_NUM" \
                 -f specification_id="$SPEC_ID" \
                 -f library="$LIBRARY" \
                 -f attempt="$ATTEMPT" \
-                -f model="$MODEL"
+                -f model="$MODEL"; then
+                DISPATCHED=1
+              fi
+
+              # `ai-attempt-4` was never created in this repo, so on the 4th
+              # repair the add fails deterministically no matter how often it
+              # is retried (PRs #7268/#7039 reached "Repair Attempt 4/4"
+              # carrying only ai-attempt-1..3 — the old `|| true` hid it).
+              gh label create "ai-attempt-${ATTEMPT}" --color "fbca04" \
+                --description "Repair attempt ${ATTEMPT}" 2>/dev/null || true
+              # Non-fatal, but loud: without it the next review resets to the
+              # attempt-0 threshold (>= 90) and the PR re-fails a bar it has
+              # already cleared. PR #9744 lost it exactly this way on 2026-07-24.
+              gh_retry "ai-attempt-${ATTEMPT} label" gh pr edit "$PR_NUM" --add-label "ai-attempt-${ATTEMPT}" \
+                || echo "::error::attempt label lost — the next review will apply the stricter attempt-0 threshold"
+
+              if [ "$DISPATCHED" -ne 1 ]; then
+                # Hand the PR to the watchdog rather than leaving it dead.
+                # `ai-rejected` + `ai-attempt-N` matches NO watchdog case
+                # (Case 2 excludes any verdict label, Case 4 excludes PRs that
+                # already have an attempt label), so dropping the verdict puts
+                # it squarely in Case 2, which re-dispatches impl-repair at the
+                # attempt number the label still encodes.
+                gh pr edit "$PR_NUM" --remove-label "ai-rejected" 2>/dev/null || true
+                echo "::error::impl-repair dispatch failed after 3 attempts — verdict label dropped so watchdog Case 2 picks PR #${PR_NUM} up"
+                exit 1
+              fi
             else
               # All 4 repair attempts exhausted
               echo "::notice::All 4 repair attempts exhausted (Score $SCORE < 50)"
               gh pr edit "$PR_NUM" --add-label "quality-poor"
 
-              gh pr comment "$PR_NUM" --body "$(cat <<'EOF'
+              # Unquoted delimiter so $SCORE/$LIBRARY/$REPOSITORY/$RUN_ID expand
+              # — with <<'EOF' this comment rendered a literal "$SCORE/100".
+              # The markdown code span's backticks MUST stay escaped: in an
+              # unquoted heredoc they would otherwise run as command
+              # substitution. Expanding the variables is safe even though
+              # $LIBRARY derives from a branch name, because bash does not
+              # re-evaluate substituted values.
+              gh pr comment "$PR_NUM" --body "$(cat <<EOF
           ## AI Review - Final Status
 
           ### Score: $SCORE/100 (Below Threshold)
@@ -885,7 +970,7 @@ jobs:
           **This is treated like an auto-reject.** The PR will be closed and any old implementation will be removed from main.
 
           **Options:**
-          1. Regenerate from scratch with `generate:$LIBRARY` label
+          1. Regenerate from scratch with \`generate:$LIBRARY\` label
           2. Manual complete rewrite
 
           ---
@@ -922,3 +1007,10 @@ jobs:
             fi
             exit 0
           fi
+
+          # Labels read fine but carry no verdict — "Add preliminary verdict
+          # label (early)" must have been skipped or its write lost. Nothing
+          # downstream listens for this state, so say so loudly instead of
+          # ending the step green with the PR quietly parked.
+          echo "::error::PR #${PR_NUM} has neither ai-approved nor ai-rejected after review (score $SCORE, threshold $THRESHOLD) — no downstream workflow was triggered"
+          exit 1

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -944,7 +944,11 @@ jobs:
                 # already have an attempt label), so dropping the verdict puts
                 # it squarely in Case 2, which re-dispatches impl-repair at the
                 # attempt number the label still encodes.
-                gh pr edit "$PR_NUM" --remove-label "ai-rejected" 2>/dev/null || true
+                # Retried too: this removal IS the hand-off to the watchdog, so
+                # letting the same brown-out swallow it would leave the PR in
+                # exactly the stranded state it is meant to escape.
+                gh_retry "ai-rejected removal" gh pr edit "$PR_NUM" --remove-label "ai-rejected" \
+                  || echo "::error::could not drop ai-rejected — PR #${PR_NUM} is stranded (ai-rejected + ai-attempt-N matches no watchdog case) and needs manual attention"
                 echo "::error::impl-repair dispatch failed after 3 attempts — verdict label dropped so watchdog Case 2 picks PR #${PR_NUM} up"
                 exit 1
               fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,46 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **A GitHub API brown-out could strand implementation PRs permanently — the hand-off calls
+  are now retried** — on 2026-07-24 (~16:05–16:26 UTC) GitHub returned HTTP 502 on the
+  workflow-dispatch endpoint and HTTP 504 on GraphQL, and four `radar-basic` PRs fell out of
+  the pipeline: #9742 was already `ai-approved` but `impl-merge`'s condition check died on a
+  `gh pr view` (so it never merged), and #9744/#9749/#9751 were `ai-rejected` but their
+  `impl-repair` dispatch never landed. `impl-review`'s verdict step is the pipeline's only
+  hand-off point — every downstream workflow starts from a call made there — so an unretried
+  blip did not merely fail a step, it left a PR with a verdict label and nothing listening.
+  All API calls in that step and in `impl-merge`'s condition check now retry 3× with linear
+  backoff, and the repair dispatch is issued *before* the attempt label so a label problem can
+  never suppress it. If the dispatch still exhausts its retries, the step now drops the
+  `ai-rejected` label on the way out: `ai-rejected` + `ai-attempt-N` matches no watchdog case,
+  whereas the label-less state is exactly Case 2, which re-dispatches the repair at the right
+  attempt number (#9675).
+- **The 4th repair attempt was silently dead — `ai-attempt-4` never existed as a label** — the
+  attempt label is what encodes the cascading review threshold (90 → 80 → 70 → 60 → 50), but
+  the repo only ever had `ai-attempt-1..3`, so on the 4th repair the add failed every time and
+  was swallowed by `|| true` (PRs #7268/#7039 reached "Repair Attempt 4/4" carrying only
+  `ai-attempt-1..3`). Every 4th review therefore re-applied the ≥ 90 attempt-0 bar, and the
+  "all attempts exhausted" branch — which closes the PR and removes the stale implementation —
+  could never be reached. The label is now created on demand (#9675).
+- **A merged implementation PR could end up with none of its bookkeeping** — `impl-merge`'s
+  5× merge retry re-invoked `gh pr merge` without re-reading state, so a merge that succeeded
+  server-side but lost its HTTP response failed four more times with "already merged" and then
+  exited 1. All post-merge steps are gated on `should_run == 'true'` (implicit `success()`), so
+  GCS promotion, the `impl:{lib}:done` label, closing the issue and the Postgres sync were all
+  skipped on an already-merged PR — the silent partial completion CLAUDE.md warns about. The
+  loop now checks for `MERGED` first and continues to the post-merge steps (#9675).
+- **Dependabot PRs could never merge while the plot pipeline was running** —
+  `auto-update-pr-branches.yml` called `update-branch` on Dependabot PRs too, but that push is
+  authored by `github-actions[bot]` and GitHub gates every workflow run it triggers behind
+  manual approval (`action_required`). Because `main` advances every few minutes while impl PRs
+  merge, each branch was re-updated long before anyone could approve, so CI never completed and
+  auto-merge never fired: PR #9674 accumulated 174 runs in 22 h — 162 `action_required` against
+  only 4 green (the original `dependabot[bot]` push). Dependabot branches are now skipped.
+  They merge fine while behind (the `main` ruleset is not strict — the file's header claimed
+  otherwise and has been corrected), and branches already poisoned by such a commit need a
+  one-time `@dependabot recreate`, since Dependabot stops rebasing a branch once a foreign
+  commit lands on it. `/dependabot`'s playbook told operators to run that same harmful
+  `update-branch` by hand and now says the opposite (#9675).
 - **anyplot.ai white-screen outage (2026-07-23, ~22:15–23:00 UTC): vite pinned back to
   8.0.16** — the npm-minor Dependabot group (#9657) bumped vite 8.0.16 → 8.1.5, whose rolldown
   1.1.5 bundler emits a broken `mui`/`@emotion` chunk under our `manualChunks` split; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,21 +142,21 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   never suppress it. If the dispatch still exhausts its retries, the step now drops the
   `ai-rejected` label on the way out: `ai-rejected` + `ai-attempt-N` matches no watchdog case,
   whereas the label-less state is exactly Case 2, which re-dispatches the repair at the right
-  attempt number (#9675).
+  attempt number (#9772).
 - **The 4th repair attempt was silently dead — `ai-attempt-4` never existed as a label** — the
   attempt label is what encodes the cascading review threshold (90 → 80 → 70 → 60 → 50), but
   the repo only ever had `ai-attempt-1..3`, so on the 4th repair the add failed every time and
   was swallowed by `|| true` (PRs #7268/#7039 reached "Repair Attempt 4/4" carrying only
   `ai-attempt-1..3`). Every 4th review therefore re-applied the ≥ 90 attempt-0 bar, and the
   "all attempts exhausted" branch — which closes the PR and removes the stale implementation —
-  could never be reached. The label is now created on demand (#9675).
+  could never be reached. The label is now created on demand (#9772).
 - **A merged implementation PR could end up with none of its bookkeeping** — `impl-merge`'s
   5× merge retry re-invoked `gh pr merge` without re-reading state, so a merge that succeeded
   server-side but lost its HTTP response failed four more times with "already merged" and then
   exited 1. All post-merge steps are gated on `should_run == 'true'` (implicit `success()`), so
   GCS promotion, the `impl:{lib}:done` label, closing the issue and the Postgres sync were all
   skipped on an already-merged PR — the silent partial completion CLAUDE.md warns about. The
-  loop now checks for `MERGED` first and continues to the post-merge steps (#9675).
+  loop now checks for `MERGED` first and continues to the post-merge steps (#9772).
 - **Dependabot PRs could never merge while the plot pipeline was running** —
   `auto-update-pr-branches.yml` called `update-branch` on Dependabot PRs too, but that push is
   authored by `github-actions[bot]` and GitHub gates every workflow run it triggers behind
@@ -168,7 +168,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   otherwise and has been corrected), and branches already poisoned by such a commit need a
   one-time `@dependabot recreate`, since Dependabot stops rebasing a branch once a foreign
   commit lands on it. `/dependabot`'s playbook told operators to run that same harmful
-  `update-branch` by hand and now says the opposite (#9675).
+  `update-branch` by hand and now says the opposite (#9772).
 - **anyplot.ai white-screen outage (2026-07-23, ~22:15–23:00 UTC): vite pinned back to
   8.0.16** — the npm-minor Dependabot group (#9657) bumped vite 8.0.16 → 8.1.5, whose rolldown
   1.1.5 bundler emits a broken `mui`/`@emotion` chunk under our `manualChunks` split; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,10 +165,10 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   auto-merge never fired: PR #9674 accumulated 174 runs in 22 h — 162 `action_required` against
   only 4 green (the original `dependabot[bot]` push). Dependabot branches are now skipped.
   They merge fine while behind (the `main` ruleset is not strict — the file's header claimed
-  otherwise and has been corrected), and branches already poisoned by such a commit need a
-  one-time `@dependabot recreate`, since Dependabot stops rebasing a branch once a foreign
-  commit lands on it. `/dependabot`'s playbook told operators to run that same harmful
-  `update-branch` by hand and now says the opposite (#9772).
+  otherwise and has been corrected). An already-updated branch needs its gated run approved
+  once; that now sticks, because nothing pushes to the branch again. `/dependabot`'s playbook
+  told operators to run that same harmful `update-branch` by hand and now says the opposite
+  (#9772).
 - **anyplot.ai white-screen outage (2026-07-23, ~22:15–23:00 UTC): vite pinned back to
   8.0.16** — the npm-minor Dependabot group (#9657) bumped vite 8.0.16 → 8.1.5, whose rolldown
   1.1.5 bundler emits a broken `mui`/`@emotion` chunk under our `manualChunks` split; the

--- a/agentic/commands/dependabot.md
+++ b/agentic/commands/dependabot.md
@@ -27,7 +27,7 @@ known GitHub quirks. Every gotcha below cost real session round-trips.
      workflow runs behind manual approval (`action_required`, so the checks never report), and
      Dependabot permanently stops rebasing a branch once a foreign commit lands on it. PR #9674
      burned 174 runs in 22 h this way. `auto-update-pr-branches.yml` skips Dependabot branches
-     for the same reason (#9675).
+     for the same reason (#9772).
    - **Already poisoned** (head commit authored by `github-actions[bot]`, checks stuck at
      `action_required`): comment `@dependabot recreate` on the PR. That force-pushes a fresh
      `dependabot[bot]`-authored head whose CI is not gated. Approving the pending run via

--- a/agentic/commands/dependabot.md
+++ b/agentic/commands/dependabot.md
@@ -20,11 +20,19 @@ known GitHub quirks. Every gotcha below cost real session round-trips.
 2. Per PR, in order:
    - Checks green → `gh pr merge <num> --auto --squash`.
    - Checks pending on an up-to-date branch → enable auto-merge anyway; it fires when green.
-   - **BEHIND branch**: update it via `gh api -X PUT repos/{owner}/{repo}/pulls/<num>/update-branch`
-     (the installed `gh` has no `pr update-branch` subcommand). **Gotcha:** branch updates pushed
-     with `GITHUB_TOKEN` (incl. `auto-update-pr-branches.yml`) do NOT trigger required checks —
-     if checks stay `expected`/missing after the update, disable auto-merge, then
-     `gh pr close <num> && gh pr reopen <num>` to re-trigger them.
+   - **BEHIND branch**: leave it alone. BEHIND does not block the merge — the `main` ruleset is
+     not strict (`strict_required_status_checks_policy: false`), so auto-merge fires on a behind
+     branch. **Never** run `gh api -X PUT .../pulls/<num>/update-branch` on a Dependabot PR: the
+     resulting merge commit is authored by `github-actions[bot]`, GitHub then gates that head's
+     workflow runs behind manual approval (`action_required`, so the checks never report), and
+     Dependabot permanently stops rebasing a branch once a foreign commit lands on it. PR #9674
+     burned 174 runs in 22 h this way. `auto-update-pr-branches.yml` skips Dependabot branches
+     for the same reason (#9675).
+   - **Already poisoned** (head commit authored by `github-actions[bot]`, checks stuck at
+     `action_required`): comment `@dependabot recreate` on the PR. That force-pushes a fresh
+     `dependabot[bot]`-authored head whose CI is not gated. Approving the pending run via
+     `gh api -X POST repos/{owner}/{repo}/actions/runs/<id>/approve` also works, but only holds
+     until something pushes to the branch again.
    - `mergeStateStatus` is computed async — after any update, poll it a few seconds until it
      stabilizes before deciding (UNKNOWN → BEHIND/CLEAN/BLOCKED).
 3. A dep bump breaking tests/config (e.g. a major with changed exports): consult **Context7**

--- a/agentic/commands/dependabot.md
+++ b/agentic/commands/dependabot.md
@@ -29,10 +29,12 @@ known GitHub quirks. Every gotcha below cost real session round-trips.
      burned 174 runs in 22 h this way. `auto-update-pr-branches.yml` skips Dependabot branches
      for the same reason (#9772).
    - **Already poisoned** (head commit authored by `github-actions[bot]`, checks stuck at
-     `action_required`): comment `@dependabot recreate` on the PR. That force-pushes a fresh
-     `dependabot[bot]`-authored head whose CI is not gated. Approving the pending run via
-     `gh api -X POST repos/{owner}/{repo}/actions/runs/<id>/approve` also works, but only holds
-     until something pushes to the branch again.
+     `action_required`): approve the gated runs once —
+     `gh api -X POST repos/{owner}/{repo}/actions/runs/<id>/approve`. Approved runs do report
+     the required contexts on a bot-authored head (verified on #9674), and since
+     `auto-update-pr-branches.yml` no longer touches these branches the head now stays put, so
+     one approval is enough. `@dependabot recreate` also works and additionally restores a
+     clean `dependabot[bot]` head, but it re-resolves the versions.
    - `mergeStateStatus` is computed async — after any update, poll it a few seconds until it
      stabilizes before deciding (UNKNOWN → BEHIND/CLEAN/BLOCKED).
 3. A dep bump breaking tests/config (e.g. a major with changed exports): consult **Context7**


### PR DESCRIPTION
## What happened

On **2026-07-24, ~16:05–16:26 UTC** GitHub's API browned out — HTTP 502 on the
workflow-dispatch endpoint, HTTP 504 on GraphQL, HTTP 429 on codeload. Four `radar-basic`
PRs fell out of the pipeline and stayed out, because the calls that hand work to the next
workflow had no retry:

| PR | Library | State it was left in | Call that died |
|---|---|---|---|
| #9742 | seaborn | `ai-approved` q90 | `impl-merge` → `gh pr view` → **504** |
| #9744 | pygal | `ai-rejected` q87 | repair dispatch → **504**; `ai-attempt-1` also lost |
| #9749 | makie | `ai-rejected` q88 | repair dispatch → **502** |
| #9751 | highcharts | `ai-rejected` q88 | repair dispatch → **502** |

`impl-review`'s verdict step is the pipeline's **only hand-off point** — every downstream
workflow starts from a call made there. So an unretried blip doesn't merely fail a step; it
leaves a PR carrying a verdict label with nothing listening.

All four have since been recovered manually and merged; this PR stops it recurring.

## Changes

**`impl-review.yml` — the verdict step**
- every API call retries 3× with linear backoff (same shape as the existing `Extract PR info`
  retry, added 2026-05-06 for this same class of failure)
- the repair is **dispatched before** the attempt label is added, and the label can no longer
  gate it. Losing the label costs one over-strict review; losing the dispatch costs the whole PR
- if the dispatch still exhausts its retries, the step drops `ai-rejected` on the way out:
  `ai-rejected` + `ai-attempt-N` matches **no** watchdog case (Case 2 excludes any verdict
  label, Case 4 excludes PRs that already have an attempt label), while the label-less state is
  exactly Case 2 — which re-dispatches the repair at the attempt number the remaining label
  still encodes
- the label read tracks success explicitly instead of inferring it from empty output, and a
  successful read with no verdict label now fails loudly instead of ending the step green

**Two bugs found while verifying the above**
- **`ai-attempt-4` never existed as a label.** The attempt label encodes the cascading
  threshold (90 → 80 → 70 → 60 → 50), but the repo only has `ai-attempt-1..3`, so on the 4th
  repair the add failed every time and `|| true` swallowed it — #7268 and #7039 both reached
  "Repair Attempt 4/4" carrying only `ai-attempt-1..3`. Every 4th review therefore re-applied
  the ≥ 90 attempt-0 bar, and the attempts-exhausted branch (close PR, remove stale
  implementation) could never be reached. Labels are now created on demand.
  *This also means my first draft of this PR was a hard blocker:* with the label add fatal, the
  4th repair would never have been dispatched at all.
- **That newly-reachable branch rendered a literal `$SCORE/100`** — quoted heredoc. Now
  expands, with the markdown backticks escaped so they can't become command substitution.

**`impl-merge.yml`**
- the 5× merge retry re-reads PR state first. A merge that succeeded server-side but lost its
  HTTP response used to fail four more times with "already merged" and exit 1 — and because
  every post-merge step is gated on `should_run == 'true'` (implicit `success()`), that skipped
  GCS promotion, the `impl:{lib}:done` label, closing the issue and the Postgres sync. A merged
  PR with none of its bookkeeping: exactly the silent partial completion CLAUDE.md warns about

**`auto-update-pr-branches.yml` — Dependabot PRs could never merge while the pipeline ran**
- the workflow called `update-branch` on Dependabot PRs. That push is authored by
  `github-actions[bot]`, so GitHub gates the resulting runs behind manual approval
  (`action_required`) — and because `main` advances every few minutes during impl merges, each
  branch was re-updated long before anyone could approve. **PR #9674 accumulated 174 runs in
  22 h: 162 `action_required` against only 4 green** (the original `dependabot[bot]` push)
- Dependabot branches are now skipped. They merge fine while behind — the `main` ruleset is
  **not** strict (`strict_required_status_checks_policy: false`); the file's header claimed the
  opposite and is corrected
- `/dependabot`'s playbook told operators to run that same harmful `update-branch` by hand; it
  now says the opposite and documents the `@dependabot recreate` remedy

## Verification

`.github/workflows/` has no verification loop (CLAUDE.md), so this was reviewed by a 4-lens
adversarial pass with an independent refutation round (regression / shell-under-`bash -e` / retry idempotency / the Dependabot
premise), and every claim was re-checked against the live repo before acting. That pass is what
caught the `ai-attempt-4` blocker and the false Dependabot-rebase premise in my first draft.

- YAML parses; `bash -n` clean on the extracted steps
- `gh_retry` semantics exercised under `bash -e`: succeeds first try / recovers after 2
  failures / multi-arg passthrough / hard failure aborts the step
- the corrected control flow tested for all three cases — normal, **attempt 4 with a
  permanently failing label add (dispatch must still fire)**, and dispatch exhaustion
  (`ai-rejected` dropped, exit 1)
- confirmed the CI runner's `gh` adds labels fine; only the locally-installed gh 2.45.0 hits
  the `projectCards` GraphQL deprecation, so hard-failing on `--add-label` is safe in CI
- ruleset strictness, the `ai-attempt-*` label set, and the poisoned Dependabot head commits
  were all read from the live repo, not assumed

## Follow-up (not in this PR)

- #9674, #9648 and #8820 already have a `github-actions[bot]` merge commit as their head. Once
  this merges their head stops moving, so approving each gated run **once** is enough — verified
  that the required contexts do report as SUCCESS on a bot-authored head after approval (#9674,
  commit `59545076`). Doing it before this merges would just get re-gated by the next push to
  `main`. (`@dependabot recreate` is an equivalent alternative; it also restores a clean
  `dependabot[bot]` head but re-resolves the versions.)
- Whether `auto-update-pr-branches.yml` should exist at all now that the ruleset is non-strict
  is worth deciding separately — it affects every auto-merge PR, so it isn't folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
