### PR TITLE
fix(impl-review): stop treating a legitimate score of 0 as a crashed review

### DIFF
--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -337,23 +337,51 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
+          # `0` is a LEGITIMATE score, not a sentinel: the Stage 1 auto-reject
+          # gates in prompts/workflow-prompts/ai-quality-review.md mandate
+          # exactly "Score = 0, verdict = REJECTED" for AR-08 (clipped element)
+          # and AR-09 (mandatory title not visible). Conflating that with "the
+          # action produced nothing" is what deadlocked PRs #10152/#10130/
+          # #10009/#10003/#9968/#9776: a correctly-rejected plot was reported as
+          # a crashed review, so the repair that would have fixed the title was
+          # never dispatched. Whether output exists is therefore tracked
+          # separately from what the score is.
+          HAS_OUTPUT=false
           if [ -f "quality_score.txt" ]; then
             SCORE=$(cat quality_score.txt | tr -d '[:space:]')
+            HAS_OUTPUT=true
           else
-            SCORE=$(gh pr view "$PR_NUM" --json comments -q '.comments[-1].body' | grep -oP 'Score: \K\d+' | head -1 || echo "0")
+            # Fall back to the review comment. Select the last *claude[bot]*
+            # comment rather than the last comment overall — on a retry the
+            # github-actions[bot] "auto-retrying" notice lands after it, and
+            # `.comments[-1]` would then read that notice and find no score.
+            SCORE=$(gh api --paginate "repos/${REPOSITORY}/issues/${PR_NUM}/comments?per_page=100" \
+              --jq '[.[] | select(.user.login == "claude[bot]")] | last | .body // ""' 2>/dev/null \
+              | grep -oP '^###\s+Score:\s+\K\d+' | head -1 || true)
+            if [ -n "$SCORE" ]; then
+              HAS_OUTPUT=true
+              echo "::notice::quality_score.txt missing; recovered score ${SCORE} from the review comment"
+            fi
           fi
 
-          # Validate score is a number between 1-100, default to 0 if invalid
-          if ! [[ "$SCORE" =~ ^[0-9]+$ ]] || [ "$SCORE" -lt 1 ] || [ "$SCORE" -gt 100 ]; then
-            echo "::warning::Invalid quality score '$SCORE', defaulting to 0"
+          # Only a non-numeric or out-of-range value is invalid. 0 passes.
+          if [ "$HAS_OUTPUT" = "true" ] && { ! [[ "$SCORE" =~ ^[0-9]+$ ]] || [ "$SCORE" -gt 100 ]; }; then
+            echo "::warning::Invalid quality score '$SCORE' — treating as missing review output"
+            HAS_OUTPUT=false
+          fi
+
+          if [ "$HAS_OUTPUT" != "true" ]; then
             SCORE="0"
           fi
 
           echo "score=$SCORE" >> $GITHUB_OUTPUT
+          echo "has_output=$HAS_OUTPUT" >> $GITHUB_OUTPUT
+          echo "::notice::score=${SCORE} has_output=${HAS_OUTPUT}"
 
       - name: Validate review output
-        if: steps.review.conclusion == 'success' && steps.score.outputs.score == '0'
+        if: steps.review.conclusion == 'success' && steps.score.outputs.has_output != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}
@@ -411,7 +439,7 @@ jobs:
           exit 1
 
       - name: Add quality score label
-        if: steps.review.conclusion == 'success' && steps.score.outputs.score != '0'
+        if: steps.review.conclusion == 'success' && steps.score.outputs.has_output == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}
@@ -440,7 +468,7 @@ jobs:
           }
 
       - name: Add preliminary verdict label (early)
-        if: steps.review.conclusion == 'success' && steps.score.outputs.score != '0'
+        if: steps.review.conclusion == 'success' && steps.score.outputs.has_output == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}
@@ -480,11 +508,11 @@ jobs:
           fi
 
       - name: Install Python dependencies for metadata update
-        if: steps.review.conclusion == 'success' && steps.score.outputs.score != '0'
+        if: steps.review.conclusion == 'success' && steps.score.outputs.has_output == 'true'
         run: pip install pyyaml
 
       - name: Update metadata and implementation header
