### PR TITLE
docs(guide): name the project flag as load-bearing for build checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deploy checks could report another project's builds** — the runbook's recipe for
+  "did this actually deploy?" flagged `--region` as the easy thing to forget and treated
+  `--project` as incidental. It is not. A gcloud install whose default project is a
+  different one returns *that* project's builds, and when its triggers happen to carry
+  the same names in the same region, the wrong answer is indistinguishable from the
+  right one — no error, just a credible list of `deploy-api` runs that stop a few days
+  ago. It produced a false "nothing has deployed since the 16th" on a day with a dozen
+  deploys. `agentic/docs/project-guide.md` now names both flags and the context check
+  that settles it.
+
 ## [3.1.0] — 2026-08-19 — Legible to machines
 
 anyplot 3.1 makes the catalogue readable by machines. An assistant asked about a plot can now find

--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -898,7 +898,7 @@ Roughly five minutes from merge to live, per build.
 #### Checking whether something actually deployed
 
 The triggers are **regional, in `europe-west4`**, and regional builds do not
-appear in the global build list. Always pass `--region`:
+appear in the global build list. Always pass both `--region` and `--project`:
 
 ```bash
 gcloud builds list --region=europe-west4 --project=anyplot --limit=10 \
@@ -910,6 +910,17 @@ Omitting `--region` returns a handful of builds from early 2026 and nothing
 since — which reads as "nothing has deployed for months" and is simply the
 wrong list. That mistake has been made and had to be corrected by the repo
 owner.
+
+Omitting `--project` fails more quietly. A gcloud install whose default project
+is another one of the owner's projects returns *that* project's builds, and
+because those triggers carry the same names in the same region, the output looks
+entirely credible — a plausible list of `deploy-api` and `deploy-app` runs that
+simply stop a few days ago. There is no error to notice. Confirm the context
+before drawing a conclusion from it:
+
+```bash
+gcloud config get-value project    # must print: anyplot
+```
 
 `.github/workflows/notify-deployment.yml` only **records** a GitHub deployment;
 it does not deploy anything. A green run there says nothing about whether the


### PR DESCRIPTION
## What

The deploy-check runbook in `agentic/docs/project-guide.md` warned about `--region` and treated `--project` as incidental. It is not.

## Why

A gcloud install whose default project is another of the owner's projects returns *that* project's builds. When those triggers carry the same names (`deploy-api`, `deploy-app`) in the same region (`europe-west4`), the wrong list is indistinguishable from the right one — no error, no warning, just a credible history of deploys that happens to stop a few days ago.

That is not hypothetical. While preparing the v3.1.0 release I ran the check without the flag and concluded "no builds since 2026-08-16" on a day anyplot had in fact deployed twelve times. The real history was one flag away.

## Change

- Names both flags as required, not just `--region`
- Adds the one-line context check that settles it: `gcloud config get-value project` must print `anyplot`
- Explains *why* this failure is quiet, so the next reader distrusts a plausible-looking list rather than only an obviously empty one

Docs-only; no code paths touched.