### PR TITLE
release: v3.1.0 — Legible to machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
-## [3.1.0] — 2026-08-18 — Legible to machines
+## [3.1.0] — 2026-08-19 — Legible to machines
 
 anyplot 3.1 makes the catalogue readable by machines. An assistant asked about a plot can now find
 it, open one library's page, read the runnable source, fetch the rendered image and cite the URL —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+## [3.1.0] — 2026-08-18 — Legible to machines
+
+anyplot 3.1 makes the catalogue readable by machines. An assistant asked about a plot can now find
+it, open one library's page, read the runnable source, fetch the rendered image and cite the URL —
+a path that was broken at four separate points, each invisible to anyone browsing the site by hand.
+Googlebot had been walking an infinite redirect; a trailing slash sent crawlers to a host that
+forbids crawling; unknown library names produced an unbounded supply of indexable near-duplicates;
+and seven AI fetchers were served an empty shell. The crawler policy that used to decline training
+crawlers is now open to every operator that follows the rules, which is also the only way Gemini
+could ever cite the catalogue. Two Plausible sites now separate what people read from what machines
+do.
+
+Behind that: a Search Console integration that had never once worked, a synthetic monitor that had
+been failing unnoticed for ten days, three new verification skills, and a security-headers and
+audit sweep across the stack.
+
 ### Added
 
 - **You can now see which assistants read the catalogue** — a `bot_fetch` event records every AI
@@ -221,9 +237,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   previews regenerate against the new major through the regular pipeline (#9609).
 - **Post-restructure `app/` cleanup:** dead components removed and stale doc paths fixed (#8630);
   ECharts / MUI X labels shortened in the `/stats` library list (#8666).
-- **Dependencies:** grouped bumps across Python (starlette, cryptography, python-multipart,
-  sqlalchemy, uvicorn, 15-update python-minor group), npm (esbuild, undici), and GitHub Actions
-  (#8668, #8823, #8824, #8864, #8978, #8980, #9074, #9513, #9515).
+- **Dependencies:** 32 grouped bumps across Python (starlette, cryptography, python-multipart,
+  sqlalchemy, uvicorn, pydantic, the python-minor group), npm (esbuild, undici, vite, react, the
+  npm-minor and mui groups) and GitHub Actions (#8330, #8668, #8823, #8824, #8864, #8977, #8978,
+  #8979, #8980, #9074, #9513, #9515, #9613, #9640, #9643, #9647, #9648, #9650, #9652, #9653, #9654,
+  #9657, #9673, #9674, #9955, #9957, #9960, #9961, #9962, #10017, #10067, #10115, #10178). One of
+  them, the vite 8.1.5 bump in #9657, took the site down and is written up under Fixed.
 
 ### Removed
 
@@ -612,6 +631,8 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   included in both server blocks and re-included in every `add_header` location
   (audit 2026-07-15 Medium#21) (#9642).
 
+*Catalog: 1,607 implementation merges across 15 libraries and 10 new plot types (heatmap-periodic-table, line-cycle-seasonal, depth-order-book, climograph-walter-lieth, audiogram-clinical, burndown-sprint, bar-heart-rate-zones, gauge-activity-rings, curve-power-duration, line-training-load-pmc); the catalogue stands at 324 specifications.*
+
 ## [3.0.0] — 2026-06-10 — Julia & JavaScript, 15 libraries & the Imprint palette
 
 anyplot 3.0 doubles the language count — Julia and JavaScript join Python and R, growing the
@@ -869,7 +890,8 @@ interactive HTML previews.
   Actions workflows (spec creation, impl generation, AI review, auto-merge); Cloud Run +
   Cloud SQL + GCS; 1,081 unit tests.
 
-[Unreleased]: https://github.com/MarkusNeusinger/anyplot/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/MarkusNeusinger/anyplot/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/MarkusNeusinger/anyplot/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/MarkusNeusinger/anyplot/compare/v2.4.0...v3.0.0
 [2.4.0]: https://github.com/MarkusNeusinger/anyplot/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/MarkusNeusinger/anyplot/compare/v2.2.0...v2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # pyproject.toml
 [project]
 name = "anyplot"
-version = "3.0.0"
+version = "3.1.0"
 description = "AI-powered plotting examples"
 authors = [{ name = "Markus Neusinger", email = "admin@anyplot.ai" }]
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -227,7 +227,7 @@ wheels = [
 
 [[package]]
 name = "anyplot"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Cuts **v3.1.0**, the first release since v3.0.0 on 2026-06-10 — 84 changelog entries over two months.

## Version choice

**Minor, by the repo's own rule.** `agentic/commands/release.md` reserves major for "new language/library waves, rebrands, breaking URL/schema changes". This window has none: no new language, no new library, no rebrand. It is a large feature batch, not a milestone in that sense — the owner confirmed the reading.

## Codename: *Legible to machines*

The theme is that an assistant asked about a plot can now find it, open one library's page, read the runnable source, fetch the rendered image and cite the URL. That path was broken at four separate points, every one of them invisible to anyone browsing the site by hand:

- Googlebot walked an infinite redirect on `/{spec}/{language}`
- a trailing slash sent crawlers to a host whose `robots.txt` forbids crawling
- unknown library names produced an unbounded supply of indexable near-duplicates
- seven AI fetchers were served the empty SPA shell

Plus the crawler policy opening to every operator that follows the rules — the only way Gemini can ever cite the catalogue — and two Plausible sites separating what people read from what machines do.

## The three files

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[3.1.0] — 2026-08-18 — Legible to machines`, fresh empty `[Unreleased]`, both compare links, intro paragraph, two aggregate lines |
| `pyproject.toml` | `3.0.0` → `3.1.0` |
| `uv.lock` | the project's own pin, one line |

## Aggregates

- **Dependencies** bullet now covers all **32** Dependabot bumps of the window; it listed nine. It also points at the one that took the site down (the vite 8.1.5 bump in #9657), which is written up under Fixed.
- **Catalog** line records 1,607 implementation merges across 15 libraries, 10 new plot types, and the catalogue at 324 specifications.

## On the lock file

`uv lock` also normalised platform markers on `secretstorage` and `statsmodels` — drift between the committed lock and a newer `uv`. Unrelated to the release and it would have made this diff harder to audit, so `uv.lock` carries **only** the version line here. `uv lock --check` passes as committed. Worth a separate housekeeping change.

## Completeness check

Every non-exempt commit since `v3.0.0` was matched against the changelog. Eleven appeared unreferenced; ten are `spec: add …` (spec-create output, exempt) and the eleventh — the white-screen outage fix — **is** documented, under the Dependabot PR number that caused it rather than the fix PR's. No gaps.

`pytest tests/unit` 1648 passed; `ruff check` clean.

## After merge

Tag and publish per `agentic/commands/release.md`:
```
git tag -a v3.1.0 -m "Legible to machines (2026-08-18)" && git push origin v3.1.0
gh release create v3.1.0 --title "v3.1.0 — Legible to machines" --notes-file <tmp>
```
The site masthead picks the tag up on its own — nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)