-        if: steps.review.conclusion == 'success' && steps.score.outputs.score != '0'
+        if: steps.review.conclusion == 'success' && steps.score.outputs.has_output == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPEC_ID: ${{ steps.pr.outputs.specification_id }}
@@ -826,7 +854,7 @@ jobs:
           exit 1
 
       - name: Add verdict label and take action
-        if: steps.review.conclusion == 'success' && steps.score.outputs.score != '0'
+        if: steps.review.conclusion == 'success' && steps.score.outputs.has_output == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -306,6 +306,14 @@ jobs:
         run: |
           gh api "repos/$REPOSITORY/issues/$PR_NUMBER/reactions" -f content=eyes
 
+      # Marks the boundary between "review comments that already existed" and
+      # "the comment this run produced", so the score fallback below can never
+      # pick up a previous attempt's score. One second of slack absorbs clock
+      # skew between the runner and GitHub's comment timestamps.
+      - name: Record review start time
+        id: t0
+        run: echo "at=$(date -u -d '1 second ago' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
       - name: Run AI Quality Review
         id: review
         continue-on-error: true
@@ -338,6 +346,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}
           REPOSITORY: ${{ github.repository }}
+          REVIEW_STARTED_AT: ${{ steps.t0.outputs.at }}
         run: |
           # `0` is a LEGITIMATE score, not a sentinel: the Stage 1 auto-reject
           # gates in prompts/workflow-prompts/ai-quality-review.md mandate
@@ -353,16 +362,31 @@ jobs:
             SCORE=$(cat quality_score.txt | tr -d '[:space:]')
             HAS_OUTPUT=true
           else
