### PR TITLE
feat(analytics): record which assistants actually read the catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Added
 
+- **You can now see which assistants read the catalogue** — a `bot_fetch` event records every AI
+  and search agent that reads a page, with `assistant` (claude, chatgpt, gemini, mistral, …),
+  `path`, and a `kind` that separates the case worth knowing: `user_directed` means a person asked
+  their assistant to open the page and is a **reader**, against `index`, `search`, `inspection` and
+  `training`, which are machines with nobody waiting. Recorded against a **separate Plausible site**
+  (`bots.anyplot.ai`) rather than the main one, because every Plausible event creates a visitor and
+  mixing these in would re-introduce the ~40% inflation that audit 2026-07-08 removed. Classic
+  search crawlers are included on purpose: per-engine crawl frequency is otherwise only visible by
+  sampling Search Console one URL at a time, which is how a months-long recrawl gap went unnoticed.
+  Hooked in as a router dependency rather than per handler, so the next endpoint added cannot go
+  unrecorded.
+
 - **Dead URLs are now visible in analytics** — a new `page_not_found` Plausible event fires when a
   visitor reaches a URL the app cannot serve, carrying the requested `path` and a `source` that
   separates the kinds of miss: `catch_all` (matches no route — usually a bad inbound link) from

--- a/api/analytics.py
+++ b/api/analytics.py
@@ -19,6 +19,77 @@ logger = logging.getLogger(__name__)
 PLAUSIBLE_ENDPOINT = "https://plausible.io/api/event"
 DOMAIN = "anyplot.ai"
 
+# AI fetches go to a SEPARATE Plausible site. Every Plausible event creates a
+# visitor, so routing these into the main site would re-introduce exactly the
+# bot inflation that audit 2026-07-08 (High #7) removed — visitor counts were
+# ~40% too high and the trend lines unusable. A second site keeps the human
+# numbers clean while still answering "how often does an assistant read this".
+BOT_DOMAIN = "bots.anyplot.ai"
+
+# Which assistant, and on whose behalf. The distinction is the point: a
+# user-directed fetch means a person asked their assistant to open this page,
+# which is a reader; an index crawler is building a corpus with no one waiting.
+# Ordered most-specific first — matching is substring-based, and e.g.
+# "claude-user" must never be shadowed by a broader "claude" pattern.
+# Vendor taxonomy per each vendor's own crawler documentation.
+AI_AGENTS: tuple[tuple[str, str, str], ...] = (
+    # (user-agent substring, assistant, kind)
+    ("claude-user", "claude", "user_directed"),
+    ("claude-searchbot", "claude", "index"),
+    ("claudebot", "claude", "training"),
+    ("chatgpt-user", "chatgpt", "user_directed"),
+    ("oai-searchbot", "chatgpt", "index"),
+    ("gptbot", "chatgpt", "training"),
+    ("perplexity-user", "perplexity", "user_directed"),
+    ("perplexitybot", "perplexity", "index"),
+    ("gemini-deep-research", "gemini", "user_directed"),
+    ("gemininotebook", "gemini", "user_directed"),
+    ("notebooklm", "gemini", "user_directed"),
+    ("google-agent", "gemini", "user_directed"),
+    ("googleagent", "gemini", "user_directed"),
+    ("mistralai-user", "mistral", "user_directed"),
+    ("mistralai-index", "mistral", "index"),
+    ("meta-externalfetcher", "meta", "user_directed"),
+    ("meta-webindexer", "meta", "index"),
+    ("duckassistbot", "duckduckgo", "user_directed"),
+    ("amzn-user", "amazon", "user_directed"),
+    ("amzn-searchbot", "amazon", "index"),
+    ("grok-deepsearch", "grok", "user_directed"),
+    ("grokbot", "grok", "user_directed"),
+    ("xai-grok", "grok", "user_directed"),
+    ("youbot", "you", "index"),
+    ("cohere-ai", "cohere", "user_directed"),
+    # Classic search crawlers. Worth recording for the same reason the AI ones
+    # are: crawl frequency per engine is otherwise only visible by sampling
+    # Search Console's URL inspection one URL at a time, which is how the
+    # months-long recrawl gap after the June 2026 outage stayed invisible.
+    ("google-inspectiontool", "google", "inspection"),
+    ("googleother", "google", "search"),
+    ("googlebot", "google", "search"),
+    ("bingbot", "bing", "search"),
+    ("duckduckbot", "duckduckgo", "search"),
+    ("yandexbot", "yandex", "search"),
+    ("baiduspider", "baidu", "search"),
+    # Last among the Apple patterns: "applebot" is a substring of
+    # "applebot-extended", which is a robots.txt token rather than a real UA —
+    # but ordering it here keeps the match correct if that ever changes.
+    ("applebot", "apple", "search"),
+)
+
+
+def detect_ai_agent(user_agent: str) -> tuple[str, str] | None:
+    """Return (assistant, kind) for a known AI or search agent, else None.
+
+    Matching is substring-based on the lowercased UA, first match wins, so
+    AI_AGENTS is ordered most-specific first.
+    """
+    ua = user_agent.lower()
+    for pattern, assistant, kind in AI_AGENTS:
+        if pattern in ua:
+            return assistant, kind
+    return None
+
+
 # Hold strong references to in-flight fire-and-forget tasks.
 # asyncio only weak-references tasks, so without this set the GC can collect
 # them mid-flight and silently drop analytics events.
