### PR TITLE
feat(analytics): report page_not_found so dead URLs stop being invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Added
 
+- **Dead URLs are now visible in analytics** — a new `page_not_found` Plausible event fires when a
+  visitor reaches a URL the app cannot serve, carrying the requested `path` and a `source` that
+  separates the kinds of miss: `catch_all` (matches no route — usually a bad inbound link) from
+  `spec_missing` (the route resolved but the content is gone — the pattern a library migration
+  leaves behind), plus `language_params` and `route_error`. Instrumented once inside
+  `NotFoundPage.tsx`, which covers all four call sites, and read from `window.location` rather than
+  router context, because the same component is the fallback inside `RouteErrorBoundary` where that
+  context is what may have failed. The 161 stale highcharts URLs would have shown up here months
+  ago. Documented in `docs/reference/plausible.md` (#10453 covers the crawler-facing half; bots run
+  no JavaScript, so the two never overlap).
+
 - **Three new verification skills** — `/verify-migrations` runs the Alembic chain against a
   throwaway Postgres (Docker, or a rootless `pgserver` fallback; single-head check,
   `upgrade head`, `alembic check` drift, downgrade roundtrip) so the shared prod DB never sees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   leaves behind), plus `language_params` and `route_error`. Instrumented once inside
   `NotFoundPage.tsx`, which covers all four call sites, and read from `window.location` rather than
   router context, because the same component is the fallback inside `RouteErrorBoundary` where that
-  context is what may have failed. The 161 stale highcharts URLs would have shown up here months
-  ago. Documented in `docs/reference/plausible.md` (#10453 covers the crawler-facing half; bots run
-  no JavaScript, so the two never overlap).
+  context is what may have failed. A fifth source, `impl_missing`, is reported from `SpecPage.tsx`,
+  which redirects such visitors to the hub instead of rendering a 404 — without it the event would
+  have missed the exact case it was built for, since that silent redirect is what a library
+  migration produces. Documented in `docs/reference/plausible.md` (#10453 covers the crawler-facing
+  half; bots run no JavaScript, so the two never overlap).
 - **Search Console API access, documented and reproducible** — `docs/reference/seo.md` gains a
   "Search Console API access" section: the domain property (`sc-domain:anyplot.ai`), the
   Application Default Credentials login that carries the `webmasters.readonly` scope, a

