### PR TITLE
fix(seo): stop a trailing slash from leaking the internal proxy URL

### DIFF
--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -102,6 +102,18 @@ jobs:
           check "$GOOGLEBOT"   "$ORIGIN/llms.txt" "# anyplot"
           check "$CHATGPTUSER" "$ORIGIN/llms.txt" "# anyplot"
 
+          # A trailing slash must normalise to the canonical URL on THIS host.
+          # It used to 307 to http://api.anyplot.ai/seo-proxy/... — internal
+          # path, wrong host, plain http, and that host disallows all crawling.
+          slash_target=$(curl -sS --max-time 30 -o /dev/null -A "$GOOGLEBOT" \
+            -w '%{redirect_url}' "$ORIGIN/scatter-basic/")
+          case "$slash_target" in
+            *"/seo-proxy"*|http://*)
+              echo "::error::trailing-slash redirect leaks or downgrades: $slash_target"
+              fail=1 ;;
+            *) echo "OK: trailing slash -> $slash_target" ;;
+          esac
+
           # Control: humans must still get the SPA shell
           check "$HUMAN" "$ORIGIN/" '<div id="root">'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **A trailing slash sent crawlers to a crawl-blocked URL** — `/box-basic/` answered `307` to
+  `http://api.anyplot.ai/seo-proxy/box-basic`: the internal proxy path, on the API host, over plain
+  http, and that host's `robots.txt` disallows everything. FastAPI's `redirect_slashes` built the
+  Location from the *proxied* request, and `@seo_proxy` set no `X-Forwarded-Proto`, so the scheme
+  came out wrong too. Humans never saw it — only bots take the proxy path — and every inbound link
+  written with a trailing slash, which is common, dead-ended there; some of the 48 Search Console
+  "Redirect error" URLs came from this. nginx now normalises the trailing slash to the canonical URL
+  before any routing, the proxy declares the scheme, and `bot-serving-check` fails if a
+  trailing-slash redirect ever again points at `/seo-proxy` or downgrades to http.
+
 - **AI assistants asked about a plot page saw nothing** — seven user-directed fetchers (eight UA
   patterns; NotebookLM and Mariner each answer to two) were absent from the `$is_bot` map in
   `app/nginx.conf` and received the empty SPA shell instead of the prerendered page: `Google-GeminiNotebook`, `Google-NotebookLM`, `Gemini-Deep-Research`,

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -163,6 +163,20 @@ server {
         include /etc/nginx/security-headers.conf;
     }
 
+    # Trailing slashes are not canonical: /box-basic/ and /box-basic are the
+    # same page, and only the second appears in the sitemap and in the page's
+    # own canonical tag. Left alone, a crawler asking for the slashed form is
+    # proxied to the seo-proxy, matches no route there, and FastAPI's
+    # redirect_slashes answers with an absolute URL rebuilt from the PROXIED
+    # request — leaking the internal host and path as
+    # http://api.anyplot.ai/seo-proxy/box-basic, over plain http, to a host
+    # whose robots.txt disallows everything. Verified live 2026-08-18: a
+    # three-hop chain ending on a crawl-blocked URL, which is how some of the
+    # 48 "Redirect error" URLs in Search Console got there.
+    #
+    # `/` itself cannot match: after `^/` there is nothing left for `/$`.
+    rewrite ^/(.*)/$ /$1 permanent;
+
     # Disable caching for index.html
     location = /index.html {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
@@ -176,6 +190,10 @@ server {
         set $seo_backend https://api.anyplot.ai;
         proxy_pass $seo_backend/seo-proxy$request_uri;
         proxy_set_header Host api.anyplot.ai;
+        # Without this the upstream sees a plain-http request and any redirect
+        # it generates is emitted as http://, downgrading the crawler's next
+        # hop. The other proxied locations already set it.
+        proxy_set_header X-Forwarded-Proto https;
         proxy_ssl_server_name on;
         proxy_ssl_verify on;
         # api.anyplot.ai serves a 4-deep Let's Encrypt chain (leaf -> YE1 ->


### PR DESCRIPTION
## Reproduce

```
$ curl -A Googlebot -sSI https://anyplot.ai/box-basic/ | grep -i '^http\|^location'
HTTP/2 307
location: http://api.anyplot.ai/seo-proxy/box-basic

$ curl https://api.anyplot.ai/robots.txt
User-agent: *
Disallow: /
```

The Location is the **internal proxy path**, on the **API host**, over **plain http** — and that host disallows all crawling, so the terminal URL is crawl-blocked. Three things wrong in one header.

A normal user agent gets a clean SPA response on the same URL. Only bots take the proxy path, so nothing anyone clicks reveals it.

## Mechanism

`@seo_proxy` forwards to `$seo_backend/seo-proxy$request_uri`, trailing slash included. That matches no route upstream, so FastAPI's `redirect_slashes` generates one — building the Location from the request it actually received, which is the **proxied** one. And `@seo_proxy` set no `X-Forwarded-Proto`, so the upstream believed it was serving plain http.

This is the same defect class as #10455 arriving by a different route, and plausibly accounts for the remainder of the 48 Search Console **Redirect error** URLs that PR did not explain. Trailing slashes are common in inbound links; every one of them dead-ended.

## Fix

Normalise at the edge, so the app never gets the chance to generate the redirect:

```nginx
rewrite ^/(.*)/$ /$1 permanent;
```

`/` itself cannot match — after `^/` there is nothing left for `/$`. Verified across `/`, `/box-basic`, `/box-basic/`, `/box-basic/python/matplotlib/`, `/plots/`, `/llms.txt`.

`X-Forwarded-Proto https` is set on the proxy regardless: a proxied app should not have to guess its own scheme, and the other proxied locations in this file already set it.

## Regression cover

`bot-serving-check` now fails if a trailing-slash redirect ever again points into `/seo-proxy` or downgrades to `http` — the two properties that made this harmful, asserted directly rather than via a status code.

## Verification

- Rewrite behaviour verified against the six URI shapes above
- YAML parses; embedded shell passes `bash -n`
- The live 307 above was captured before the change; nginx changes are only observable after deploy, which is a known gap in this repo's verification loops and stated as such

🤖 Generated with [Claude Code](https://claude.com/claude-code)