### PR TITLE
docs(seo): document Search Console API access, fix the auditor's auth probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,3 +98,13 @@ PORT=8000
 # CLI_MODEL_GEMINI_SMALL=gemini-2.0-flash
 # CLI_MODEL_GEMINI_MEDIUM=gemini-2.0-flash-thinking
 # CLI_MODEL_GEMINI_LARGE=gemini-2.5-pro
+
+# ============================================================================
+# Google Search Console (optional — enables the seo-auditor's full mode)
+# ============================================================================
+# Setup and the two gotchas: docs/reference/seo.md ("Search Console API access").
+# Credentials are NOT stored here — they come from Application Default Credentials:
+#   gcloud auth application-default login \
+#     --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/webmasters.readonly
+# SEARCH_CONSOLE_PROPERTY=sc-domain:anyplot.ai
+# SEARCH_CONSOLE_ACCOUNT=owner@example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Added
 
+- **Search Console API access, documented and reproducible** — `docs/reference/seo.md` gains a
+  "Search Console API access" section: the domain property (`sc-domain:anyplot.ai`), the
+  Application Default Credentials login that carries the `webmasters.readonly` scope, a
+  verification snippet, and the two failure modes that otherwise cost a session — the gcloud CLI
+  token can never hold the scope, and the localhost callback flow dies with `missing_code` on
+  WSL2 before you finish the consent screen. Machine-specific values move to `.env`
+  (`SEARCH_CONSOLE_PROPERTY`, `SEARCH_CONSOLE_ACCOUNT`, documented in `.env.example`), so a
+  second machine is one login away from full-mode audits.
+
 - **Three new verification skills** — `/verify-migrations` runs the Alembic chain against a
   throwaway Postgres (Docker, or a rootless `pgserver` fallback; single-head check,
   `upgrade head`, `alembic check` drift, downgrade roundtrip) so the shared prod DB never sees
@@ -177,6 +186,17 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   interactive don't fit a static-first catalog (#8645).
 
 ### Fixed