--- a/app/src/components/RouteErrorBoundary.tsx
+++ b/app/src/components/RouteErrorBoundary.tsx
@@ -97,7 +97,7 @@ export function RouteErrorBoundary() {
   }, [shouldAttemptReload]);
 
   if (isRouteErrorResponse(error) && error.status === 404) {
-    return <NotFoundPage />;
+    return <NotFoundPage source="route_error" />;
   }
 
   if (shouldAttemptReload) {

--- a/app/src/pages/NotFoundPage.test.tsx
+++ b/app/src/pages/NotFoundPage.test.tsx
@@ -1,14 +1,27 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { NotFoundPage } from 'src/pages/NotFoundPage';
 import { render, screen } from 'src/test-utils';
+
+const mockTrackEvent = vi.fn();
 
 // Mock react-helmet-async to avoid provider requirement
 vi.mock('react-helmet-async', () => ({
   Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('src/hooks/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackPageview: vi.fn(),
+    trackEvent: mockTrackEvent,
+  }),
+}));
+
 describe('NotFoundPage', () => {
+  beforeEach(() => {
+    mockTrackEvent.mockClear();
+  });
+
   it('renders page.miss() heading', () => {
     render(<NotFoundPage />);
     expect(screen.getByRole('heading', { level: 1, name: /page not found/i })).toBeInTheDocument();
@@ -23,5 +36,35 @@ describe('NotFoundPage', () => {
     render(<NotFoundPage />);
     const link = screen.getByRole('link', { name: /go home/i });
     expect(link).toHaveAttribute('href', '/');
+  });
+});
+
+describe('NotFoundPage analytics', () => {
+  beforeEach(() => {
+    mockTrackEvent.mockClear();
+  });
+
+  it('reports the miss with the path that was requested', () => {
+    window.history.pushState({}, '', '/bar-basic/python/highcharts');
+    render(<NotFoundPage />);
+    expect(mockTrackEvent).toHaveBeenCalledWith('page_not_found', {
+      path: '/bar-basic/python/highcharts',
+      source: 'catch_all',
+    });
+  });
+
+  it('distinguishes a routed-but-missing spec from an unmatched URL', () => {
+    window.history.pushState({}, '', '/bar-basic/python/highcharts');
+    render(<NotFoundPage source="spec_missing" />);
+    expect(mockTrackEvent).toHaveBeenCalledWith('page_not_found', {
+      path: '/bar-basic/python/highcharts',
+      source: 'spec_missing',
+    });
+  });
+
+  it('fires once per mount, not once per render', () => {
+    const { rerender } = render(<NotFoundPage />);
+    rerender(<NotFoundPage />);
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/pages/NotFoundPage.tsx
+++ b/app/src/pages/NotFoundPage.tsx
@@ -11,8 +11,19 @@ import { paths } from 'src/routes/paths';
 import { colors, semanticColors, typography } from 'src/theme';
 
 /** Where the miss came from — a URL that matches no route is a different
- *  problem from one that routes fine but names content we no longer have. */
-export type NotFoundSource = 'catch_all' | 'spec_missing' | 'language_params' | 'route_error';
+ *  problem from one that routes fine but names content we no longer have.
+ *
+ *  `impl_missing` is the odd one out: it is reported from SpecPage, which
+ *  redirects the visitor to the hub rather than rendering this page, so the
+ *  event fires without a 404 ever being shown. It is still the same signal —
+ *  a URL naming content that no longer exists — and it is the case a library
+ *  migration actually produces, so it belongs in the same event. */
+export type NotFoundSource =
+  | 'catch_all'
+  | 'spec_missing'
+  | 'impl_missing'
+  | 'language_params'
+  | 'route_error';
 
 interface NotFoundPageProps {
   source?: NotFoundSource;

--- a/app/src/pages/NotFoundPage.tsx
+++ b/app/src/pages/NotFoundPage.tsx
@@ -19,11 +19,7 @@ import { colors, semanticColors, typography } from 'src/theme';
  *  a URL naming content that no longer exists — and it is the case a library
  *  migration actually produces, so it belongs in the same event. */
 export type NotFoundSource =
-  | 'catch_all'
-  | 'spec_missing'
-  | 'impl_missing'
-  | 'language_params'
-  | 'route_error';
+  'catch_all' | 'spec_missing' | 'impl_missing' | 'language_params' | 'route_error';
 
 interface NotFoundPageProps {
   source?: NotFoundSource;

--- a/app/src/pages/NotFoundPage.tsx
+++ b/app/src/pages/NotFoundPage.tsx
@@ -1,13 +1,34 @@
+import { useEffect } from 'react';
+
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 
+import { useAnalytics } from 'src/hooks/useAnalytics';
 import { paths } from 'src/routes/paths';
 import { colors, semanticColors, typography } from 'src/theme';
 
-export function NotFoundPage() {
+/** Where the miss came from — a URL that matches no route is a different
+ *  problem from one that routes fine but names content we no longer have. */
+export type NotFoundSource = 'catch_all' | 'spec_missing' | 'language_params' | 'route_error';
+
+interface NotFoundPageProps {
+  source?: NotFoundSource;
+}
+
+export function NotFoundPage({ source = 'catch_all' }: NotFoundPageProps = {}) {
+  const { trackEvent } = useAnalytics();
+
+  useEffect(() => {
+    // window.location rather than useLocation: this component is also the
+    // fallback inside RouteErrorBoundary, where router context is exactly the
+    // thing that may have failed, and an analytics call must never be the
+    // reason the 404 page itself cannot render.
+    trackEvent('page_not_found', { path: window.location.pathname, source });
+  }, [source, trackEvent]);
+
   return (
     <>
       <Helmet>

--- a/app/src/pages/SpecPage.test.tsx
+++ b/app/src/pages/SpecPage.test.tsx
@@ -22,11 +22,15 @@ vi.mock('react-helmet-async', () => ({
   Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// The real useAnalytics returns useCallback-stable functions. Rebuilding them
+// per render here would give every consumer a fresh identity, which turns any
+// effect that lists trackEvent as a dependency into an infinite render loop —
+// so the mock has to hold the same contract.
+const mockTrackEvent = vi.fn();
+const mockAnalytics = { trackPageview: vi.fn(), trackEvent: mockTrackEvent };
+
 vi.mock('src/hooks', () => ({
-  useAnalytics: () => ({
-    trackPageview: vi.fn(),
-    trackEvent: vi.fn(),
-  }),
+  useAnalytics: () => mockAnalytics,
   useAppData: () => ({
     librariesData: [
       { id: 'matplotlib', name: 'Matplotlib', language: 'python' },
@@ -103,6 +107,10 @@ function mockFetchError() {
 }
 
 describe('SpecPage', () => {
+  beforeEach(() => {
+    mockTrackEvent.mockClear();
+  });
+
   it('shows loading state initially', () => {
     // Never-resolving fetch keeps loading=true
     globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
@@ -164,6 +172,33 @@ describe('SpecPage', () => {
       expect(screen.getByTestId('spec-detail-view')).toBeInTheDocument();
     });
     expect(screen.queryByTestId('spec-overview')).not.toBeInTheDocument();
+  });
+
+  it('reports impl_missing when the URL names an implementation that is gone', async () => {
+    // The shape a library migration leaves behind: the spec exists, the
+    // library/language pair does not. The visitor is redirected to the hub
+    // rather than shown a 404, so this event is the only trace it leaves.
+    mockParams = { specId: 'scatter-basic', language: 'python', library: 'highcharts' };
+    mockFetchSuccess();
+    render(<SpecPage />);
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith('page_not_found', {
+        path: window.location.pathname,
+        source: 'impl_missing',
+      });
+    });
+  });
+
+  it('does not report a miss when the implementation exists', async () => {
+    mockParams = { specId: 'scatter-basic', language: 'python', library: 'matplotlib' };
+    mockFetchSuccess();
+    render(<SpecPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('spec-detail-view')).toBeInTheDocument();
+    });
+    expect(mockTrackEvent).not.toHaveBeenCalledWith('page_not_found', expect.anything());
   });
 
   it('renders description text', async () => {

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -107,6 +107,13 @@ export function SpecPage() {
             i => i.library_id === urlLibrary && i.language === urlLanguage
           );
           if (!matched) {
+            // The URL names an implementation that does not exist — the shape a
+            // library migration leaves behind. The visitor is redirected rather
+            // than shown a 404, so nothing else in the app would ever record it.
+            trackEvent('page_not_found', {
+              path: window.location.pathname,
+              source: 'impl_missing',
+            });
             navigate(
               {
                 pathname: specPath(specId!),
@@ -130,7 +137,7 @@ export function SpecPage() {
     };
 
     fetchSpec();
-  }, [specId, urlLanguage, urlLibrary, navigate]);
+  }, [specId, urlLanguage, urlLibrary, navigate, trackEvent]);
 
   // Implementations the carousel cycles through. In detail mode, this is what
   // `<LibraryPills>` walks via prev/next. ALL impls of the spec by default; if

--- a/app/src/pages/SpecPage.tsx
+++ b/app/src/pages/SpecPage.tsx
@@ -364,7 +364,7 @@ export function SpecPage() {
   }
 
   if (error === 'Spec not found' || (!error && !specData)) {
-    return <NotFoundPage />;
+    return <NotFoundPage source="spec_missing" />;
   }
   if (error) {
     return (

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -25,7 +25,7 @@ const lazySpec = () =>
 
 function SpecLanguageRedirect() {
   const { specId, language } = useParams();
-  if (!specId || !language) return <NotFoundPage />;
+  if (!specId || !language) return <NotFoundPage source="language_params" />;
   return (
     <Navigate
       to={{ pathname: specPath(specId), search: `?language=${encodeURIComponent(language)}` }}
@@ -97,7 +97,7 @@ const router = createBrowserRouter([
           { path: ':specId', lazy: lazySpec },
           { path: ':specId/:language', element: <SpecLanguageRedirect /> },
           { path: ':specId/:language/:library', lazy: lazySpec },
-          { path: '*', element: <NotFoundPage /> },
+          { path: '*', element: <NotFoundPage source="catch_all" /> },
         ],
       },
     ],

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -143,6 +143,18 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 | `feedback_opened` | `path` | FeedbackWidget.tsx | User clicks the floating feedback FAB and the quick mini-stack of 👍 / 👎 / 💬 appears (issue #5662). `path` is `window.location.pathname + search` at open time. |
 | `feedback_submitted` | `path`, `reaction`?, `has_contact`, `spec_id`?, `mode` | FeedbackWidget.tsx | User submits a feedback entry. `reaction` ∈ `thumbs_up`, `thumbs_down`, `bug`, `idea` (omitted if none selected). `mode` is `"quick"` for a one-tap 👍/👎 from the mini-stack, `"full"` for a submit from the detailed dialog. `has_contact` is `"true"`/`"false"` — the contact field is now a free-form name/email/handle, not strictly an email. `spec_id` is set when the current route resolves to a spec page. |
 
+### Diagnostics
+
+| Event | Properties | Source | Description |
+|-------|-----------|--------|-------------|
+| `page_not_found` | `path`, `source` | NotFoundPage.tsx | A visitor reached a URL the app cannot serve. `path` is `window.location.pathname` at mount. `source` says which kind of miss it was: `catch_all` (the URL matches no route at all), `spec_missing` (the route resolved but the spec or implementation does not exist), `language_params` (a `/{spec}/{language}` URL arrived without both segments), `route_error` (the router itself returned a 404 response). |
+
+Read `source` before `path`. A `catch_all` miss is usually a bad inbound link;
+a `spec_missing` miss is content that used to exist and no longer does, which is
+the pattern a library migration leaves behind. The bot-facing side of the same
+URLs answers HTTP 404 from `api/routers/seo.py`, but crawlers never run
+JavaScript, so nothing they do appears here — this event covers humans only.
+
 ### Landing page navigation (`nav_click`)
 
 A single event captures every clickable surface on the chrome and the new

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -147,13 +147,21 @@ https://anyplot.ai/{spec_id}/{language}/{library}/{category}/{value}/...
 
 | Event | Properties | Source | Description |
 |-------|-----------|--------|-------------|
-| `page_not_found` | `path`, `source` | NotFoundPage.tsx | A visitor reached a URL the app cannot serve. `path` is `window.location.pathname` at mount. `source` says which kind of miss it was: `catch_all` (the URL matches no route at all), `spec_missing` (the route resolved but the spec or implementation does not exist), `language_params` (a `/{spec}/{language}` URL arrived without both segments), `route_error` (the router itself returned a 404 response). |
+| `page_not_found` | `path`, `source` | NotFoundPage.tsx, SpecPage.tsx | A visitor reached a URL the app cannot serve. `path` is `window.location.pathname`. `source` says which kind of miss it was: `catch_all` (the URL matches no route at all), `spec_missing` (the spec itself does not exist), `impl_missing` (the spec exists but not that library/language pair), `language_params` (a `/{spec}/{language}` URL arrived without both segments), `route_error` (the router returned a 404 response). |
 
 Read `source` before `path`. A `catch_all` miss is usually a bad inbound link;
-a `spec_missing` miss is content that used to exist and no longer does, which is
-the pattern a library migration leaves behind. The bot-facing side of the same
-URLs answers HTTP 404 from `api/routers/seo.py`, but crawlers never run
-JavaScript, so nothing they do appears here — this event covers humans only.
+`impl_missing` is content that used to exist and no longer does, which is the
+pattern a library migration leaves behind and the one worth alerting on.
+
+One asymmetry to know about: `impl_missing` fires without a 404 page ever being
+shown. `SpecPage.tsx` redirects those visitors to the spec hub with a language
+filter, to preserve their intent — so the event is reported from there rather
+than from `NotFoundPage.tsx`. Every other source accompanies a rendered 404.
+
+The bot-facing side of the same URLs answers HTTP 404 from `api/routers/seo.py`,
+but crawlers never run JavaScript and `app/nginx.conf` short-circuits bot user
+agents with `return 202` on `/api/event`, so nothing they do appears here — this
+event covers humans only.
 
 ### Landing page navigation (`nav_click`)
 


### PR DESCRIPTION
## Why

The Plausible instrumentation covers 30-odd interactions — copies, downloads, filters, tab toggles, map clicks — but never recorded a **miss**. A visitor landing on a URL the app cannot serve produced no signal at all.

That gap has a concrete cost: 161 stale `/{spec}/python/highcharts` URLs survived the Python→JS migration (#8516) for months. They were only found by reading Search Console. Humans were hitting them the whole time, invisibly.

## The event

| Event | Properties | Source |
|---|---|---|
| `page_not_found` | `path`, `source` | `NotFoundPage.tsx` |

`source` separates the two cases worth telling apart:

- **`catch_all`** — the URL matches no route. Usually a bad inbound link.
- **`spec_missing`** — the route resolved fine, the content behind it is gone. This is what a library migration leaves behind, and it is the one worth alerting on.
- `language_params`, `route_error` — the remaining paths.

## Two implementation choices

**Instrumented inside `NotFoundPage`, not at its call sites.** There are four (`routes/index.tsx` ×2, `SpecPage.tsx`, `RouteErrorBoundary.tsx`); putting the effect in the component means no future call site can forget it, and each one just tags its origin.

**Path read from `window.location`, not `useLocation`.** This component is also the fallback inside `RouteErrorBoundary`, where router context is precisely the thing that may have failed. Analytics must never be the reason the 404 page itself cannot render.

## Interaction with the crawler-side work

#10453 makes the seo-proxy answer 404 for these same URLs. The two halves never overlap and cannot double-count: crawlers run no JavaScript, and `app/nginx.conf` already short-circuits bot user agents with `if ($is_bot) { return 202; }` on `/api/event` — the guard added after bots inflated visitor counts ~40% (audit 2026-07-08 High #7). Verified that guard is still in place rather than assumed.

## Verification

- `yarn test` — 612 passed across 68 files, including 3 new tests: the path/source payload, the routed-but-missing variant, and once-per-mount rather than once-per-render
- `yarn tsc --noEmit` — clean
- `yarn lint` — clean
- Documented in `docs/reference/plausible.md` under a new Diagnostics section, with guidance on reading `source` before `path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)