@@ -108,7 +179,9 @@ def detect_platform(user_agent: str) -> str:
     return "unknown"
 
 
-async def _send_plausible_event(user_agent: str, client_ip: str, name: str, url: str, props: dict) -> None:
+async def _send_plausible_event(
+    user_agent: str, client_ip: str, name: str, url: str, props: dict, domain: str = DOMAIN
+) -> None:
     """Internal: Send event to Plausible (called as background task).
 
     Args:
@@ -117,13 +190,15 @@ async def _send_plausible_event(user_agent: str, client_ip: str, name: str, url:
         name: Event name
         url: Page URL
         props: Event properties
+        domain: Plausible site to record against; BOT_DOMAIN keeps AI traffic
+            out of the human numbers
     """
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             await client.post(
                 PLAUSIBLE_ENDPOINT,
                 headers={"User-Agent": user_agent, "X-Forwarded-For": client_ip, "Content-Type": "application/json"},
-                json={"name": name, "url": url, "domain": DOMAIN, "props": props},
+                json={"name": name, "url": url, "domain": domain, "props": props},
             )
     except Exception as e:
         # warning (not debug) so prod outages of the Plausible pipeline are
@@ -198,6 +273,39 @@ def track_og_image(
     # Fire-and-forget: create task without awaiting, but add exception handler.
     # Track via _BACKGROUND_TASKS so the GC cannot collect the task before it runs.
     task = asyncio.create_task(_send_plausible_event(user_agent, client_ip, "og_image_view", url, props))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    task.add_done_callback(_handle_task_exception)
+
+
+def track_bot_fetch(request: Request, path: str) -> None:
+    """Record an AI or search agent reading a page (fire-and-forget).
+
+    Recorded against BOT_DOMAIN, never the main site: every Plausible event
+    creates a visitor, and mixing these in is what made the human numbers
+    unusable before audit 2026-07-08.
+
+    Non-agent traffic is ignored, so humans and unclassified bots cost nothing
+    beyond a substring scan. The `kind` prop is the one that answers the
+    question worth asking — `user_directed` means a person asked their
+    assistant to open this page, which is a reader; `search`, `index` and
+    `training` are machines building a corpus with nobody waiting.
+
+    Args:
+        request: FastAPI request, for the UA and forwarded IP
+        path: Public path being read, e.g. "/box-basic/python/matplotlib"
+    """
+    user_agent = request.headers.get("user-agent", "")
+    detected = detect_ai_agent(user_agent)
+    if detected is None:
+        return
+    assistant, kind = detected
+
+    client_ip = request.headers.get("x-forwarded-for", request.client.host if request.client else "")
+    props = {"assistant": assistant, "kind": kind, "path": path}
+    url = f"https://anyplot.ai{path}"
+
+    task = asyncio.create_task(_send_plausible_event(user_agent, client_ip, "bot_fetch", url, props, domain=BOT_DOMAIN))
     _BACKGROUND_TASKS.add(task)
     task.add_done_callback(_BACKGROUND_TASKS.discard)
     task.add_done_callback(_handle_task_exception)

--- a/api/analytics.py
+++ b/api/analytics.py
@@ -13,6 +13,8 @@ import re
 import httpx
 from fastapi import Request
 
+from api.request_context import client_ip as resolve_client_ip
+
 
 logger = logging.getLogger(__name__)
 
@@ -239,7 +241,7 @@ def track_og_image(
         filters: Query params for filtered home page (e.g., {'lib': 'plotly', 'dom': 'statistics'})
     """
     user_agent = request.headers.get("user-agent", "")
-    client_ip = request.headers.get("x-forwarded-for", request.client.host if request.client else "")
+    client_ip = resolve_client_ip(request)
     platform = detect_platform(user_agent)
 
     # Build URL based on page type. Spec routes follow /{spec}/{language}/{library}.
@@ -301,7 +303,13 @@ def track_bot_fetch(request: Request, path: str) -> None:
         return
     assistant, kind = detected
 
-    client_ip = request.headers.get("x-forwarded-for", request.client.host if request.client else "")
+    # Resolve through the shared helper rather than reading the raw header:
+    # x-forwarded-for is a comma-separated chain once more than one proxy has
+    # appended to it, so the raw value is neither a valid single IP for
+    # Plausible nor the right one for geolocation. The helper also prefers
+    # cf-connecting-ip and takes the rightmost entry, which is the one a
+    # client cannot forge.
+    client_ip = resolve_client_ip(request)
     props = {"assistant": assistant, "kind": kind, "path": path}
     url = f"https://anyplot.ai{path}"
 

--- a/api/request_context.py
+++ b/api/request_context.py
@@ -1,0 +1,32 @@
+"""Request-scoped helpers shared across routers."""
+
+from fastapi import Request
+
+
+def client_ip(request: Request) -> str:
+    """Resolve the client IP for rate-limit / dup-suppression keying.
+
+    Trust order (client → Cloudflare → Cloud Run):
+    1. `cf-connecting-ip` — Cloudflare overwrites any client-supplied value on
+       proxied traffic, so browsers on anyplot.ai cannot spoof it.
+    2. Rightmost non-empty `x-forwarded-for` entry — appended by the trusted
+       infrastructure hop. The *leftmost* entry (used here previously) is
+       client-controlled: spoofing it evaded the rate limit and allowed
+       poisoning another user's bucket to lock them out. Empty entries from
+       malformed headers ("1.2.3.4, ") are skipped so a caller can't force
+       everyone into one shared empty-string bucket.
+    3. `request.client.host` as the last resort.
+
+    A caller bypassing Cloudflare via the run.app URL can still forge
+    `cf-connecting-ip`, but that only scatters its *own* submissions across
+    buckets — no better than rotating source IPs, and it can no longer
+    impersonate a victim's bucket.
+    """
+    cf_ip = request.headers.get("cf-connecting-ip", "").strip()
+    if cf_ip:
+        return cf_ip
+    forwarded = request.headers.get("x-forwarded-for", "")
+    for entry in reversed(forwarded.split(",")):
+        if entry.strip():
+            return entry.strip()
+    return request.client.host if request.client else ""

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.dependencies import require_db
 from api.exceptions import raise_validation_error
+from api.request_context import client_ip as _client_ip
 from api.schemas import FeedbackRequest, FeedbackResponse
 from core.database import FEEDBACK_REACTIONS, FeedbackRepository
 
@@ -35,35 +36,6 @@ RATE_LIMIT_MAX = 5
 _URL_RE = re.compile(r"https?://", re.IGNORECASE)
 MAX_URLS_IN_MESSAGE = 1  # 2+ links treated as link-stuffing SEO spam
 DUPLICATE_LOOKBACK = timedelta(minutes=10)
-
-
-def _client_ip(request: Request) -> str:
-    """Resolve the client IP for rate-limit / dup-suppression keying.
-
-    Trust order (client → Cloudflare → Cloud Run):
-    1. `cf-connecting-ip` — Cloudflare overwrites any client-supplied value on
-       proxied traffic, so browsers on anyplot.ai cannot spoof it.
-    2. Rightmost non-empty `x-forwarded-for` entry — appended by the trusted
-       infrastructure hop. The *leftmost* entry (used here previously) is
-       client-controlled: spoofing it evaded the rate limit and allowed
-       poisoning another user's bucket to lock them out. Empty entries from
-       malformed headers ("1.2.3.4, ") are skipped so a caller can't force
-       everyone into one shared empty-string bucket.
-    3. `request.client.host` as the last resort.
-
-    A caller bypassing Cloudflare via the run.app URL can still forge
-    `cf-connecting-ip`, but that only scatters its *own* submissions across
-    buckets — no better than rotating source IPs, and it can no longer
-    impersonate a victim's bucket.
-    """
-    cf_ip = request.headers.get("cf-connecting-ip", "").strip()
-    if cf_ip:
-        return cf_ip
-    forwarded = request.headers.get("x-forwarded-for", "")
-    for entry in reversed(forwarded.split(",")):
-        if entry.strip():
-            return entry.strip()
-    return request.client.host if request.client else ""
 
 
 def _hash_ip(ip: str) -> str:

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.analytics import track_bot_fetch
 from api.cache import cache_key, get_cache, get_or_set_cache, set_cache
 from api.dependencies import optional_db
 from core.config import settings
@@ -19,7 +20,21 @@ from core.database.connection import get_db_context
 from core.utils import strip_noqa_comments
 
 
-router = APIRouter(tags=["seo"])
+async def _record_bot_fetch(request: Request) -> None:
+    """Router dependency: record which agent read which page.
+
+    Attached to the router rather than to each handler — there are a dozen and
+    the next one added would silently go unrecorded. Only /seo-proxy paths are
+    page reads; robots.txt and sitemap.xml also live on this router and are not.
+    """
+    path = request.url.path
+    if not path.startswith("/seo-proxy"):
+        return
+    # Report the public URL, not this router's internal prefix
+    track_bot_fetch(request, path.removeprefix("/seo-proxy") or "/")
+
+
+router = APIRouter(tags=["seo"], dependencies=[Depends(_record_bot_fetch)])
 
 # Canonical spec-id shape — lowercase alphanumerics with hyphen separators.
 # Same pattern enforced in automation/scripts/sync_to_postgres.py. Used here to

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -228,6 +228,47 @@ CWV tracking is production-only and dynamically imported (zero dev/bundle cost).
 
 ---
 
+## AI and crawler traffic (separate site)
+
+Agent traffic is recorded against a **second Plausible site, `bots.anyplot.ai`**,
+never the main one. Every Plausible event creates a visitor, so routing these
+into `anyplot.ai` would re-introduce the inflation that audit 2026-07-08
+(High #7) removed — visitor counts ran ~40% high and the trend lines were
+unusable. The bot site has no tracking script installed and never will: its
+events arrive server-side through the Events API, which is why it shows
+"Setup pending" in the Plausible UI. That is expected, not a broken install.
+
+| Event | Properties | Source | Description |
+|-------|-----------|--------|-------------|
+| `bot_fetch` | `assistant`, `kind`, `path` | `api/routers/seo.py` (router dependency) | An AI assistant or search crawler read a catalogue page. Recorded on `bots.anyplot.ai`. |
+
+`kind` is the property worth filtering on:
+
+| `kind` | Meaning |
+|--------|---------|
+| `user_directed` | A person asked their assistant to open this page. This is a **reader** |
+| `index` | An assistant's search index is building a corpus; no one is waiting |
+| `search` | A classic search crawler (Googlebot, bingbot, …) |
+| `inspection` | Search Console's URL inspection tool |
+| `training` | A training-corpus crawler |
+
+`assistant` carries the vendor (`claude`, `chatgpt`, `gemini`, `mistral`,
+`perplexity`, `meta`, `amazon`, `duckduckgo`, `grok`, `google`, `bing`, …).
+The taxonomy lives in `AI_AGENTS` in `api/analytics.py`, ordered most-specific
+first because matching is substring-based: `claude-user`, `claude-searchbot`
+and `claudebot` mean three different things and a broader `claude` pattern
+would collapse them.
+
+Search crawlers are included deliberately. Crawl frequency per engine is
+otherwise only visible by sampling Search Console's URL inspection one URL at a
+time — which is how a months-long recrawl gap after the June 2026 outage went
+unnoticed until someone went looking.
+
+Only `/seo-proxy/*` paths count as page reads; `robots.txt` and `sitemap.xml`
+live on the same router and are machine files, not catalogue pages. The
+reported `path` is always the public URL, never the internal `/seo-proxy`
+prefix.
+
 ## Server-side og:image tracking
 
 Social media bots (Twitter, WhatsApp, Teams, etc.) don't execute JavaScript, so og:image requests can only be tracked server-side.

--- a/docs/reference/plausible.md
+++ b/docs/reference/plausible.md
@@ -242,6 +242,17 @@ events arrive server-side through the Events API, which is why it shows
 |-------|-----------|--------|-------------|
 | `bot_fetch` | `assistant`, `kind`, `path` | `api/routers/seo.py` (router dependency) | An AI assistant or search crawler read a catalogue page. Recorded on `bots.anyplot.ai`. |
 
+Register the three properties on the **`bots.anyplot.ai`** site, not on
+`anyplot.ai` — property registration is per site, and without it the events
+still arrive but cannot be broken down, which is the whole point of collecting
+them:
+
+| Property | Description | Used by |
+|----------|-------------|---------|
+| `assistant` | Vendor (`claude`, `chatgpt`, `gemini`, `mistral`, `perplexity`, `meta`, `amazon`, `duckduckgo`, `grok`, `google`, `bing`, …) | `bot_fetch` |
+| `kind` | Why it fetched — see the table below | `bot_fetch` |
+| `path` | Public path that was read, e.g. `/box-basic/python/matplotlib` | `bot_fetch` |
+
 `kind` is the property worth filtering on:
 
 | `kind` | Meaning |

--- a/tests/unit/api/test_analytics.py
+++ b/tests/unit/api/test_analytics.py
@@ -1,10 +1,19 @@
 """Tests for server-side Plausible analytics tracking."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.analytics import PLATFORM_PATTERNS, _detect_whatsapp_variant, detect_platform, track_og_image
+from api.analytics import (
+    BOT_DOMAIN,
+    PLATFORM_PATTERNS,
+    _detect_whatsapp_variant,
+    detect_ai_agent,
+    detect_platform,
+    track_bot_fetch,
+    track_og_image,
+)
 
 
 class TestDetectPlatform:
@@ -298,3 +307,104 @@ class TestSendPlausibleEvent:
                 url="https://anyplot.ai/",
                 props={},
             )
+
+
+class TestDetectAiAgent:
+    """Which assistant, and on whose behalf."""
+
+    @pytest.mark.parametrize(
+        ("user_agent", "expected"),
+        [
+            # The three Anthropic agents differ only by suffix and mean very
+            # different things — a broader "claude" pattern would collapse them.
+            ("Mozilla/5.0 (compatible; Claude-User/1.0)", ("claude", "user_directed")),
+            ("Mozilla/5.0 (compatible; Claude-SearchBot/1.0)", ("claude", "index")),
+            ("Mozilla/5.0 (compatible; ClaudeBot/1.0)", ("claude", "training")),
+            ("Mozilla/5.0 (compatible; ChatGPT-User/1.0)", ("chatgpt", "user_directed")),
+            ("Mozilla/5.0 (compatible; OAI-SearchBot/1.4)", ("chatgpt", "index")),
+            ("Mozilla/5.0 (compatible; GPTBot/1.4)", ("chatgpt", "training")),
+            ("MistralAI-User/1.0", ("mistral", "user_directed")),
+            ("MistralAI-Index/1.0", ("mistral", "index")),
+            ("Mozilla/5.0 (compatible; Amzn-User/1.0)", ("amazon", "user_directed")),
+            ("Mozilla/5.0 (compatible; Amzn-SearchBot/1.0)", ("amazon", "index")),
+            ("meta-externalfetcher/1.1", ("meta", "user_directed")),
+            ("Mozilla/5.0 (compatible; Meta-WebIndexer/1.0)", ("meta", "index")),
+            # DuckDuckGo's assistant and its search crawler are separate agents
+            ("DuckAssistBot/1.2", ("duckduckgo", "user_directed")),
+            ("Mozilla/5.0 (compatible; DuckDuckBot/1.1)", ("duckduckgo", "search")),
+            # Gemini fetchers embed a full browser UA and identify by suffix
+            ("Mozilla/5.0 (X11) Chrome/126.0 Safari/537.36 Google-GeminiNotebook", ("gemini", "user_directed")),
+            ("Mozilla/5.0 (compatible; Gemini-Deep-Research)", ("gemini", "user_directed")),
+            ("Mozilla/5.0 (compatible; Googlebot/2.1)", ("google", "search")),
+            ("Mozilla/5.0 (compatible; Google-InspectionTool/1.0)", ("google", "inspection")),
+            ("Mozilla/5.0 (compatible; bingbot/2.0)", ("bing", "search")),
+        ],
+    )
+    def test_classifies(self, user_agent: str, expected: tuple[str, str]) -> None:
+        assert detect_ai_agent(user_agent) == expected
+
+    @pytest.mark.parametrize(
+        "user_agent",
+        [
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/126.0 Safari/537.36",
+            "Twitterbot/1.0",
+            "Slackbot-LinkExpanding 1.0",
+            "",
+        ],
+    )
+    def test_ignores_humans_and_non_ai_bots(self, user_agent: str) -> None:
+        """Link-preview and social bots are not agents reading the catalogue."""
+        assert detect_ai_agent(user_agent) is None
+
+
+class TestTrackBotFetch:
+    """Recording an agent reading a page."""
+
+    @staticmethod
+    def _request(user_agent: str) -> MagicMock:
+        request = MagicMock()
+        request.headers = {"user-agent": user_agent}
+        request.client.host = "203.0.113.7"
+        return request
+
+    @pytest.mark.asyncio
+    async def test_records_against_the_bot_site_not_the_main_one(self) -> None:
+        """Mixing these into anyplot.ai is what broke the human numbers before."""
+        with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            track_bot_fetch(self._request("Mozilla/5.0 (compatible; Claude-User/1.0)"), "/box-basic")
+            await asyncio.sleep(0)  # let the fire-and-forget task run
+
+            assert mock_client.post.call_args[1]["json"]["domain"] == BOT_DOMAIN
+
+    @pytest.mark.asyncio
+    async def test_carries_assistant_kind_and_public_path(self) -> None:
+        with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            track_bot_fetch(self._request("MistralAI-User/1.0"), "/box-basic/python/matplotlib")
+            await asyncio.sleep(0)
+
+            payload = mock_client.post.call_args[1]["json"]
+            assert payload["name"] == "bot_fetch"
+            # the public URL, never this router's /seo-proxy prefix
+            assert payload["url"] == "https://anyplot.ai/box-basic/python/matplotlib"
+            assert payload["props"] == {
+                "assistant": "mistral",
+                "kind": "user_directed",
+                "path": "/box-basic/python/matplotlib",
+            }
+
+    @pytest.mark.asyncio
+    async def test_sends_nothing_for_a_human(self) -> None:
+        with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            track_bot_fetch(self._request("Mozilla/5.0 (X11; Linux) Chrome/126.0 Safari/537.36"), "/")
+            await asyncio.sleep(0)
+
+            mock_client.post.assert_not_called()

--- a/tests/unit/api/test_analytics.py
+++ b/tests/unit/api/test_analytics.py
@@ -399,6 +399,30 @@ class TestTrackBotFetch:
             }
 
     @pytest.mark.asyncio
