### PR TITLE
fix(echarts): replace every newline in the tooltip, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,14 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **CodeQL alert #103** — an ECharts tooltip called `.replace("\n", " ")` with a string argument,
+  which replaces only the first occurrence
+  (`plots/bar-heart-rate-zones/implementations/javascript/echarts.js`). Nothing renders differently
+  today, since every zone label carries exactly one newline; the defect is latent, and a label
+  gaining a second line break would put a raw newline inside the tooltip's HTML. The pattern occurs
+  exactly once across the catalogue — were it recurring it would belong in the generation prompt,
+  since `plots/` is pipeline output and a regeneration overwrites this file (#10480).
+
 - **The bot analytics recorded nothing at all** — Plausible identifies crawler user agents and
   discards their events, so forwarding the real one guaranteed an empty dashboard. Verified against
   the live API: the same event sent as `Claude-User` never appears, sent as a browser agent it does,

--- a/plots/bar-heart-rate-zones/implementations/javascript/echarts.js
+++ b/plots/bar-heart-rate-zones/implementations/javascript/echarts.js
@@ -52,7 +52,7 @@ chart.setOption({
     formatter: (params) => {
       const idx = params[0].dataIndex;
       return (
-        `<b>${zoneNames[idx].replace("\n", " ")}</b><br/>` +
+        `<b>${zoneNames[idx].replace(/\n/g, " ")}</b><br/>` +
         `Duration: <b>${minutes[idx]} min</b><br/>` +
         `HR range: ${hrRanges[idx]}`
       );


### PR DESCRIPTION
Closes CodeQL alert #103 (`js/incomplete-sanitization`) on `plots/bar-heart-rate-zones/implementations/javascript/echarts.js:55`.

```diff
-`<b>${zoneNames[idx].replace("\n", " ")}</b><br/>` +
+`<b>${zoneNames[idx].replace(/\n/g, " ")}</b><br/>` +
```

`.replace` with a string argument replaces only the first occurrence.

## Nothing renders differently today

Every entry in `zoneNames` carries exactly one newline (`"Z1\nRecovery"`, `"Z2\nEndurance"`, …), so first-occurrence and all-occurrences produce the same string. The defect is latent: a label gaining a second line break would put a raw newline inside the tooltip's HTML.

```
two newlines, before: "A B\nC"   ← the second survives
two newlines, after:  "A B C"
```

Worth fixing anyway — the alert is real and the cost is one character.

## Scope

Checked the whole catalogue: this pattern appears **exactly once**. If it recurred it would belong in the generation prompt rather than in the generated file, since `plots/` is pipeline output and a regeneration of this spec overwrites it.

`node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)