+
+- **`seo-auditor` could never reach Search Console** — its auth contract probed
+  `gcloud auth print-access-token`, which mints the gcloud CLI credential; that credential's
+  scope set is fixed and can never include `webmasters.readonly`, so every audit since the
+  command was written reported `Search Console mode: structural-only` (2026-04-26, 2026-05-05,
+  2026-07-08). It now probes Application Default Credentials. The same contract also forbade
+  every non-`GET` call while asking for query data — Search Analytics is a `POST` — so the
+  auditor was told to collect data it was simultaneously barred from fetching; read-ness is now
+  anchored to the `webmasters.readonly` scope rather than the HTTP verb, which additionally
+  unlocks `urlInspection`. Its Coverage guidance no longer asks for the page-indexing report
+  buckets, which have no API at all.
 
 - **Model↔migration index drift fixed before it could drop production indexes** — seven
   migration-created indexes (`ix_specs_issue`, `ix_specs_tags` GIN, `ix_impls_library_id`,

--- a/agentic/commands/audit/seo-auditor.md
+++ b/agentic/commands/audit/seo-auditor.md
@@ -8,7 +8,7 @@ The `webmasters.readonly` scope is the guarantee, not the HTTP verb: with that s
 
 You may only:
 - HTTP `GET` against `https://anyplot.ai/*` (sitemap, robots.txt, sample HTML)
-- Search Console **read** methods: `GET /webmasters/v3/sites`, `GET /webmasters/v3/sites/{site}/sitemaps`, `POST /webmasters/v3/sites/{site}/searchAnalytics/query`, and `POST /v1/urlInspection/index:inspect` (2000/day quota — sample, don't sweep)
+- Search Console **read** methods: `GET /webmasters/v3/sites`, `GET /webmasters/v3/sites/{site}/sitemaps`, `POST /webmasters/v3/sites/{site}/searchAnalytics/query`, and `POST https://searchconsole.googleapis.com/v1/urlInspection/index:inspect` — note the **different host**: URL Inspection is not under `www.googleapis.com/webmasters/v3`, and calling it there returns 404 (2000/day quota — sample, don't sweep)
 - reading a token from Application Default Credentials (see the auth contract below)
 
 Forbidden: any sitemap submit/delete, any Indexing API call (those are write-side), any URL-removal call, and re-authenticating (`gcloud auth ... login`) — if the scope is missing, report it, don't fix it. If unsure, do not call.

--- a/agentic/commands/audit/seo-auditor.md
+++ b/agentic/commands/audit/seo-auditor.md
@@ -4,17 +4,19 @@ You are the **seo-auditor** on the audit team. Your scope is **search visibility
 
 ## Read-only is absolute
 
+The `webmasters.readonly` scope is the guarantee, not the HTTP verb: with that scope every write method fails at Google's end regardless of what you send. So read methods that happen to be `POST` are allowed.
+
 You may only:
 - HTTP `GET` against `https://anyplot.ai/*` (sitemap, robots.txt, sample HTML)
-- HTTP `GET` against the Search Console API (`https://www.googleapis.com/webmasters/v3/...`)
-- `gcloud auth print-access-token` (read-only — mints a token for the active SA, doesn't change anything)
+- Search Console **read** methods: `GET /webmasters/v3/sites`, `GET /webmasters/v3/sites/{site}/sitemaps`, `POST /webmasters/v3/sites/{site}/searchAnalytics/query`, and `POST /v1/urlInspection/index:inspect` (2000/day quota — sample, don't sweep)
+- reading a token from Application Default Credentials (see the auth contract below)
 
-Forbidden: any non-`GET`, any Search Console write (`searchanalytics/sitemaps/inspection` write methods), any Index API call (those are write-side), any URL-removal call. If unsure, do not call.
+Forbidden: any sitemap submit/delete, any Indexing API call (those are write-side), any URL-removal call, and re-authenticating (`gcloud auth ... login`) — if the scope is missing, report it, don't fix it. If unsure, do not call.
 
 ## Auth contract — never block the run
 
-1. Probe: `gcloud auth print-access-token 2>/dev/null` (if absent, structural-only mode).
-2. If a token is available, GET `https://www.googleapis.com/webmasters/v3/sites` and check whether `https://anyplot.ai/` (or `sc-domain:anyplot.ai`) is returned.
+1. Probe ADC: `gcloud auth application-default print-access-token 2>/dev/null`, or `google.auth.default(scopes=["https://www.googleapis.com/auth/webmasters.readonly"])` in a `uv run` script. **Do not use `gcloud auth print-access-token`** — that is the gcloud CLI credential, whose fixed scope set can never include `webmasters.readonly`, so it always fails here. If ADC is absent or unscoped, go to structural-only mode and name the missing scope in the LIMITATION line; setup is in `docs/reference/seo.md` ("Search Console API access").
+2. If a token is available, GET `https://www.googleapis.com/webmasters/v3/sites` and check whether `sc-domain:anyplot.ai` (or `https://anyplot.ai/`) is returned. It is a **domain** property, so `siteUrl` values must be sent URL-encoded (`sc-domain%3Aanyplot.ai`) in later paths.
 3. If the property is returned: **full mode** — do both Search Console checks AND structural checks.
 4. If the property is NOT returned, OR no token is available: **structural-only mode** — do the structural checks only. Surface a banner in the report header. Do NOT abort.
 5. Always report the active mode in the COVERAGE line.
@@ -24,7 +26,8 @@ Forbidden: any non-`GET`, any Search Console write (`searchanalytics/sitemaps/in
 ### Full mode (Search Console-backed)
 
 - **Performance**: top queries last 28d; top landing pages; queries with high impressions but low CTR (<2%) → meta-description/title rewrite opportunities; queries on page 2 (positions 11–20) → easy wins with internal linking
-- **Coverage**: indexed vs excluded URLs, crawl errors, soft-404s, "Discovered – currently not indexed" (Google saw it, refused to index → usually thin/duplicate content); flag any spec/impl page in `Excluded`
+- **Coverage**: the page-indexing report buckets ("Crawled/Discovered – currently not indexed", "Duplicate without user-selected canonical") have **no API** — do not try to derive them. Sample `urlInspection` instead: take ~30 URLs (top-impression, zero-impression-but-in-sitemap, and indexed-but-not-in-sitemap) and report the `coverageState` / `lastCrawlTime` distribution with its sample size. A stale `lastCrawlTime` or a lingering `Server error (5xx)` from a past outage is a finding in its own right. If the question really needs the full buckets, ask the lead for a UI CSV export rather than guessing
+- **Sitemap vs reality**: compare `<loc>` entries against the pages that actually drew impressions — URLs with impressions that are *missing* from the sitemap are orphans (usually stale URLs from a library/rename migration), and sitemap URLs with zero impressions are the silent tail
 - **Sitemaps**: submitted vs discovered URL count, last-read status, errors
 - **Mobile usability**: any pages flagged
 - **CWV (field, CrUX-backed)**: cross-check against `pagespeed-auditor` lab numbers — divergence is itself a finding (lead computes it in Phase 3)

--- a/docs/reference/seo.md
+++ b/docs/reference/seo.md
@@ -407,6 +407,89 @@ location = /sitemap.xml {
 }
 ```
 
+## Search Console API access
+
+Search Console holds data that no crawl of the site can reproduce: what people actually searched
+for, which URLs Google indexed, and when it last crawled them. Without it the `seo-auditor` in
+`/audit` falls back to `structural-only` mode. Credentials are per-machine, so set this up once
+on every machine you audit from.
+
+### Property and account
+
+The property is a domain property, `sc-domain:anyplot.ai`. Access is tied to the Google account
+that owns it — not to a service account, and not to the repository. Keep the machine-specific
+values in `.env`, which is gitignored:
+
+```bash
+SEARCH_CONSOLE_PROPERTY=sc-domain:anyplot.ai
+SEARCH_CONSOLE_ACCOUNT=owner@example.com
+```
+
+The same account also owns `sc-domain:pyplots.ai`, the site's former domain. Keep that property:
+it carries the crawl and redirect history of the migration to `anyplot.ai`.
+
+### Set up credentials
+
+1. Enable the API on the GCP project. This is already done for `anyplot` and only needs
+   repeating for a new project:
+
+   ```bash
+   gcloud services enable searchconsole.googleapis.com --project=anyplot
+   ```
+
+2. Authenticate with Application Default Credentials. The Search Console API needs the
+   `webmasters.readonly` scope, and ADC is the only credential on this machine that can carry
+   it:
+
+   ```bash
+   gcloud auth application-default login \
+     --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/webmasters.readonly
+   gcloud auth application-default set-quota-project anyplot
+   ```
+
+   Always keep `cloud-platform` in the scope list. The login overwrites ADC, and dropping the
+   scope locks this machine's other Google clients (Cloud SQL, GCS) out.
+
+3. Verify that the property comes back:
+
+   ```bash
+   uv run --with google-auth --with requests python -c "
+   import google.auth
+   from google.auth.transport.requests import AuthorizedSession
+   creds, _ = google.auth.default(scopes=['https://www.googleapis.com/auth/webmasters.readonly'])
+   resp = AuthorizedSession(creds).get('https://www.googleapis.com/webmasters/v3/sites')
+   print(resp.status_code, resp.text[:400])
+   "
+   ```
+
+   You want HTTP 200 and `sc-domain:anyplot.ai` with `permissionLevel: siteOwner` in the list.
+
+### Two traps that cost a session
+
+**`gcloud auth print-access-token` returns the wrong token.** It mints a token for the gcloud CLI
+credential, whose scope set is fixed (`cloud-platform`, `compute`, `sqlservice.login`) and can
+never include `webmasters.readonly`. Every Search Console call made with it fails, which is why
+audits before 2026-08-18 all reported `structural-only`. Read the token from ADC instead — either
+`google.auth.default()` in a script, or `gcloud auth application-default print-access-token`.
+
+**The localhost callback flow may never complete.** On some machines — WSL2 in particular — the
+default browser flow dies within seconds with `(missing_code) Missing code parameter in
+response`, because a port probe or a browser prefetch reaches `127.0.0.1:8085` before you finish
+the consent screen, and gcloud aborts on the first request without a `code` parameter. Retrying
+does not help. Use `--no-launch-browser` instead and paste the `4/0A…` code that Google displays;
+that code is single-use and PKCE-bound to the waiting process. When you run the login
+non-interactively, hold its stdin open (for example with `tail -f` on a file you append the code
+to), otherwise gcloud crashes with `EOFError` before you can answer the prompt.
+
+### What the API cannot answer
+
+Search Analytics (queries, pages, dates — without the UI's 1000-row cap), the `sitemaps`
+endpoint, and per-URL `urlInspection/index:inspect` (2000 calls per day) are all available. The
+**page indexing report buckets** — "Crawled – currently not indexed", "Discovered – currently not
+indexed", "Duplicate without user-selected canonical" — have no API at all. Those numbers only
+come from a CSV export in the Search Console UI, so ask for one when the question is about
+indexing coverage rather than about ranking.
+
 ## Testing
 
 ### Test bot detection locally

--- a/docs/reference/seo.md
+++ b/docs/reference/seo.md
@@ -450,19 +450,23 @@ it carries the crawl and redirect history of the migration to `anyplot.ai`.
    Always keep `cloud-platform` in the scope list. The login overwrites ADC, and dropping the
    scope locks this machine's other Google clients (Cloud SQL, GCS) out.
 
-3. Verify that the property comes back:
+3. Verify that the property comes back, using the snippet below.
 
-   ```bash
-   uv run --with google-auth --with requests python -c "
-   import google.auth
-   from google.auth.transport.requests import AuthorizedSession
-   creds, _ = google.auth.default(scopes=['https://www.googleapis.com/auth/webmasters.readonly'])
-   resp = AuthorizedSession(creds).get('https://www.googleapis.com/webmasters/v3/sites')
-   print(resp.status_code, resp.text[:400])
-   "
-   ```
+The verification snippet is deliberately unindented: pasted with leading whitespace, the
+heredoc terminator stops closing the block and Python rejects the indented program.
 
-   You want HTTP 200 and `sc-domain:anyplot.ai` with `permissionLevel: siteOwner` in the list.
+```bash
+uv run --with google-auth --with requests python - <<'PY'
+import google.auth
+from google.auth.transport.requests import AuthorizedSession
+
+creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/webmasters.readonly"])
+resp = AuthorizedSession(creds).get("https://www.googleapis.com/webmasters/v3/sites")
+print(resp.status_code, resp.text[:400])
+PY
+```
+
+You want HTTP 200 and `sc-domain:anyplot.ai` with `permissionLevel: siteOwner` in the list.
 
 ### Two traps that cost a session
 


### PR DESCRIPTION
## Why

The user granted Search Console API access this session so the indexing/ranking problems on `anyplot.ai` could actually be analysed. Two things had to be fixed to make that stick beyond one machine and one session.

**The `seo-auditor` has never reached Search Console.** Its auth contract probed `gcloud auth print-access-token`, which mints the *gcloud CLI* credential. That credential's scope set is fixed (`cloud-platform`, `compute`, `sqlservice.login`) and can never include `webmasters.readonly`. Every audit since the command was written reported `Search Console mode: structural-only`:

- `agentic/audits/2026-04-26-all.md`
- `agentic/audits/2026-05-05-all.md`
- `agentic/audits/2026-07-08-product-ux.md`

Only Application Default Credentials can carry the scope. Verified working now — `GET /webmasters/v3/sites` returns `sc-domain:anyplot.ai` with `permissionLevel: siteOwner`.

**The read-only contract contradicted itself.** It forbade "any non-`GET`" while instructing the auditor to pull top queries — but `searchAnalytics/query` is a `POST`. Read-ness now hangs off the `webmasters.readonly` scope rather than the HTTP verb, which is the real guarantee: with that scope every write method fails at Google's end regardless of what is sent. That also unlocks `urlInspection/index:inspect`, the only API-side view of per-URL index state — and the one that surfaced the finding below.

## What changed

| File | Change |
|---|---|
| `docs/reference/seo.md` | New "Search Console API access" section: property, ADC login, verification snippet, the two traps, and what the API cannot answer |
| `agentic/commands/audit/seo-auditor.md` | Auth probe → ADC; read-only rule anchored to the scope; Coverage guidance no longer asks for buckets that have no API |
| `.env.example` | `SEARCH_CONSOLE_PROPERTY`, `SEARCH_CONSOLE_ACCOUNT` (credentials stay in ADC, never in the file) |
| `CHANGELOG.md` | Entries under Added + Fixed |

The verification snippet in the docs was executed verbatim as written, including its indentation — an earlier draft used a heredoc whose terminator sat indented inside the numbered list and would have broken on paste.

## Two traps, documented because each cost real time

1. `gcloud auth print-access-token` is the wrong token (above).
2. The localhost callback flow cannot complete on WSL2: both `--launch-browser` and the default flow died within seconds with `(missing_code) Missing code parameter in response`, because something reaches `127.0.0.1:8085` before the consent screen is finished and gcloud aborts on the first request without a `code` parameter. `--no-launch-browser` works, but needs its stdin held open or it crashes with `EOFError`.

## Not in this PR

The audit itself is still running. The first API-side findings — a residue of URLs still held at `Server error (5xx)` from the June crawler outage that #9617 fixed, ~180 indexed URLs absent from the sitemap after the highcharts Python→JS migration, and an unvalidated `{language}/{library}` URL space in `api/routers/seo.py:757` that serves 200 + self-referencing canonical for combinations like `/bar-basic/klingon/matplotlib` — are being quantified and will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)