+    async def test_resolves_a_forwarded_for_chain_to_one_address(self) -> None:
+        """Multiple proxies append to XFF, so the raw header is not an IP.
+
+        Plausible needs a single address for geolocation, and the rightmost
+        entry is the one a client cannot forge — the same rule the feedback
+        rate limiter uses, which is why both now share one resolver.
+        """
+        request = MagicMock()
+        request.headers = {
+            "user-agent": "Mozilla/5.0 (compatible; Claude-User/1.0)",
+            "x-forwarded-for": "203.0.113.7, 198.51.100.2, 10.0.0.9",
+        }
+        request.client.host = "127.0.0.1"
+
+        with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            track_bot_fetch(request, "/box-basic")
+            await asyncio.sleep(0)
+
+            assert mock_client.post.call_args[1]["headers"]["X-Forwarded-For"] == "10.0.0.9"
+
+    @pytest.mark.asyncio
     async def test_sends_nothing_for_a_human(self) -> None:
         with patch("api.analytics.httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -697,6 +697,25 @@ class TestSeoProxyRouter:
             assert "1 plot specifications" in response.text
             assert "hundreds of" not in response.text
 
+    def test_seo_proxy_records_the_agent_that_read_the_page(self, client: TestClient) -> None:
+        """The router dependency reports the PUBLIC path, not its own prefix."""
+        with patch(DB_CONFIG_PATCH, return_value=False), patch("api.routers.seo.track_bot_fetch") as track:
+            client.get("/seo-proxy/bar-basic", headers={"User-Agent": "Mozilla/5.0 (compatible; Claude-User/1.0)"})
+        track.assert_called_once()
+        assert track.call_args.args[1] == "/bar-basic"
+
+    def test_seo_proxy_home_records_root(self, client: TestClient) -> None:
+        with patch(DB_CONFIG_PATCH, return_value=False), patch("api.routers.seo.track_bot_fetch") as track:
+            client.get("/seo-proxy/", headers={"User-Agent": "Mozilla/5.0 (compatible; Claude-User/1.0)"})
+        assert track.call_args.args[1] == "/"
+
+    def test_robots_and_sitemap_are_not_page_reads(self, client: TestClient) -> None:
+        """Both live on this router but are machine files, not catalogue pages."""
+        with patch("api.routers.seo.track_bot_fetch") as track:
+            client.get("/robots.txt", headers={"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)"})
+            client.get("/sitemap.xml", headers={"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)"})
+        track.assert_not_called()
+
     def test_seo_home_canonical_ignores_filter_params(self, client: TestClient) -> None:
         """Filter params must not produce a self-canonicalising copy of the home page.
 

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -705,8 +705,10 @@ class TestSeoProxyRouter:
         assert track.call_args.args[1] == "/bar-basic"
 
     def test_seo_proxy_home_records_root(self, client: TestClient) -> None:
+        """The proxy root maps to "/", and the hook fires exactly once per request."""
         with patch(DB_CONFIG_PATCH, return_value=False), patch("api.routers.seo.track_bot_fetch") as track:
             client.get("/seo-proxy/", headers={"User-Agent": "Mozilla/5.0 (compatible; Claude-User/1.0)"})
+        track.assert_called_once()
         assert track.call_args.args[1] == "/"
 
     def test_robots_and_sitemap_are_not_page_reads(self, client: TestClient) -> None:


### PR DESCRIPTION
## The gap

Plausible knew about 30-odd human interactions and nothing about the machines. Two specific holes:

1. **The platform table has no AI in it.** The 27 patterns in `api/analytics.py` cover social, messaging, search and link-preview services — `claude`, `chatgpt`, `perplexity`, `gemini` and `mistral` appear **zero** times. Even an og:image fetch by Claude was recorded as unknown.
2. **Page reads were never tracked**, only image fetches. The seo-proxy sees every agent server-side and reported none of them.

The mechanism itself was proven: server-side events with a bot user agent do land — `og_image_view` is visible in the dashboard under Goals.

## The event

| Event | Properties | Site |
|---|---|---|
| `bot_fetch` | `assistant`, `kind`, `path` | **`bots.anyplot.ai`** |

`kind` is the property that carries the meaning:

| `kind` | Meaning |
|---|---|
| `user_directed` | a person asked their assistant to open this page — a **reader** |
| `index` | an assistant's search index building a corpus; nobody waiting |
| `search` | classic crawler (Googlebot, bingbot, …) |
| `inspection` | Search Console URL inspection |
| `training` | training-corpus crawler |

## Why a separate Plausible site

Every Plausible event creates a visitor. Sending these to `anyplot.ai` would re-introduce exactly what audit 2026-07-08 (High #7) removed — bot traffic ran visitor counts ~40% high and made the trend lines unusable, which is why `app/nginx.conf` answers bot UAs with `202` on `/api/event`.

The bot site has no tracking script and never will; it is fed only by the Events API, so its "Setup pending" state in the Plausible UI is expected rather than a broken install. Documented so nobody "fixes" it later.

## Why search crawlers are included

Per-engine crawl frequency is otherwise visible only by sampling Search Console's URL inspection one URL at a time. That is precisely how a months-long recrawl gap after the June outage stayed invisible until someone went looking — 823 URLs sat in a `Server error (5xx)` state whose median last crawl predated the fix that resolved it.

## Two implementation choices

**Ordered, substring-based taxonomy.** `claude-user`, `claude-searchbot` and `claudebot` mean three genuinely different things and a broader `claude` pattern would collapse them into one number. Tests pin all three, plus the `DuckAssistBot`/`DuckDuckBot` and `Amzn-User`/`Amzn-SearchBot` pairs that fail the same way, and assert that a real browser and Twitterbot classify as nothing at all.

**A router dependency, not a call per handler.** There are a dozen handlers on this router; the next one added would otherwise be silently unrecorded. `robots.txt` and `sitemap.xml` share the router and are excluded — machine files, not catalogue pages — and the reported `path` is always the public URL, never the internal `/seo-proxy` prefix. A test covers each.

## Verification

- `pytest tests/unit` — 1628 passed
- `ruff check` + `ruff format --check` — clean
- `mypy api/analytics.py api/routers/seo.py` — no issues
- The classifier was run against 17 real user-agent strings before any test was written

## Known, not addressed here

`og_image_view` still reports to the **main** site, so bot image fetches already count as visitors there today — pre-existing, and moving it would break the continuity of that goal's history. Worth a decision separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)