### PR TITLE
fix(watchdog): stop one bad dispatch from killing the whole scan

### DIFF
--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -468,6 +468,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ steps.pr.outputs.pr_number }}
           SCORE: ${{ steps.score.outputs.score }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           LABEL="quality:${SCORE}"
           gh label create "$LABEL" --color "0e8a16" --description "Quality score ${SCORE}/100" 2>/dev/null || true
@@ -481,6 +482,24 @@ jobs:
             echo "::notice::Removing stale quality labels: $STALE"
             gh pr edit "$PR_NUM" --remove-label "$STALE" 2>/dev/null || true
           fi
+
+          # Reaching this step means the review produced real output, so the
+          # previous failure streak is over. `ai-review-rescued` is the
+          # one-shot token both impl-review-retry.yml and watchdog Case 1
+          # check before rescuing; nothing ever cleared it, so it meant "this
+          # PR was rescued once, ever" instead of "this failure streak was
+          # already rescued once". A PR that failed review twice at any point
+          # in its life was therefore permanently outside automation — 9 of
+          # the 11 PRs stuck on 2026-08-05 carried this pair. Clearing both
+          # labels on a successful review restores the intended semantics.
+          # Deleted via the REST API: `gh pr edit --remove-label` fails on
+          # this repo with a GraphQL "Projects (classic) is being deprecated"
+          # error on repository.pullRequest.projectCards.
+          for OLD in ai-review-failed ai-review-rescued; do
+            if gh api -X DELETE "repos/${REPOSITORY}/issues/${PR_NUM}/labels/${OLD}" >/dev/null 2>&1; then
+              echo "::notice::Cleared ${OLD} — review succeeded, failure streak reset"
+            fi
+          done
 
           # Retry on transient GitHub API failures (e.g. 504) — without this,
           # a single 5xx leaves the PR stuck with no quality label and the

--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -90,7 +90,19 @@ jobs:
               return 0
             fi
 
-            err=$(printf '%s' "$err" | head -c 300 | tr '\n' ' ')
+            # Truncate with parameter expansion, never a pipeline. The obvious
+            # `printf '%s' "$err" | head -c 300 | tr '\n' ' '` reintroduces the
+            # very bug this function exists to fix: once the message exceeds
+            # the pipe buffer, `head` exits after its 300 bytes, `printf` takes
+            # SIGPIPE and returns 141, `pipefail` propagates that to the
+            # assignment, and `set -e` kills the scan — in the error path, so
+            # only a pathological message would ever expose it. Measured on
+            # this runner: 60 000 bytes survives, 70 000 exits 141. Parameter
+            # expansion forks nothing and cannot fail. `::warning::` is
+            # line-oriented, so newlines must go or everything after the first
+            # one leaks into the raw log.
+            err=${err//$'\n'/ }
+            err=${err:0:300}
             if [[ "$err" == *"disabled workflow"* ]]; then
               # Not transient and not something a retry fixes — a human turned
               # the workflow off. Report it plainly and keep scanning.

--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -399,4 +399,15 @@ jobs:
             fi
           fi
 
-          echo "::notice::Watchdog scan complete"
+          # Surface the tally. Individual failures are warned about inline, but
+          # a scan that dispatched nothing successfully now looks identical to
+          # a quiet, healthy one unless the total is stated — and an
+          # always-green watchdog that quietly rescues nothing is the failure
+          # mode this whole PR is about. Deliberately not `exit 1`: aborting is
+          # what took the scan down in the first place, and a red run would
+          # hide the summary behind a failed step.
+          if (( DISPATCH_FAILURES > 0 )); then
+            echo "::warning::Watchdog scan complete — ${DISPATCH_FAILURES} dispatch(es) failed (see warnings above)"
+          else
+            echo "::notice::Watchdog scan complete — all dispatches succeeded"
+          fi

--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -64,14 +64,42 @@ jobs:
           STALE_SEC=$(( STALE_HOURS * 3600 ))
           NOW=$(date -u +%s)
 
+          DISPATCH_FAILURES=0
+
+          # A failed dispatch must never abort the scan. This function used to
+          # call `gh workflow run` bare under `set -e`, so a single unroutable
+          # dispatch killed the whole run and every PR after it went unscanned
+          # — the safety net failing silently, in the one place where nothing
+          # else is watching. That is what happened on 2026-08-02..04: five of
+          # fourteen scheduled scans died on HTTP 422 "Cannot trigger a
+          # 'workflow_dispatch' on a disabled workflow" because daily-regen.yml
+          # was disabled manually, while the log line above the failure had
+          # already announced "→ dispatching". The announcement now follows the
+          # attempt instead of preceding it, so the log cannot claim a dispatch
+          # that did not happen.
           dispatch() {
             local label="$1"; shift
             if [[ "$DRY_RUN" == "true" ]]; then
               echo "::notice::[dry-run] $label → gh workflow run $*"
-            else
-              echo "::notice::$label → dispatching"
-              gh workflow run "$@"
+              return 0
             fi
+
+            local err
+            if err=$(gh workflow run "$@" 2>&1); then
+              echo "::notice::$label → dispatched"
+              return 0
+            fi
+
+            err=$(printf '%s' "$err" | head -c 300 | tr '\n' ' ')
+            if [[ "$err" == *"disabled workflow"* ]]; then
+              # Not transient and not something a retry fixes — a human turned
+              # the workflow off. Report it plainly and keep scanning.
+              echo "::warning::${label} → SKIPPED, target workflow is disabled: ${err}"
+            else
+              echo "::warning::${label} → dispatch FAILED: ${err}"
+            fi
+            DISPATCH_FAILURES=$(( DISPATCH_FAILURES + 1 ))
+            return 0
           }
 
           ensure_label() {
@@ -125,11 +153,23 @@ jobs:
             fi
 
             # Case 2: stalled repair handoff
-            #   has ai-attempt-N + quality:M, no ai-approved/ai-rejected,
+            #   has ai-attempt-N + quality:M, not ai-approved,
             #   PR untouched for stale_hours → re-dispatch impl-repair
+            #
+            #   `ai-rejected` used to be excluded here, which left
+            #   `ai-rejected` + `ai-attempt-N` matching NO case at all: Case 2
+            #   rejected it for having a verdict, Case 4 for having an attempt
+            #   label. That combination is the exact state impl-review.yml
+            #   leaves behind when its impl-repair dispatch fails — its own
+            #   comment says so and tries to drop `ai-rejected` to escape into
+            #   this case, which only works when that removal also succeeds.
+            #   PR #9949 sat in it for ten days. Excluding only `ai-approved`
+            #   (Case 3's business) closes the hole; the age guard keeps a
+            #   normal in-flight repair from being re-dispatched, and the
+            #   `watchdog:repair-rescued-N` marker keeps it one-shot.
             if echo " $labels " | grep -qE " ai-attempt-[0-9]+ " \
                && echo " $labels " | grep -qE " quality:[0-9]+ " \
-               && ! echo " $labels " | grep -qE " (ai-approved|ai-rejected) " \
+               && ! echo " $labels " | grep -qE " ai-approved " \
                && (( age > STALE_SEC )); then
               attempt=$(echo " $labels " | grep -oP "ai-attempt-\K[0-9]+" | sort -nr | head -1)
               marker="watchdog:repair-rescued-$attempt"

--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -350,9 +350,29 @@ jobs:
           # immediately after dispatch and would spill into it). Like the
           # cron, the window is UTC-fixed: it matches Berlin evening under
           # CEST and sits an hour earlier in local terms under CET.
+          #
+          # A manually disabled daily-regen is an INTENTIONAL operator state,
+          # not a starved schedule: the maintainer switches it off and on to
+          # manage the monthly token budget. Reviving it would override that
+          # decision, and "starved, re-dispatching" is simply a false report.
+          # Without this check the rescue also cannot succeed — a disabled
+          # workflow rejects workflow_dispatch with HTTP 422 — so every scan
+          # would log a warning and burn a dispatch failure for as long as the
+          # maintainer keeps it off, which is exactly the noise that hid the
+          # real breakage before. `disabled_inactivity` is GitHub switching
+          # schedules off after 60 days of repo inactivity; that one is worth
+          # flagging loudly, but it is equally undispatchable, so both states
+          # skip the rescue and only the message differs.
           LIVENESS_HOURS=10
           HOUR=$(date -u +%-H)
-          if (( HOUR >= 17 && HOUR <= 21 )); then
+          REGEN_STATE=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/daily-regen.yml" \
+            --jq '.state' 2>/dev/null || echo "unknown")
+
+          if [[ "$REGEN_STATE" == "disabled_manually" ]]; then
+            echo "::notice::daily-regen liveness: workflow is disabled manually — intentional, rescue skipped"
+          elif [[ "$REGEN_STATE" == disabled_* ]]; then
+            echo "::warning::daily-regen liveness: workflow state is '${REGEN_STATE}' — cannot be dispatched, rescue skipped"
+          elif (( HOUR >= 17 && HOUR <= 21 )); then
             echo "::notice::daily-regen liveness: inside/adjacent to quiet window (UTC hour $HOUR) — check skipped"
           else
             # --branch main: schedule runs (and rescue dispatches) live on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,9 +158,17 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   (3) `ai-review-rescued` was written once and cleared by nothing, so it meant "this PR was ever
   rescued" rather than "this failure streak was already rescued" — any PR that failed review
   twice in its life was permanently outside automation, which described 9 of the 11 PRs stuck on
-  2026-08-05. A successful review now clears it along with `ai-review-failed`. Verified with a
-  harness that extracts `dispatch()` verbatim from the YAML and exercises 11 cases (disabled
-  target, transient failure, success, and the six Case 2 label shapes) (#10180).
+  2026-08-05. A successful review now clears it along with `ai-review-failed`.
+  (4) The cron-liveness rescue treated a manually disabled `daily-regen` as a starved schedule.
+  It is not: the maintainer switches that workflow off and on to manage the monthly token budget,
+  so reviving it would override a deliberate decision, and "starved, re-dispatching" was simply a
+  false report — one that could never succeed anyway, since a disabled workflow rejects
+  `workflow_dispatch`. Section C now reads the workflow state first and skips the rescue for any
+  disabled state, quietly for `disabled_manually` and loudly for GitHub's 60-day
+  `disabled_inactivity`. Verified with harnesses that extract `dispatch()` verbatim from the YAML
+  and replicate the Case 2 and Section C guards exactly: 23 cases covering a disabled target,
+  transient failure and success, the six Case 2 label shapes, and the full workflow-state ×
+  quiet-window × gap matrix (#10180).
 
 - **A correctly rejected plot was reported as a crashed review, deadlocking the PR** —
   `impl-review.yml` used quality score `0` as its sentinel for "the AI review produced no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   twice in its life was permanently outside automation, which described 9 of the 11 PRs stuck on
   2026-08-05. A successful review now clears it along with `ai-review-failed`. Verified with a
   harness that extracts `dispatch()` verbatim from the YAML and exercises 11 cases (disabled
-  target, transient failure, success, and the six Case 2 label shapes) (#PRNUM2).
+  target, transient failure, success, and the six Case 2 label shapes) (#10180).
 
 - **A correctly rejected plot was reported as a crashed review, deadlocking the PR** —
   `impl-review.yml` used quality score `0` as its sentinel for "the AI review produced no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,30 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The pipeline's safety net had three holes, and one of them was armed** — follow-up to #10179,
+  which stopped PRs *entering* the dead-end; this stops them *staying* there.
+  (1) `watchdog-stuck-jobs.yml` called `gh workflow run` bare under `set -euo pipefail`, so a
+  single unroutable dispatch aborted the entire scan and every PR after it went unscanned — the
+  safety net failing silently, where nothing else is watching. Five of fourteen scheduled scans
+  died this way on 2026-08-02..04 with HTTP 422 `Cannot trigger a 'workflow_dispatch' on a
+  disabled workflow`, because `daily-regen.yml` is disabled manually while the watchdog's
+  cron-liveness rescue keeps trying to revive it — and the log announced `→ dispatching` *before*
+  attempting, so the run reported rescues it never performed. Dispatch failures are now counted
+  and reported, never fatal, with a disabled target called out as the non-transient case it is;
+  the log line now follows the attempt. This was live: `daily-regen` last ran 16:51 UTC against a
+  10 h liveness threshold, so the next scan after 02:51 UTC would have died again.
+  (2) `ai-rejected` + `ai-attempt-N` matched **no** watchdog case — Case 2 excluded any verdict
+  label, Case 4 excluded any attempt label — which is exactly the state `impl-review.yml` leaves
+  behind when its `impl-repair` dispatch fails, as its own comment says. PR #9949 sat in it for
+  ten days. Case 2 now excludes only `ai-approved` (Case 3's business); the existing age guard
+  and `watchdog:repair-rescued-N` marker keep it from racing an in-flight repair.
+  (3) `ai-review-rescued` was written once and cleared by nothing, so it meant "this PR was ever
+  rescued" rather than "this failure streak was already rescued" — any PR that failed review
+  twice in its life was permanently outside automation, which described 9 of the 11 PRs stuck on
+  2026-08-05. A successful review now clears it along with `ai-review-failed`. Verified with a
+  harness that extracts `dispatch()` verbatim from the YAML and exercises 11 cases (disabled
+  target, transient failure, success, and the six Case 2 label shapes) (#PRNUM2).
+
 - **A correctly rejected plot was reported as a crashed review, deadlocking the PR** —
   `impl-review.yml` used quality score `0` as its sentinel for "the AI review produced no
   output", but `0` is also a score the review prompt *mandates*: the Stage 1 auto-reject gates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,8 +166,9 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `workflow_dispatch`. Section C now reads the workflow state first and skips the rescue for any
   disabled state, quietly for `disabled_manually` and loudly for GitHub's 60-day
   `disabled_inactivity`. Verified with harnesses that extract `dispatch()` verbatim from the YAML
-  and replicate the Case 2 and Section C guards exactly: 23 cases covering a disabled target,
-  transient failure and success, the six Case 2 label shapes, and the full workflow-state ×
+  and replicate the Case 2 and Section C guards exactly: 25 cases covering a disabled target,
+  transient failure and success, counter propagation through the real
+  `while ... done < <(...)` scan loop, the six Case 2 label shapes, and the full workflow-state ×
   quiet-window × gap matrix (#10180).
 
 - **A correctly rejected plot was reported as a crashed review, deadlocking the PR** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,9 +167,10 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   disabled state, quietly for `disabled_manually` and loudly for GitHub's 60-day
   `disabled_inactivity`. Verified with harnesses that extract `dispatch()` verbatim from the YAML
   and replicate the Case 2 and Section C guards exactly: 25 cases covering a disabled target,
-  transient failure and success, counter propagation through the real
+  transient failure and success, a 100 KiB error message, counter propagation through the real
   `while ... done < <(...)` scan loop, the six Case 2 label shapes, and the full workflow-state ×
-  quiet-window × gap matrix (#10180).
+  quiet-window × gap matrix — each regression case checked to actually fail against the
+  pre-fix code (#10180).
 
 - **A correctly rejected plot was reported as a crashed review, deadlocking the PR** —
   `impl-review.yml` used quality score `0` as its sentinel for "the AI review produced no


### PR DESCRIPTION
Follow-up to #10179. That PR stopped implementation PRs from **entering** the review dead-end; this one stops them from **staying** there. Three verified holes in the pipeline's only safety net.

## 1. A failed dispatch aborted the entire scan — and this is armed right now

`dispatch()` called `gh workflow run` bare under `set -euo pipefail`. One unroutable dispatch therefore killed the whole run, and every PR after it went unscanned — the safety net failing silently, in the one place where nothing else is watching.

Five of the last fourteen scheduled scans died exactly this way (`30749881831`, `30781315973`, `30803034385`, `30824022333`, `30872621465`):

```
could not create workflow dispatch event: HTTP 422: Cannot trigger a
'workflow_dispatch' on a disabled workflow (.../workflows/265430494/dispatches)
##[error]Process completed with exit code 1.
```

Workflow `265430494` is `.github/workflows/daily-regen.yml`, state `disabled_manually`. The watchdog's Section C cron-liveness rescue keeps trying to revive it and cannot. Worse, the `→ dispatching` line was printed **before** the attempt, so the log claimed rescues that never happened — which is why Section C reported "dispatching" on 08-03 and 08-04 while `daily-regen` stayed down.

**This is not historical.** `daily-regen` last ran `2026-08-05T16:51Z` and `LIVENESS_HOURS=10`, so from ~`02:51Z` the gap trips again and the next scheduled scan (`0 */6 * * *`) dies with it.

Dispatch failures are now counted and surfaced, never fatal; a disabled target is named as the non-transient condition it is; and the log line follows the attempt instead of preceding it.

## 2. `ai-rejected` + `ai-attempt-N` matched no case at all

Case 2 excluded any verdict label, Case 4 excluded any attempt label — so that pair fell through everything. It is exactly the state `impl-review.yml` leaves behind when its `impl-repair` dispatch fails; the file's own comment documents the escape hatch (drop `ai-rejected` so Case 2 picks it up) which only works if *that* API call also succeeds. **PR #9949 sat in this state for ten days.**

Case 2 now excludes only `ai-approved` (Case 3's business). The existing `age > STALE_SEC` guard keeps it from racing an in-flight repair, and the `watchdog:repair-rescued-N` marker keeps it one-shot.

## 3. `ai-review-rescued` was never cleared

Case 1 writes it; nothing removes it. So it meant *"this PR was ever rescued"* instead of *"this failure streak was already rescued once"*. Any PR that failed review twice in its lifetime was permanently outside automation — **9 of the 11 PRs stuck on 2026-08-05 carried this pair**, and both `impl-review-retry.yml` and watchdog Case 1 refused them.

A successful review now clears it together with `ai-review-failed`, restoring the intended per-streak semantics. Done via the REST API: `gh pr edit --remove-label` fails on this repo with `GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)` — hit while cleaning up these very PRs.

## Verification

Workflow changes have no verification loop in this repo, so `dispatch()` is extracted **verbatim from the YAML** and exercised against a stubbed `gh`, and the Case 2 guard is replicated exactly as written:

```
--- (c) a failed dispatch must not abort the scan ---
PASS  disabled workflow: scan survives               rc=0
PASS  disabled workflow: reported as such            rc=0
PASS  transient error: scan survives                 rc=0
PASS  success: no failures counted                   rc=0
PASS  success: claims dispatched only after the fact rc=0
--- (b) Case 2 must now cover ai-rejected + ai-attempt-N ---
PASS  the #9949 dead-end is now caught               match
PASS  multi-attempt dead-end caught                  match
PASS  original Case 2 shape still caught             match
PASS  ai-approved still left to Case 3               skip
PASS  no attempt label -> left to Case 4             skip
PASS  no score label -> not Case 2                   skip

ALL CASES PASS
```

`yaml.safe_load` clean on both changed workflows.

Hole 3's fix rides in `impl-review.yml` rather than the watchdog, because a successful review is the only event that can truthfully say the failure streak ended. Its effect was observed live: after #10179 merged, #10130 and #10003 were resumed and both reviews now score `0` → `ai-rejected` → **`impl-repair` dispatched** (runs at 21:38), the hand-off that had not fired in ten days.

**Open question for the maintainer, deliberately not actioned here:** `daily-regen.yml` was disabled manually a few hours ago — plausibly to stop the flood of stranded PRs that #10179 has now fixed at the source. Re-enabling it is your call; this PR only makes the watchdog survive the disabled state instead of dying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)