-            # Fall back to the review comment. Select the last *claude[bot]*
-            # comment rather than the last comment overall — on a retry the
-            # github-actions[bot] "auto-retrying" notice lands after it, and
-            # `.comments[-1]` would then read that notice and find no score.
-            SCORE=$(gh api --paginate "repos/${REPOSITORY}/issues/${PR_NUM}/comments?per_page=100" \
-              --jq '[.[] | select(.user.login == "claude[bot]")] | last | .body // ""' 2>/dev/null \
+            # Fall back to the review comment, under two constraints:
+            #
+            #  1. Select the last *claude[bot]* comment, not the last comment
+            #     overall — on a retry the github-actions[bot] "auto-retrying"
+            #     notice lands after the review, and `.comments[-1]` would read
+            #     that notice and find no score.
+            #  2. Only accept a comment posted by THIS run. A PR that has
+            #     already been reviewed carries older review comments with a
+            #     stale score (PR #9948 still shows `Score: 89/100` from its
+            #     first review), and reading one of those would attach a score
+            #     the current implementation never earned. Comparing RFC 3339
+            #     UTC timestamps lexicographically is exact here: GitHub and
+            #     `date -u` emit the same fixed-width `...Z` format.
+            SCORE=$(gh api --paginate "repos/${REPOSITORY}/issues/${PR_NUM}/comments?per_page=100" 2>/dev/null \
+              | jq -s --arg since "$REVIEW_STARTED_AT" -r \
+                  'add // []
+                   | [.[] | select(.user.login == "claude[bot]")
+                          | select(.created_at >= $since)]
+                   | last | .body // ""' \
               | grep -oP '^###\s+Score:\s+\K\d+' | head -1 || true)
             if [ -n "$SCORE" ]; then
               HAS_OUTPUT=true
-              echo "::notice::quality_score.txt missing; recovered score ${SCORE} from the review comment"
+              echo "::notice::quality_score.txt missing; recovered score ${SCORE} from this run's review comment"
+            else
+              echo "::notice::quality_score.txt missing and no review comment from this run (since ${REVIEW_STARTED_AT})"
             fi
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   overall — on a retry the bot's own "auto-retrying" notice landed last and shadowed the score
   it was looking for. Verified with a harness that extracts the step body verbatim from the YAML
   and exercises 12 cases (score 0 via file and via comment fallback, normal scores, and the four
-  genuine no-output shapes) (#PRNUM).
+  genuine no-output shapes) (#10179).
 - **CI lint went red on every PR after a ruff minor bump** — `pyproject.toml` pins
   `ruff>=0.15.21` without an upper bound, CI resolved **0.16.0**, and that version started
   formatting Python code blocks inside Markdown: 20 tracked `.md` files suddenly "would be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,11 +152,13 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   #10009, #10003, #9968, #9776), all with an `AR-09` verdict in hand. Output presence is now
   tracked as its own `has_output` step output, so a score of `0` flows into the normal
   rejected → repair path and only genuinely absent output raises `ai-review-failed`. The
-  comment fallback also now reads the last **`claude[bot]`** comment instead of the last comment
-  overall — on a retry the bot's own "auto-retrying" notice landed last and shadowed the score
-  it was looking for. Verified with a harness that extracts the step body verbatim from the YAML
-  and exercises 12 cases (score 0 via file and via comment fallback, normal scores, and the four
-  genuine no-output shapes) (#10179).
+  comment fallback also now reads the last **`claude[bot]`** comment posted by the *current* run,
+  instead of the last comment overall — on a retry the bot's own "auto-retrying" notice landed
+  last and shadowed the score, while an unscoped author filter would have reused a previous
+  attempt's score (#9948 still shows `Score: 89/100` from its first review). Verified with a
+  harness that extracts the step body verbatim from the YAML and exercises 17 cases (score 0 via
+  file and via comment fallback, stale-score reuse, normal scores, and the five genuine
+  no-output shapes) (#10179).
 - **CI lint went red on every PR after a ruff minor bump** — `pyproject.toml` pins
   `ruff>=0.15.21` without an upper bound, CI resolved **0.16.0**, and that version started
   formatting Python code blocks inside Markdown: 20 tracked `.md` files suddenly "would be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,25 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **A correctly rejected plot was reported as a crashed review, deadlocking the PR** —
+  `impl-review.yml` used quality score `0` as its sentinel for "the AI review produced no
+  output", but `0` is also a score the review prompt *mandates*: the Stage 1 auto-reject gates
+  (`AR-08` clipped element, `AR-09` mandatory title not visible) require exactly
+  "Score = 0, verdict = REJECTED". Every plot that tripped those gates therefore hit
+  `Validate review output` → `::error::AI Review did not produce valid output files` →
+  `ai-review-failed` → `exit 1`, which skipped the verdict step — the pipeline's *only*
+  hand-off point — so `impl-repair` was never dispatched and the missing title was never fixed.
+  The retry listener rescued once, the re-review scored `0` again (deterministically: the plot
+  was unchanged), and the resulting `ai-review-failed` + `ai-review-rescued` pair matches no
+  watchdog case, stranding the PR for good. Six PRs sat in exactly that state (#10152, #10130,
+  #10009, #10003, #9968, #9776), all with an `AR-09` verdict in hand. Output presence is now
+  tracked as its own `has_output` step output, so a score of `0` flows into the normal
+  rejected → repair path and only genuinely absent output raises `ai-review-failed`. The
+  comment fallback also now reads the last **`claude[bot]`** comment instead of the last comment
+  overall — on a retry the bot's own "auto-retrying" notice landed last and shadowed the score
+  it was looking for. Verified with a harness that extracts the step body verbatim from the YAML
+  and exercises 12 cases (score 0 via file and via comment fallback, normal scores, and the four
+  genuine no-output shapes) (#PRNUM).
 - **CI lint went red on every PR after a ruff minor bump** — `pyproject.toml` pins
   `ruff>=0.15.21` without an upper bound, CI resolved **0.16.0**, and that version started
   formatting Python code blocks inside Markdown: 20 tracked `.md` files suddenly "would be


### PR DESCRIPTION
## The bug

`impl-review.yml` used quality score `0` as its sentinel for *"the AI review produced no output"*. But `0` is also a score the review prompt **mandates**: the Stage 1 auto-reject gates in `prompts/workflow-prompts/ai-quality-review.md` require exactly `Score = 0, verdict = REJECTED` for **AR-08** (clipped element) and **AR-09** (mandatory title not visible).

Prompt and workflow therefore contradicted each other, and the pipeline was guaranteed to dead-end on exactly the plots it is designed to reject hardest.

## The deadlock chain

1. Plot renders without a visible title → **AR-09** → reviewer returns `Score: 0/100`, `Verdict: REJECTED` — **this is correct behaviour**
2. `Extract quality score` normalised it: `::warning::Invalid quality score '0', defaulting to 0`
3. `Validate review output` fired on `score == '0'` → `::error::AI Review did not produce valid output files` → `ai-review-failed` → `exit 1`
4. `exit 1` skipped **`Add verdict label and take action`** — which the file itself documents as *"the pipeline's only hand-off point: every downstream workflow (merge, repair) starts from a call made right here"*
5. So **`impl-repair` was never dispatched** and the missing title was never fixed
6. `impl-review-retry.yml` rescued once → the re-review scored `0` again (deterministically — the plot was unchanged) → `ai-review-failed` re-applied
7. `ai-review-failed` + `ai-review-rescued` matches **no** watchdog case (`watchdog-stuck-jobs.yml:116` only emits a `::warning::` and defers to a human) → **PR stranded permanently**

## Evidence

Six open PRs sit in exactly that state, each with an AR-09 verdict already in hand:

| PR | Library / spec | Reported score | Verdict | Gate |
|---|---|---|---|---|
| #10152 | seaborn windrose-basic | 0 | REJECTED | AR-09 |
| #10130 | muix streamgraph-basic | 0 | REJECTED | AR-09 |
| #10009 | matplotlib wireframe-3d-basic | 0 | REJECTED | AR-09 |
| #10003 | d3 ternary-basic | 0 | REJECTED | AR-09 |
| #9968 | plotnine treemap-basic | 0 | REJECTED | AR-09 |
| #9776 | matplotlib polar-basic | 0 | REJECTED | AR-09 |

This was never an infrastructure failure. In run [31035492709](https://github.com/MarkusNeusinger/anyplot/actions/runs/31035492709) the Claude action reported `"subtype": "success"`, `"is_error": false`, 15 turns, `permission_denials_count: 0` — and posted a complete review ending in `### Score: 0/100` / `### Verdict: REJECTED`. 94 of the last 100 `impl-review` runs are green; the 6 failures are these gate-tripping plots.

## The fix

Output presence becomes its own signal, decoupled from the score value:

- `Extract quality score` now emits **`has_output`** alongside `score`. `0` is accepted as a valid score; only a non-numeric or out-of-range value marks output as missing.
- The six gates that keyed off `score != '0'` / `score == '0'` now key off `has_output`.
- A score of `0` therefore flows into the normal `ai-rejected` → `impl-repair` path (threshold floor is 50, so `0 < 50` → rejected → repair dispatched), and only genuinely absent output raises `ai-review-failed`.

**Second, latent bug fixed in the same step:** the comment fallback read `.comments[-1].body`, but on a retry the workflow's own *"auto-retrying"* notice is posted **after** the review — so the fallback searched the notice and found no score. It now selects the last `claude[bot]` comment.

**Deliberately not changed:** `watchdog-stuck-jobs.yml`. With the root cause fixed, "review produced no output twice in a row" (PRs #9953/#9952/#9951, which have no `claude[bot]` comment at all) is a genuine failure that *should* escalate to a human rather than loop forever.

## Verification

GitHub Actions changes have no verification loop in this repo, so the step's shell body was tested directly: a harness extracts the `Extract quality score` `run:` block **verbatim from the YAML** and exercises it with a stubbed `gh`.

```
--- the regression that caused the deadlock ---
PASS  file score 0 (AR-09 auto-reject)               score=0    has_output=true
PASS  comment fallback, score 0                      score=0    has_output=true
--- normal operation must be unchanged ---
PASS  file score 87 / 100 / 1 / trailing-newline 73  score=...  has_output=true
PASS  comment fallback, score 87                     score=87   has_output=true
--- genuine 'no output' must still be detected ---
PASS  no file, no review comment                     score=0    has_output=false
PASS  no file, comment without a score line          score=0    has_output=false
PASS  file with non-numeric garbage                  score=0    has_output=false
PASS  file with out-of-range score                   score=0    has_output=false
PASS  empty file                                     score=0    has_output=false

ALL CASES PASS
```

YAML validity re-checked after the edit (`yaml.safe_load`, 20 steps parsed).

Residual risk: the `if:` expression rewrites and the `REPOSITORY` env addition are only observable on a real pipeline run. Recovery path for the six stranded PRs after merge: re-dispatch `impl-review.yml -f pr_number=<n>`, which will now score them 0, label `ai-rejected`, and hand them to `impl-repair` to fix the titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)