### PR TITLE
fix(ci): keep ruff off Markdown so a minor bump stops breaking lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `*.md`. Deliberately not fixed by reformatting those files — nine of them are
   `prompts/library/*.md`, whose snippets steer code generation, so rewriting quote style there
   is a pipeline change wearing a formatting costume. Verified against both 0.15.21 and 0.16.0
-  (`format --check` + `check` clean on 148 files).
+  (`format --check` + `check` clean on 148 files) (#9899).
 - **A GitHub API brown-out could strand implementation PRs permanently — the hand-off calls
   are now retried** — on 2026-07-24 (~16:05–16:26 UTC) GitHub returned HTTP 502 on the
   workflow-dispatch endpoint and HTTP 504 on GraphQL, and four `radar-basic` PRs fell out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,14 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **CI lint went red on every PR after a ruff minor bump** — `pyproject.toml` pins
+  `ruff>=0.15.21` without an upper bound, CI resolved **0.16.0**, and that version started
+  formatting Python code blocks inside Markdown: 20 tracked `.md` files suddenly "would be
+  reformatted", none of them touched by the PR that hit it. Ruff's exclude list now carries
+  `*.md`. Deliberately not fixed by reformatting those files — nine of them are
+  `prompts/library/*.md`, whose snippets steer code generation, so rewriting quote style there
+  is a pipeline change wearing a formatting costume. Verified against both 0.15.21 and 0.16.0
+  (`format --check` + `check` clean on 148 files).
 - **A GitHub API brown-out could strand implementation PRs permanently — the hand-off calls
   are now retried** — on 2026-07-24 (~16:05–16:26 UTC) GitHub returned HTTP 502 on the
   workflow-dispatch endpoint and HTTP 504 on GraphQL, and four `radar-basic` PRs fell out of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,12 @@ exclude = [
     "temp",
     "plots",
     "scripts",
+    # ruff 0.16 formats Python code blocks inside Markdown. Twenty tracked .md
+    # files change under it — including prompts/library/*.md, whose snippets
+    # steer code generation, so a quote-style rewrite there would be a pipeline
+    # change disguised as formatting. Ruff owns this repo's Python, not its
+    # prose; formatting the docs stays a deliberate, separate decision.
+    "*.md",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

- `pyproject.toml` pins `ruff>=0.15.21` with no upper bound. CI resolved **0.16.0** today, and that version formats Python code blocks **inside Markdown** — 20 tracked `.md` files immediately counted as unformatted and `Run Linting` went red on every PR (first seen on #9898, which touches none of those files).
- Fix: `*.md` joins ruff's exclude list. Ruff owns this repo's Python, not its prose.
- Deliberately **not** fixed by reformatting the 20 files: nine are `prompts/library/*.md`, whose snippets steer code generation, so a quote-style rewrite there is a pipeline change wearing a formatting costume. If the docs should be ruff-formatted, that is its own decision with its own review.

## Plan

N/A — unblocks CI.

## Test plan

- [x] `uvx ruff@0.16.0 format --check .` → `148 files already formatted` (was: `20 files would be reformatted`)
- [x] `uvx ruff@0.16.0 check .` → `All checks passed!`
- [x] Same two commands on `ruff@0.15.21` (the version CI resolved while green) → identical results, so the change is not version-specific
- [ ] `Run Linting` green on this PR