### PR TITLE
fix(seo): 404 unknown language/library combinations instead of inventing a page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The SEO proxy no longer invents pages** — `/{spec}/{language}/{library}` served HTTP 200 with
+  a self-referencing canonical for *any* language and library string, because neither segment is
+  validated against a vocabulary: `/bar-basic/klingon/matplotlib` and
+  `/bar-basic/python/erfundenelib` were both indexable pages. That is an unbounded supply of thin
+  near-duplicates competing with the 3,913 real URLs for the same crawl budget, and it is why 161
+  URLs from the highcharts Python→JS migration (#8516) were still indexed months after those
+  implementations were deleted. Unknown combinations now return 404, and the 404 is not cached so
+  a later regen becomes visible immediately. The stale URLs are dropped rather than redirected:
+  measured over 28 days they carry 4.4% of impressions and 10 clicks in total.
+
 - **Model↔migration index drift fixed before it could drop production indexes** — seven
   migration-created indexes (`ix_specs_issue`, `ix_specs_tags` GIN, `ix_impls_library_id`,
   `ix_impls_quality_score`, `ix_impls_impl_tags` GIN, `ix_feedback_created_at` DESC,

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -744,24 +744,22 @@ async def seo_spec_implementation(
     impl = next(
         (i for i in spec.impls if i.library_id == library and i.library and i.library.language == language), None
     )
-    image = (
-        f"https://api.anyplot.ai/og/{spec_id}/{language}/{library}.png"
-        if impl and impl.preview_url
-        else DEFAULT_HOME_IMAGE
-    )
+    if impl is None:
+        # The spec exists but this language/library pair does not. This used to
+        # serve a 200 with a minimal meta-only page, so that bots holding stale
+        # URLs after a regen still got something — but neither segment is
+        # validated anywhere, so every {spec}/{any string}/{any string} URL was
+        # an indexable page carrying its own self-referencing canonical. That is
+        # an unbounded supply of thin near-duplicates competing with the real
+        # catalogue for the same crawl budget, and it kept 161 URLs from the
+        # highcharts Python->JS migration (#8516) indexed months after the
+        # implementations were deleted. They are worth 10 clicks per 28 days
+        # between them, so they are dropped rather than redirected.
+        raise HTTPException(status_code=404, detail="Implementation not found")
 
-    if impl:
-        code_impl = await ImplRepository(db).get_code(spec_id, library, language)
-        code = strip_noqa_comments(code_impl.code) if code_impl and code_impl.code else None
-        result = _build_impl_html(spec, impl, code, image)
-    else:
-        # Unknown language/library combination for a real spec: keep serving
-        # the minimal meta-only page (bots may hold stale URLs after regens).
-        result = _render_bot_html(
-            title=f"{html.escape(spec.title)} - {html.escape(library)} | anyplot.ai",
-            description=html.escape(spec.description or DEFAULT_DESCRIPTION),
-            image=html.escape(image, quote=True),
-            url=f"https://anyplot.ai/{html.escape(spec_id)}/{html.escape(language)}/{html.escape(library)}",
-        )
+    image = f"https://api.anyplot.ai/og/{spec_id}/{language}/{library}.png" if impl.preview_url else DEFAULT_HOME_IMAGE
+    code_impl = await ImplRepository(db).get_code(spec_id, library, language)
+    code = strip_noqa_comments(code_impl.code) if code_impl and code_impl.code else None
+    result = _build_impl_html(spec, impl, code, image)
     set_cache(key, result)
     return HTMLResponse(result)

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -838,12 +838,29 @@ class TestSeoProxyRouter:
         """
         client, _ = db_client
 
+        # Give the spec a JavaScript-only implementation so the wrong-language
+        # case is genuinely exercised: /python/highcharts must fail on the
+        # language filter, not merely because the library id is absent.
+        js_impl = MagicMock()
+        js_impl.library_id = "highcharts"
+        js_impl.library = MagicMock()
+        js_impl.library.language = "javascript"
+        js_impl.preview_url = None
+        mock_spec.impls = [*mock_spec.impls, js_impl]
+
         mock_spec_repo = MagicMock()
         mock_spec_repo.get_by_id = AsyncMock(return_value=mock_spec)
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_code = AsyncMock(return_value=None)
 
-        with patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo):
-            # Library exists in the catalogue, but not for this language
+        with (
+            patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.seo.ImplRepository", return_value=mock_impl_repo),
+        ):
+            # Library exists on this spec, but only under a different language
             assert client.get("/seo-proxy/scatter-basic/python/highcharts").status_code == 404
+            # ...while its real language still resolves
+            assert client.get("/seo-proxy/scatter-basic/javascript/highcharts").status_code == 200
             # Library that does not exist at all
             assert client.get("/seo-proxy/scatter-basic/python/madeuplib").status_code == 404
             # Language that does not exist at all

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -829,6 +829,40 @@ class TestSeoProxyRouter:
             response = client.get("/seo-proxy/nonexistent-spec/python/matplotlib")
             assert response.status_code == 404
 
+    def test_seo_spec_implementation_unknown_combination_is_404(self, db_client, mock_spec) -> None:
+        """A real spec with a language/library pair that has no implementation must 404.
+
+        Neither segment is validated against a vocabulary, so a 200 here made
+        every {spec}/{any string}/{any string} URL an indexable page with its
+        own self-referencing canonical.
+        """
+        client, _ = db_client
+
+        mock_spec_repo = MagicMock()
+        mock_spec_repo.get_by_id = AsyncMock(return_value=mock_spec)
+
+        with patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo):
+            # Library exists in the catalogue, but not for this language
+            assert client.get("/seo-proxy/scatter-basic/python/highcharts").status_code == 404
+            # Library that does not exist at all
+            assert client.get("/seo-proxy/scatter-basic/python/madeuplib").status_code == 404
+            # Language that does not exist at all
+            assert client.get("/seo-proxy/scatter-basic/klingon/matplotlib").status_code == 404
+
+    def test_seo_spec_implementation_404_is_not_cached(self, db_client, mock_spec) -> None:
+        """A 404 must not populate the cache, or a later real regen stays invisible."""
+        client, _ = db_client
+
+        mock_spec_repo = MagicMock()
+        mock_spec_repo.get_by_id = AsyncMock(return_value=mock_spec)
+
+        with (
+            patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.seo.set_cache") as mock_set_cache,
+        ):
+            assert client.get("/seo-proxy/scatter-basic/python/madeuplib").status_code == 404
+            mock_set_cache.assert_not_called()
+
     def test_seo_spec_implementation_fallback_image(self, db_client, mock_spec) -> None:
         """SEO spec implementation should use default image when impl has no preview."""
         client, _ = db_client


### PR DESCRIPTION
## The problem, measured

`/{spec}/{language}/{library}` validates neither the language nor the library segment against any vocabulary, and the handler's fallback served HTTP 200 with a minimal meta-only page for anything it could not resolve. Verified against production:

```
/bar-basic/python/highcharts    → 200  (highcharts is JS-only since #8516)
/bar-basic/klingon/matplotlib   → 200
/bar-basic/python/erfundenelib  → 200
/bar-basic/PYTHON/matplotlib    → 200  (duplicate of the lowercase URL)
```

Each of those carries its own self-referencing canonical — an explicit instruction to Google that it is a distinct, real page. The URL space is unbounded, and it competes with the 3,913 real catalogue URLs for the same crawl budget.

This is not hypothetical. Search Console shows **161 URLs from the highcharts Python→JS migration (#8516) still indexed** months after those implementations were deleted, because the fallback kept answering 200 for them. `urlInspection` confirms them as `Submitted and indexed` with crawls as recent as 2026-08-14.

## Why 404 and not a redirect

The orphan set is worth **4.4% of impressions and 10 clicks over 28 days**, spread across 180 URLs at positions 24–72. A redirect map keyed on "which language does this library live in now" would cost more to build and maintain than it preserves. Dropping them is the owner's call, made on those numbers.

## What changed

- Unknown combination → `404`, replacing the 200 fallback (`api/routers/seo.py`)
- The 404 is **not** cached, so a spec that later gains that implementation through a regen becomes visible on the next request rather than after a TTL
- Two tests: the three 404 shapes (library-wrong-language, unknown library, unknown language) and the no-cache guarantee

The tier above already made this call for the same reason — `/{spec}/{language}` 301s to the hub with the comment "consolidated into `/{spec_id}` to eliminate duplicate content". This is the tier below it finally getting the same treatment.

## Verification

- `pytest tests/unit` — 1587 passed
- `ruff check` + `ruff format --check` — clean (format reformatted `seo.py`; re-checked after)
- `mypy api/routers/seo.py` — no issues

## Deliberately not in scope

`/?spec=point-basic` and `/{spec}/{language}/{library}?view=interactive` are indexed as separate pages too — query-parameter duplicates need a canonical fix rather than a status-code fix, and that is a different change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)