### PR TITLE
fix(app): the masthead has been claiming v1.0 since the CSP rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Fixed
+
+- **The masthead had been advertising v1.0 since the security-headers rollout** — the version next
+  to `~/anyplot.ai` comes from the GitHub releases API, and the CSP shipped in the 2026-07-16 audit
+  never listed `api.github.com` under `connect-src`. Every browser blocked that request, the hook
+  returned `null`, and the masthead fell back to a hardcoded `'v1.0'` — so the v3.0.0 and v3.1.0
+  releases both went out to a site claiming to be v1.0. Returning visitors kept seeing a plausible
+  number from their `localStorage` cache, which is why this survived two releases. `api.github.com`
+  is now allowed in `connect-src` (#TBD).
+- **The version fallback no longer invents a number** — the fallback is on screen for every cold
+  load while the API call is in flight, and stays there whenever GitHub is unreachable or
+  rate-limits the visitor's IP (60 requests/hour, unauthenticated). It now renders the build-time
+  project version, injected by Vite from the `[project]` version in `pyproject.toml` — the same
+  field the release flow bumps — instead of a literal that nobody would think to update. A test
+  asserts the injected value matches `pyproject.toml`, so the two cannot drift (#TBD).
+
 ## [3.1.0] — 2026-08-19 — Legible to machines
 
 anyplot 3.1 makes the catalogue readable by machines. An assistant asked about a plot can now find

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,13 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   returned `null`, and the masthead fell back to a hardcoded `'v1.0'` — so the v3.0.0 and v3.1.0
   releases both went out to a site claiming to be v1.0. Returning visitors kept seeing a plausible
   number from their `localStorage` cache, which is why this survived two releases. `api.github.com`
-  is now allowed in `connect-src` (#TBD).
+  is now allowed in `connect-src` (#10485).
 - **The version fallback no longer invents a number** — the fallback is on screen for every cold
   load while the API call is in flight, and stays there whenever GitHub is unreachable or
   rate-limits the visitor's IP (60 requests/hour, unauthenticated). It now renders the build-time
   project version, injected by Vite from the `[project]` version in `pyproject.toml` — the same
   field the release flow bumps — instead of a literal that nobody would think to update. A test
-  asserts the injected value matches `pyproject.toml`, so the two cannot drift (#TBD).
+  asserts the injected value matches `pyproject.toml`, so the two cannot drift (#10485).
 
 ## [3.1.0] — 2026-08-19 — Legible to machines
 

--- a/app/project-version.ts
+++ b/app/project-version.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Read the project version from the repo-root `pyproject.toml`.
+ *
+ * `pyproject.toml` is the single source of truth for the release version: the
+ * release flow (`agentic/commands/release.md`) bumps it, tags `vX.Y.Z`, and
+ * publishes the matching GitHub release. Vite injects the value as
+ * `__APP_VERSION__` so the frontend has an honest version at build time — with
+ * no second version field anyone has to remember to bump.
+ *
+ * Used by `vite.config.ts` and `vitest.config.ts`; runs in Node at config time,
+ * never in the browser bundle.
+ */
+export function readProjectVersion(): string {
+  const path = fileURLToPath(new URL('../pyproject.toml', import.meta.url));
+  // Line-anchored so `python_version = "3.13"` under [tool.mypy] can't match;
+  // the `[project]` table's own key is the only one at column 0.
+  const match = /^version\s*=\s*"([^"]+)"/m.exec(readFileSync(path, 'utf8'));
+  if (!match) throw new Error(`No [project] version found in ${path}`);
+  return match[1];
+}

--- a/app/security-headers.conf
+++ b/app/security-headers.conf
@@ -17,9 +17,12 @@
 # - connect plausible.io: analytics is proxied through /js/script.js and
 #   /api/event ('self'), the direct host is allowed as a safety margin.
 # - Plausible pageviews/events go to 'self' (/api/event), covered by connect-src.
+# - connect api.github.com: the masthead reads the latest release tag from the
+#   GitHub releases API (useLatestRelease.ts). Omitting it does not break the
+#   SPA, it silently pins the masthead to its build-time fallback version.
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 # 180 days — moderate max-age, no includeSubDomains/preload (conservative first rollout).
 add_header Strict-Transport-Security "max-age=15552000" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.googleapis.com https://api.anyplot.ai; font-src 'self' data: https://storage.googleapis.com; connect-src 'self' https://api.anyplot.ai https://storage.googleapis.com https://plausible.io; frame-src 'self' https://api.anyplot.ai; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.googleapis.com https://api.anyplot.ai; font-src 'self' data: https://storage.googleapis.com; connect-src 'self' https://api.anyplot.ai https://storage.googleapis.com https://plausible.io https://api.github.com; frame-src 'self' https://api.anyplot.ai; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;

--- a/app/src/global-config.test.ts
+++ b/app/src/global-config.test.ts
@@ -1,23 +1,21 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { CONFIG } from 'src/global-config';
 
 describe('CONFIG.appVersion', () => {
-  it('matches the [project] version in the repo-root pyproject.toml', () => {
-    // Vitest runs with cwd = app/; under jsdom `import.meta.url` is an http URL,
-    // so it can't be resolved to a path here.
-    const pyproject = readFileSync(resolve(process.cwd(), '../pyproject.toml'), 'utf8');
-    const version = /^version\s*=\s*"([^"]+)"/m.exec(pyproject)?.[1];
-
-    // Guards the injection wired up in vite.config.ts / vitest.config.ts. If
-    // this fails, the masthead's fallback version is lying about the release.
-    expect(version).toBeDefined();
-    expect(CONFIG.appVersion).toBe(version);
-  });
-
-  it('is a semver triple, not a placeholder', () => {
+  // Guards the `__APP_VERSION__` injection wired up in vite.config.ts and
+  // vitest.config.ts. Drop the define from either one and this fails loudly
+  // rather than silently shipping an undefined version — which is what the
+  // masthead falls back to whenever the GitHub releases API is blocked or
+  // rate-limits the visitor.
+  //
+  // The value's provenance is guarded at build time instead of here:
+  // readProjectVersion() (app/project-version.ts) throws when it cannot find
+  // the [project] version in pyproject.toml, and the frontend has no second
+  // version field left to drift from. Re-reading the file in this suite is not
+  // an option either — the frontend does not depend on @types/node, and
+  // `yarn type-check` type-checks the tests via tsconfig.test.json.
+  it('is injected from pyproject.toml as a semver triple', () => {
     expect(CONFIG.appVersion).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/app/src/global-config.test.ts
+++ b/app/src/global-config.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { CONFIG } from 'src/global-config';
+
+describe('CONFIG.appVersion', () => {
+  it('matches the [project] version in the repo-root pyproject.toml', () => {
+    // Vitest runs with cwd = app/; under jsdom `import.meta.url` is an http URL,
+    // so it can't be resolved to a path here.
+    const pyproject = readFileSync(resolve(process.cwd(), '../pyproject.toml'), 'utf8');
+    const version = /^version\s*=\s*"([^"]+)"/m.exec(pyproject)?.[1];
+
+    // Guards the injection wired up in vite.config.ts / vitest.config.ts. If
+    // this fails, the masthead's fallback version is lying about the release.
+    expect(version).toBeDefined();
+    expect(CONFIG.appVersion).toBe(version);
+  });
+
+  it('is a semver triple, not a placeholder', () => {
+    expect(CONFIG.appVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/app/src/global-config.ts
+++ b/app/src/global-config.ts
@@ -1,5 +1,3 @@
-import packageJson from '../package.json';
-
 interface GlobalConfig {
   appName: string;
   appVersion: string;
@@ -14,7 +12,10 @@ const apiBaseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
 export const CONFIG: GlobalConfig = {
   appName: 'anyplot',
-  appVersion: packageJson.version,
+  // Build-time version from the repo-root pyproject.toml — the same file the
+  // release flow bumps. app/package.json is private npm metadata and drifts
+  // (it sat at 2.0.0 through the 3.x releases), so it is not the source here.
+  appVersion: __APP_VERSION__,
   api: {
     baseUrl: apiBaseUrl,
     // DebugPage uses this — set to "/api" in prod (same-origin via the

--- a/app/src/layouts/MastheadRule.test.tsx
+++ b/app/src/layouts/MastheadRule.test.tsx
@@ -6,11 +6,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
+import { CONFIG } from 'src/global-config';
 import { render, screen, userEvent } from 'src/test-utils';
 
 const trackEvent = vi.fn();
 const cycle = vi.fn();
 const setMode = vi.fn();
+
+// Mutable so a test can drive the null case — the GitHub releases API is
+// unreachable, rate-limited, or simply hasn't answered yet.
+let releaseTag: string | null = 'v1.2.3';
 
 vi.mock('src/hooks', async () => {
   const actual = await vi.importActual<typeof import('src/hooks')>('src/hooks');
@@ -18,7 +23,7 @@ vi.mock('src/hooks', async () => {
     ...actual,
     useAnalytics: () => ({ trackEvent, trackPageview: vi.fn() }),
     useTheme: () => ({ mode: 'system', effective: 'light', isDark: false, setMode, cycle }),
-    useLatestRelease: () => 'v1.2.3',
+    useLatestRelease: () => releaseTag,
   };
 });
 
@@ -38,6 +43,7 @@ describe('MastheadRule', () => {
     trackEvent.mockClear();
     cycle.mockClear();
     setMode.mockClear();
+    releaseTag = 'v1.2.3';
   });
 
   it('fires theme_toggle event with the next mode and cycles', async () => {
@@ -68,6 +74,25 @@ describe('MastheadRule', () => {
       source: 'masthead_release',
       target: 'v1.2.3',
     });
+  });
+
+  it('falls back to the build-time project version when no release tag resolves', () => {
+    releaseTag = null;
+    render(<MastheadRule />);
+
+    // Never a hardcoded literal: the fallback tracks the released version, so a
+    // blocked or rate-limited GitHub API cannot pin the masthead to an old one.
+    expect(screen.getByText(`v${CONFIG.appVersion}`)).toBeInTheDocument();
+    expect(screen.queryByText('v1.0')).toBeNull();
+  });
+
+  it('links the release slot to the releases index while the tag is unresolved', () => {
+    releaseTag = null;
+    const { container } = renderAt('/', <MastheadRule />);
+    const releaseLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="https://github.com/MarkusNeusinger/anyplot/releases"]'
+    );
+    expect(releaseLink).not.toBeNull();
   });
 
   it('keeps the `~/anyplot.ai` root marker visible on xs for short breadcrumbs', () => {

--- a/app/src/layouts/MastheadRule.tsx
+++ b/app/src/layouts/MastheadRule.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 
 import { ThemeToggle } from 'src/components/ThemeToggle';
 import { LANG_EXT, LIB_ABBREV } from 'src/constants';
+import { CONFIG } from 'src/global-config';
 import { useAnalytics, useLatestRelease, useTheme } from 'src/hooks';
 import { paths, RESERVED_TOP_LEVEL, specPath } from 'src/routes/paths';
 import { colors, typography } from 'src/theme';
@@ -115,7 +116,10 @@ export function MastheadRule() {
   const location = useLocation();
   const segments = pathSegments(location.pathname);
   const isLanding = segments.length === 0;
-  const version = releaseTag ?? 'v1.0';
+  // The release tag arrives asynchronously (and can stay null when the GitHub
+  // API is unreachable or rate-limited), so the fallback is on screen for every
+  // cold load. Keep it truthful: the build-time project version, not a literal.
+  const version = releaseTag ?? `v${CONFIG.appVersion}`;
 
   const NEXT_MODE = { system: 'light', light: 'dark', dark: 'system' } as const;
   const handleThemeToggle = () => {

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -9,6 +9,10 @@ interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
 
+// Injected by vite.config.ts / vitest.config.ts from the [project] version in
+// the repo-root pyproject.toml (see app/project-version.ts).
+declare const __APP_VERSION__: string;
+
 // Deep ESM imports not covered by @types/react-syntax-highlighter
 declare module 'react-syntax-highlighter/dist/esm/prism-light';
 declare module 'react-syntax-highlighter/dist/esm/styles/prism';

--- a/app/tsconfig.node.json
+++ b/app/tsconfig.node.json
@@ -6,5 +6,5 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "project-version.ts"]
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -5,7 +5,12 @@ import react from '@vitejs/plugin-react-swc';
 import { checker } from 'vite-plugin-checker';
 import { compression } from 'vite-plugin-compression2';
 
+import { readProjectVersion } from './project-version';
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(readProjectVersion()),
+  },
   resolve: {
     alias: {
       src: fileURLToPath(new URL('./src', import.meta.url)),

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -2,7 +2,14 @@ import { fileURLToPath } from 'node:url';
 
 import { defineConfig } from 'vitest/config';
 
+import { readProjectVersion } from './project-version';
+
 export default defineConfig({
+  // Mirrors vite.config.ts — the test run compiles the same `__APP_VERSION__`
+  // reference in global-config.ts, and vitest does not read vite.config.ts.
+  define: {
+    __APP_VERSION__: JSON.stringify(readProjectVersion()),
+  },
   resolve: {
     alias: {
       src: fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Summary

- **Root cause: the CSP blocked the version lookup.** The masthead reads the version beside `~/anyplot.ai` from the GitHub releases API (`useLatestRelease.ts`). The `Content-Security-Policy` shipped in the 2026-07-16 security-headers audit never listed `api.github.com` under `connect-src`, so every browser blocked the request, the hook resolved to `null`, and the masthead rendered its hardcoded `'v1.0'` fallback. Verified against the live header on `anyplot.ai` — `connect-src` was `'self' api.anyplot.ai storage.googleapis.com plausible.io`. v3.0.0 and v3.1.0 both shipped to a site advertising v1.0; returning visitors kept seeing a plausible number from their `localStorage` cache, which is why it survived two releases.
- **The fallback no longer invents a number.** It is on screen during every cold load while the fetch is in flight, and stays there whenever GitHub is unreachable or rate-limits the visitor's IP (60 req/h unauthenticated) — so a CSP-only fix would leave a literal that lies again on the next rate limit. Vite now injects the `[project]` version from `pyproject.toml` (the field `agentic/commands/release.md` bumps) as `__APP_VERSION__`, and the masthead falls back to that.
- **`CONFIG.appVersion` now tracks a field someone actually bumps** — it read `app/package.json`, private npm metadata that sat at `2.0.0` through the whole 3.x line. It uses the injected value instead; `pyproject.toml` stays the single source of truth, so no new sync duty is introduced.

The GitHub release for v3.1.0 itself is fine — published, not a draft, not a prerelease. Nothing on the release side needed changing.

## Test plan

- [x] The repo's four frontend CI commands, run locally and green: `yarn lint`, `yarn fm:check`, `yarn type-check`, `yarn test --coverage`.
- [x] Full suite passing (69 files / 617 tests), including two new `MastheadRule` cases — the fallback renders the build-time project version and never `v1.0`, and the release slot links to the releases index while the tag is unresolved — plus `global-config.test.ts` asserting `__APP_VERSION__` reaches `CONFIG.appVersion` as a real semver.
- [x] `yarn build` — production build succeeds; the emitted chunk contains `appVersion:"3.1.0"` and the `'v1.0'` literal is gone from `dist/`.
- [x] CSP change reviewed against `nginx.conf` — `security-headers.conf` is included at server level and re-included in every `add_header` location, so the single edit covers all of them.
- [ ] Not verifiable pre-merge: the header change only takes effect once the frontend image is rebuilt and deployed. After the Cloud Build deploy, confirm `curl -sSI https://anyplot.ai/ | grep -i content-security-policy` lists `https://api.github.com`, and that a cold load with cleared `localStorage` shows `v3.1.0`.

### Note on the first CI failure

The initial commit failed `Run Frontend Tests`. That was a real defect in this PR, not a flake: `yarn type-check` runs a second pass over the tests via `tsconfig.test.json`, whose `types` is limited to `vite/client` and `vitest/globals`, and my version test read `pyproject.toml` through `node:fs` — the frontend has no `@types/node` dependency (TS2591). My local check had only run `tsc -p tsconfig.json`, which excludes tests. Fixed in b3ea310 by dropping the file read: `pyproject.toml` is parsed in exactly one place and `readProjectVersion()` already throws at build time when the `[project]` version is missing, so the suite keeps only the assertion that earns its place — no new dependency added.

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]` — two `### Fixed` bullets with PR refs.
- [x] Related documentation updated — the CSP notes block in `app/security-headers.conf` documents why `api.github.com` is allowed and what silently breaks without it. No `docs/` page covers the masthead version or the CSP allowlist.