### PR TITLE
fix(seo): trim meta descriptions to what a search result actually shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **Meta descriptions were three times too long to survive a search result** — every prerendered
+  page passed the full spec description straight into `<meta name="description">`. Measured across
+  40 live pages: median 424 characters, longest 801, and all 40 over Google's ~155-character
+  truncation point, so the sentence that decides the click was never the one being written. The
+  2026-05-05 audit recorded this and it had not moved since. The meta and OG tags now carry a trim
+  that ends on the last full sentence that fits (falling back to a word boundary), taking the same
+  sample to a median of 142 with none over the limit. Visible body copy and JSON-LD keep the full
+  description — the trim is for the snippet, not the content — and it runs on the raw text before
+  escaping, so it can never cut through an HTML entity.
+
 - **Model↔migration index drift fixed before it could drop production indexes** — seven
   migration-created indexes (`ix_specs_issue`, `ix_specs_tags` GIN, `ix_impls_library_id`,
   `ix_impls_quality_score`, `ix_impls_impl_tags` GIN, `ix_feedback_created_at` DESC,

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -219,10 +219,15 @@ def _meta_description(text: str | None) -> str:
     """Trim a description to what a search result will actually display.
 
     Only the meta/OG tag is trimmed; the visible body copy and the JSON-LD keep
-    the full text, because those are content rather than snippet. Prefers to end
-    on a sentence that fits, and falls back to a word boundary so the trim never
-    lands mid-word or mid-entity — which is also why this runs on the raw text,
-    before HTML escaping, rather than on an escaped string it could cut through.
+    the full text, because those are content rather than snippet.
+
+    Ends on the last full sentence that fits — but only where that lands past
+    the halfway mark. A description opening with a short sentence ("A Smith
+    chart.") would otherwise yield a snippet of a dozen characters, wasting the
+    slot that decides the click; below that threshold a word-boundary trim of
+    the full text carries more information. The word-boundary fallback also
+    keeps the trim off mid-word, and running on raw text rather than an escaped
+    string means it can never cut through an HTML entity.
     """
     text = " ".join((text or "").split())
     if len(text) <= _META_DESCRIPTION_LIMIT:

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -209,6 +209,37 @@ _BOT_NAV_HTML = (
 )
 
 
+# Google truncates the SERP snippet around 155 characters and rewrites what it
+# cannot use. Spec descriptions in this catalogue run to a median of 395 (max
+# 801), so the sentence that decides the click was never the one being written.
+_META_DESCRIPTION_LIMIT = 155
+
+
+def _meta_description(text: str | None) -> str:
+    """Trim a description to what a search result will actually display.
+
+    Only the meta/OG tag is trimmed; the visible body copy and the JSON-LD keep
+    the full text, because those are content rather than snippet. Prefers to end
+    on a sentence that fits, and falls back to a word boundary so the trim never
+    lands mid-word or mid-entity — which is also why this runs on the raw text,
+    before HTML escaping, rather than on an escaped string it could cut through.
+    """
+    text = " ".join((text or "").split())
+    if len(text) <= _META_DESCRIPTION_LIMIT:
+        return text
+
+    window = text[: _META_DESCRIPTION_LIMIT + 1]
+    for stop in (". ", "! ", "? "):
+        end = window.rfind(stop)
+        if end >= _META_DESCRIPTION_LIMIT // 2:
+            return text[: end + 1]
+
+    cut = window.rfind(" ")
+    if cut <= 0:
+        return text[:_META_DESCRIPTION_LIMIT].rstrip() + "\u2026"
+    return text[:cut].rstrip(" ,;:\u2014-") + "\u2026"
+
+
 def _jsonld_script(payload: dict) -> str:
     """Serialize a JSON-LD payload into a <script> element for the template head.
 
@@ -335,6 +366,7 @@ def _build_spec_hub_html(spec, image: str) -> str:
     spec_id_esc = html.escape(spec.id)
     title_esc = html.escape(spec.title)
     desc_esc = html.escape(spec.description or DEFAULT_DESCRIPTION)
+    meta_desc_esc = html.escape(_meta_description(spec.description or DEFAULT_DESCRIPTION))
     image_esc = html.escape(image, quote=True)
     hub_url = f"https://anyplot.ai/{spec.id}"
 
@@ -372,7 +404,7 @@ def _build_spec_hub_html(spec, image: str) -> str:
     }
     return _render_bot_html(
         title=f"{title_esc} | anyplot.ai",
-        description=desc_esc,
+        description=meta_desc_esc,
         image=image_esc,
         url=f"https://anyplot.ai/{spec_id_esc}",
         body=body,
@@ -392,6 +424,7 @@ def _build_impl_html(spec, impl, code: str | None, image: str) -> str:
     title_esc = html.escape(spec.title)
     lib_name_esc = html.escape(lib_name)
     desc_esc = html.escape(spec.description or DEFAULT_DESCRIPTION)
+    meta_desc_esc = html.escape(_meta_description(spec.description or DEFAULT_DESCRIPTION))
     image_esc = html.escape(image, quote=True)
     hub_url = f"https://anyplot.ai/{spec.id}"
     page_url = f"{hub_url}/{language_id}/{impl.library_id}"
@@ -444,7 +477,7 @@ def _build_impl_html(spec, impl, code: str | None, image: str) -> str:
     }
     return _render_bot_html(
         title=f"{title_esc} - {lib_name_esc} | anyplot.ai",
-        description=desc_esc,
+        description=meta_desc_esc,
         image=image_esc,
         url=html.escape(page_url, quote=True),
         body=body,

--- a/tests/unit/api/test_seo_helpers.py
+++ b/tests/unit/api/test_seo_helpers.py
@@ -11,12 +11,14 @@ from unittest.mock import MagicMock
 
 from api.routers.seo import (
     _HOME_JSONLD,
+    _META_DESCRIPTION_LIMIT,
     _build_home_body,
     _build_impl_html,
     _build_sitemap_xml,
     _build_spec_hub_html,
     _jsonld_script,
     _lastmod,
+    _meta_description,
     _render_bot_html,
     _spec_index_entries,
     _spec_links_html,
@@ -420,3 +422,61 @@ class TestDisplayNameMaps:
         from api.routers.seo import _LIBRARY_NAMES
 
         assert set(_LIBRARY_NAMES) == {lib["id"] for lib in LIBRARIES_METADATA}
+
+
+class TestMetaDescription:
+    """Trimming spec descriptions down to what a search result will display."""
+
+    def test_short_text_is_untouched(self) -> None:
+        text = "A vertical bar chart for categorical data."
+        assert _meta_description(text) == text
+
+    def test_none_and_empty_are_empty(self) -> None:
+        assert _meta_description(None) == ""
+        assert _meta_description("   ") == ""
+
+    def test_whitespace_is_normalised(self) -> None:
+        assert _meta_description("two\n\n  words") == "two words"
+
+    def test_long_text_fits_the_snippet(self) -> None:
+        text = "word " * 200
+        result = _meta_description(text)
+        assert len(result) <= _META_DESCRIPTION_LIMIT + 1  # +1 for the ellipsis
+
+    def test_prefers_a_sentence_boundary_in_range(self) -> None:
+        """Ends on the last full sentence that still fits, not the first."""
+        first = "A vertical bar chart that displays categorical data with rectangular bars."
+        second = "Heights are proportional to values."
+        text = f"{first} {second} " + "Detail that runs well past the snippet limit. " * 5
+        result = _meta_description(text)
+        assert result == f"{first} {second}"
+        assert len(result) <= _META_DESCRIPTION_LIMIT
+
+    def test_single_overlong_sentence_is_not_kept_whole(self) -> None:
+        """A sentence end past the limit must not be selected."""
+        text = "One enormous clause " * 20 + "and then a stop."
+        result = _meta_description(text)
+        assert len(result) <= _META_DESCRIPTION_LIMIT + 1
+        assert result.endswith("\u2026")
+
+    def test_falls_back_to_a_word_boundary(self) -> None:
+        text = "word " * 200  # no sentence punctuation anywhere
+        result = _meta_description(text)
+        assert result.endswith("\u2026")
+        assert not result.rstrip("\u2026").endswith(" ")
+        # never splits a word
+        assert all(chunk == "word" for chunk in result.rstrip("\u2026").split())
+
+    def test_never_cuts_a_dangling_separator(self) -> None:
+        text = "alpha beta gamma, " * 40
+        result = _meta_description(text)
+        assert ",\u2026" not in result
+
+    def test_runs_before_escaping_so_entities_stay_intact(self) -> None:
+        """The trim operates on raw text; escaping afterwards can't be cut mid-entity."""
+        import html as html_module
+
+        text = "Ampersands & angle brackets <like this> " * 20
+        escaped = html_module.escape(_meta_description(text))
+        # A truncated entity would leave a bare & followed by a non-entity run
+        assert re.search(r"&(?!amp;|lt;|gt;|quot;|#x27;)", escaped) is None

--- a/tests/unit/api/test_seo_helpers.py
+++ b/tests/unit/api/test_seo_helpers.py
@@ -467,6 +467,14 @@ class TestMetaDescription:
         # never splits a word
         assert all(chunk == "word" for chunk in result.rstrip("\u2026").split())
 
+    def test_short_opening_sentence_does_not_win(self) -> None:
+        """A sentence ending before the halfway mark is not worth the whole slot."""
+        text = "A Smith chart. " + "It maps complex impedance onto a normalised polar grid " * 5
+        result = _meta_description(text)
+        assert result != "A Smith chart."
+        assert len(result) > _META_DESCRIPTION_LIMIT // 2
+        assert result.endswith("\u2026")
+
     def test_never_cuts_a_dangling_separator(self) -> None:
         text = "alpha beta gamma, " * 40
         result = _meta_description(text)


### PR DESCRIPTION
## Measured, before and after

Every prerendered page passed the full spec description into `<meta name="description">` and `og:description`. Across 40 live pages sampled with a Googlebot user agent:

| | min | median | max | over 160 |
|---|---:|---:|---:|---:|
| before | 264 | 424 | 801 | **40 / 40** |
| after | 82 | 142 | 156 | 0 / 40 |

Google truncates around 155 characters and rewrites what it cannot use, so the sentence meant to earn the click never reached a searcher. The 2026-05-05 audit recorded this against `api/routers/seo.py` and it has not moved since. With sitewide CTR at 0.64%, it is the cheapest lever on the list.

## What the trim produces

It ends on the **last full sentence that still fits**, falling back to a word boundary with an ellipsis, so a snippet is never left dangling mid-word or after a comma:

> **801 →** "A panoramic mountain silhouette chart that renders the horizon as seen from a fixed vantage point, like a photograph of a ridgeline against the sky." *(148)*

> **553 →** "A Smith chart is a specialized circular diagram used in RF engineering to display complex impedance and reflection coefficients on a normalized polar grid." *(155)*

## Two deliberate boundaries

**Body copy and JSON-LD keep the full description.** The trim is for the snippet, not the content — Google reads the body for relevance, and shortening it there would trade a CTR gain for a relevance loss.

**It runs on raw text, before `html.escape()`.** Trimming an already-escaped string can cut through an entity and emit a bare ampersand. A test asserts no truncated entity survives escaping.

## Verification

- `pytest tests/unit` — 1594 passed, 8 new helper tests
- `ruff check` + `ruff format --check` — clean
- Before/after table above produced by running the new helper over live production descriptions, not fixtures

## Known follow-up

All 15 implementation pages of a spec still share one description, which is a duplicate signal across 15 URLs. Fixing *that* needs a per-library description rather than a shorter one — the owner has proposed a dedicated short-description column in the DB, which would address length and duplication together. This PR is the safety net that works today for all 327 specs with no migration; it should stay as the fallback for specs where that column is null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)