### PR TITLE
fix(ci): the bot-serving monitor has been failing for ten days

### DIFF
--- a/.github/workflows/bot-serving-check.yml
+++ b/.github/workflows/bot-serving-check.yml
@@ -65,7 +65,12 @@ jobs:
           }
 
           # Bot path: prerendered per-route HTML from the seo-proxy
-          check "$GOOGLEBOT"  "$ORIGIN/"                                "<title>anyplot.ai</title>"
+          # Prefix, not the full title: the copy changed to "anyplot.ai —
+          # AI-generated plot catalog for 15 libraries" and this check went red
+          # for ten consecutive days without anyone noticing. The prefix still
+          # separates the prerendered page from the SPA shell, whose title is
+          # "any.plot() — any library.", which is the property under test.
+          check "$GOOGLEBOT"  "$ORIGIN/"                                "<title>anyplot.ai"
           check "$GOOGLEBOT"  "$ORIGIN/scatter-basic"                   "<title>Basic Scatter Plot | anyplot.ai</title>"
           check "$TWITTERBOT" "$ORIGIN/scatter-basic/python/matplotlib" "<title>Basic Scatter Plot - Matplotlib | anyplot.ai</title>"
 
@@ -108,6 +113,12 @@ jobs:
           slash_target=$(curl -sS --max-time 30 -o /dev/null -A "$GOOGLEBOT" \
             -w '%{redirect_url}' "$ORIGIN/scatter-basic/")
           case "$slash_target" in
+            "")
+              # No redirect at all: %{redirect_url} is empty, which the previous
+              # form printed as "OK: trailing slash -> " and passed. Copilot
+              # raised this twice; it means the rewrite has disappeared.
+              echo "::error::trailing slash produced no redirect — the rewrite is gone"
+              fail=1 ;;
             *"/seo-proxy"*|http://*|*:8080/*)
               echo "::error::trailing-slash redirect leaks or downgrades: $slash_target"
               fail=1 ;;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The daily bot-serving monitor had been red for ten days** — it greps for an exact home-page
+  title, the copy changed to "anyplot.ai — AI-generated plot catalog for 15 libraries", and every
+  scheduled run since 2026-08-09 failed on that one line. Nothing else was wrong, and nobody looked:
+  this run of SEO work edited the workflow twice and cited it repeatedly as the regression cover for
+  changes that have no local verification loop, while it was failing daily. It now matches on the
+  prefix, which still separates the prerendered page from the SPA shell — the property actually
+  under test — and no longer breaks on copy. The trailing-slash check also no longer passes when
+  there is no redirect at all: an empty `%{redirect_url}` printed "OK" and returned success, which
+  Copilot raised on two separate PRs (#10478).
+
 - **The trailing-slash redirect leaked the internal port** — #10473 removed a redirect to
   `http://api.anyplot.ai/seo-proxy/…` and replaced it with `http://anyplot.ai:8080/…`: a smaller
   version of the same defect, since nginx builds a `permanent` rewrite's Location from


### PR DESCRIPTION
## The finding

```
$ gh run list --workflow=bot-serving-check.yml --limit 10
2026-08-18  failure (schedule)
2026-08-17  failure (schedule)
2026-08-16  failure (schedule)
...
2026-08-09  failure (schedule)
```

Ten consecutive scheduled runs, all red, on **one line**:

```
expects: <title>anyplot.ai</title>
actual:  <title>anyplot.ai — AI-generated plot catalog for 15 libraries</title>
```

Nothing else was broken. `grep -qF` on the full title, copy changed, check died.

## Why it matters more than a stale string

This run of SEO work edited this workflow **twice** and cited it repeatedly as the regression cover for precisely the class of change that has no local verification loop — nginx behaviour, bot serving. It was failing daily throughout.

The trailing-slash port leak that shipped today is the proof: the guard existed, it would have caught it, and it was already red so nobody would have seen it. A monitor nobody reads protects nothing.

Found by an independent audit, not by me — I had asserted the guard's value in three PR bodies without once checking whether it was green.

## Changes

**Home check matches on the prefix.** `<title>anyplot.ai` still separates the prerendered page from the SPA shell, whose title is `any.plot() — any library.` — that separation *is* the property under test. The full title was never the point and made the check break on copy edits.

**Empty redirect is now a failure.** `%{redirect_url}` is empty when there is no redirect, which fell through to the success branch and printed `OK: trailing slash -> `. So the rewrite disappearing entirely would have read as a pass. Copilot raised this on #10473 and again on #10476; neither addressed it.

## After merge

The workflow needs a manual `workflow_dispatch` to confirm the first green run in ten days — the schedule alone would leave it unverified until tomorrow. Note it will only pass once #10476 has deployed, since the trailing-slash assertion is currently correct to fail.

## Not fixed here

Nothing alerted on ten days of failure. The workflow reports into GitHub Actions and that is the whole notification path. Worth a decision separately — a monitor that fails silently is only marginally better than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)