### PR TITLE
fix(seo): stop Googlebot looping forever on /{spec}/{language}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **Googlebot was walking an infinite redirect on every `/{spec}/{language}` URL** — the handler
+  answered `Location: /seo-proxy/{spec}`, its own internal path. nginx serves crawlers by
+  prepending `/seo-proxy` to the request URI, so the bot fetched `anyplot.ai/seo-proxy/{spec}`,
+  which arrived as `/seo-proxy/seo-proxy/{spec}` and re-matched the same route with
+  `spec_id="seo-proxy"` — redirecting again, forever. `curl -A Googlebot` gives up after 50 hops
+  at `anyplot.ai/seo-proxy/seo-proxy`; a normal user agent never saw it, because only bots take
+  the proxy path. Search Console recorded it as 48 URLs under **Redirect error**. The Location is
+  now the public URL, and a regression test asserts both that it never starts with `/seo-proxy`
+  and that re-entering with the prefix nginx adds resolves instead of bouncing.
+
 - **Model↔migration index drift fixed before it could drop production indexes** — seven
   migration-created indexes (`ix_specs_issue`, `ix_specs_tags` GIN, `ix_impls_library_id`,
   `ix_impls_quality_score`, `ix_impls_impl_tags` GIN, `ix_feedback_created_at` DESC,

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -693,25 +693,34 @@ async def seo_spec_language(spec_id: str, language: str):
     """Permanent redirect: language-overview URLs now live on the hub with ?language=.
 
     The /{spec_id}/{language} tier was consolidated into /{spec_id} to eliminate
-    duplicate content. Bots following this endpoint get a 301 to the hub proxy;
-    humans get the SPA redirect configured in app/src/router.tsx. The `language`
-    query parameter is dropped because the hub's canonical tag does not include
-    it — Google should consolidate the page, not a filtered variant.
+    duplicate content. Bots following this endpoint get a 301 to the public hub
+    URL; humans get the SPA redirect configured in app/src/router.tsx. The
+    `language` query parameter is dropped because the hub's canonical tag does
+    not include it — Google should consolidate the page, not a filtered variant.
     """
     del language  # referenced for route matching only; deliberately not forwarded
     if not _SPEC_ID_RE.fullmatch(spec_id):
         raise HTTPException(status_code=404, detail="Spec not found")
+    # The Location must be the PUBLIC url, not this router's internal path.
+    # nginx serves crawlers by prepending /seo-proxy to the incoming request
+    # URI (`proxy_pass $seo_backend/seo-proxy$request_uri`), so a Location of
+    # /seo-proxy/{spec} is fetched by the bot as anyplot.ai/seo-proxy/{spec},
+    # arrives here as /seo-proxy/seo-proxy/{spec}, and re-matches this very
+    # route with spec_id="seo-proxy" and language="{spec}" -- which redirects
+    # again, forever. Googlebot recorded the loop as 48 "Redirect error" URLs.
+    #
     # Belt-and-braces redirect-target sanitisation:
     #   1. _SPEC_ID_RE.fullmatch() above already constrains spec_id to
-    #      lowercase alphanum + hyphens.
+    #      lowercase alphanum + hyphens, and requires it to be non-empty.
     #   2. urllib.parse.quote() percent-encodes anything outside [-A-Za-z0-9],
     #      which is a CodeQL-recognised sanitizer for `py/url-redirection`.
     #   3. urlparse() + scheme/netloc check guarantees the assembled URL is
-    #      a same-origin path (no `//evil.com` or `https://evil.com`).
+    #      a same-origin path, and the explicit "//" rejection keeps it from
+    #      being read as a protocol-relative url (`//evil.com`).
     safe_spec = quote(spec_id, safe="-")
-    target = "/seo-proxy/" + safe_spec
+    target = "/" + safe_spec
     parsed = urlparse(target)
-    if parsed.scheme or parsed.netloc or not target.startswith("/seo-proxy/"):
+    if parsed.scheme or parsed.netloc or not target.startswith("/") or target.startswith("//"):
         raise HTTPException(status_code=400, detail="Invalid redirect target")
     return RedirectResponse(url=target, status_code=301)
 

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -690,7 +690,7 @@ async def seo_spec_hub(spec_id: str, db: AsyncSession | None = Depends(optional_
 
 @router.get("/seo-proxy/{spec_id}/{language}")
 async def seo_spec_language(spec_id: str, language: str):
-    """Permanent redirect: language-overview URLs now live on the hub with ?language=.
+    """Permanent redirect: language-overview URLs are consolidated onto the hub.
 
     The /{spec_id}/{language} tier was consolidated into /{spec_id} to eliminate
     duplicate content. Bots following this endpoint get a 301 to the public hub

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -785,12 +785,16 @@ class TestSeoProxyRouter:
         loops until the crawler gives up — which is exactly what Googlebot
         recorded against the live site.
         """
-        location = client.get("/seo-proxy/scatter-basic/python", follow_redirects=False).headers["location"]
+        response = client.get("/seo-proxy/scatter-basic/python", follow_redirects=False)
+        assert response.status_code == 301
+        location = response.headers["location"]
         assert not location.startswith("/seo-proxy")
         assert not location.startswith("//")
-        # One more hop must not redirect again: re-entering with the proxy
-        # prefix that nginx adds has to resolve, not bounce.
-        assert client.get(f"/seo-proxy{location}", follow_redirects=False).status_code != 301
+        # One more hop must terminate: re-entering with the proxy prefix that
+        # nginx adds has to resolve. Asserting 200 rather than "not 301" — the
+        # loop would come back just as happily as a 302, 307 or 308.
+        with patch(DB_CONFIG_PATCH, return_value=False):
+            assert client.get(f"/seo-proxy{location}", follow_redirects=False).status_code == 200
 
     def test_seo_spec_language_rejects_malformed_spec_id(self, client: TestClient) -> None:
         """Malformed spec_ids must 404, not redirect — prevents header injection."""

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -775,7 +775,22 @@ class TestSeoProxyRouter:
         """
         response = client.get("/seo-proxy/scatter-basic/python", follow_redirects=False)
         assert response.status_code == 301
-        assert response.headers["location"] == "/seo-proxy/scatter-basic"
+        assert response.headers["location"] == "/scatter-basic"
+
+    def test_seo_spec_language_redirect_target_is_public_not_internal(self, client: TestClient) -> None:
+        """The Location must be the public URL, never this router's own prefix.
+
+        nginx serves crawlers by prepending /seo-proxy to the request URI, so a
+        Location under /seo-proxy comes back one level deeper on every hop and
+        loops until the crawler gives up — which is exactly what Googlebot
+        recorded against the live site.
+        """
+        location = client.get("/seo-proxy/scatter-basic/python", follow_redirects=False).headers["location"]
+        assert not location.startswith("/seo-proxy")
+        assert not location.startswith("//")
+        # One more hop must not redirect again: re-entering with the proxy
+        # prefix that nginx adds has to resolve, not bounce.
+        assert client.get(f"/seo-proxy{location}", follow_redirects=False).status_code != 301
 
     def test_seo_spec_language_rejects_malformed_spec_id(self, client: TestClient) -> None:
         """Malformed spec_ids must 404, not redirect — prevents header injection."""


### PR DESCRIPTION
## Reproduce it

```
$ curl -A Googlebot -sSI https://anyplot.ai/bar-basic/python | grep -i '^http\|^location'
HTTP/2 301
location: /seo-proxy/bar-basic

$ curl -A Googlebot -sS -o /dev/null -L -w '%{url_effective} %{num_redirects}\n' https://anyplot.ai/bar-basic/python
curl: (47) Maximum (50) redirects followed
https://anyplot.ai/seo-proxy/seo-proxy 50
```

A normal user agent gets a clean `200` on the same URL. Only bots take the proxy path, so nothing a human clicks ever reveals this.

## Mechanism

The handler answers with `Location: /seo-proxy/{spec}` — its own internal path. nginx serves crawlers by prepending `/seo-proxy` to the request URI:

```nginx
location @seo_proxy {
    proxy_pass $seo_backend/seo-proxy$request_uri;
}
```

So the bot fetches `anyplot.ai/seo-proxy/bar-basic`, it arrives here as `/seo-proxy/seo-proxy/bar-basic`, and re-matches **this same route** with `spec_id="seo-proxy"`, `language="bar-basic"` — which redirects again. The terminal URL `anyplot.ai/seo-proxy/seo-proxy` is the loop's fixed point.

## Impact

Search Console's coverage export (2026-08-18) lists **48 URLs under Redirect error**. This is also why the `/{spec}/{language}` consolidation never delivered what it was designed for: instead of handing crawlers to the hub, it handed them a loop.

## The fix

`Location` becomes the public URL `/{spec}`. The bot fetches `anyplot.ai/{spec}`, nginx maps it to `/seo-proxy/{spec}`, which serves 200.

The sanitisation keeps the CodeQL-recognised `urlparse` scheme/netloc pattern and gains an explicit `//` rejection, because the target no longer carries a fixed literal prefix to anchor the check on. `_SPEC_ID_RE` (`^[a-z0-9]+(-[a-z0-9]+)*$`) already guarantees a non-empty `[a-z0-9-]` segment before `quote()` runs.

## Tests

The existing test asserted the buggy Location verbatim, so it encoded the bug — updated. A new regression test pins both halves: the Location never starts with `/seo-proxy`, and re-entering with the prefix nginx adds must resolve rather than bounce.

Verified by mutation, not by inspection: restoring `"/seo-proxy/" + safe_spec` fails both tests; the corrected target passes them.

- `pytest tests/unit` — 1586 passed
- `ruff check` + `ruff format --check` — clean
- `mypy api/routers/seo.py` — no issues

## After merge

The Redirect-error bucket becomes eligible for **Validate fix** in Search Console. It should not be clicked before this deploys — a failed validation makes Google back off from the next attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)