### PR TITLE
fix(api): open the machine interface AI agents were locked out of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   HTTP client: the code endpoint, the GCS render URL pattern (light/dark, responsive
   widths, WebP), OpenAPI and the MCP endpoint. Until now an agent had to walk the 400 KB
   sitemap or guess URL shapes; the prerendered pages that carry this information are
-  user-agent-gated, so most agents never saw them (AI-access audit 2026-08-19).
+  user-agent-gated, so most agents never saw them (AI-access audit 2026-08-19) (#10487).
 
 ### Fixed
 
@@ -32,16 +32,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   served `Disallow: /` (only `/og/` excepted), telling every robots-compliant assistant
   that the REST endpoints, `openapi.json` and the MCP transport were off-limits — on the
   very host `llms.txt` advertises as the machine interface. The read API is now open;
-  only `/debug` and `/proxy` stay excluded.
+  only `/debug` and `/proxy` stay excluded (#10487).
 - **Non-Python code is reachable at the obvious URL** — `/specs/{id}/{library}/code`
   defaulted its `language` parameter to `python`, so the natural URL 404'd for all seven
   R/Julia/JavaScript libraries (28% of the catalogue) with a misleading "not found".
   Library ids are globally unique, so the language now resolves from the registry;
-  an explicit `?language=` still wins.
+  an explicit `?language=` still wins (#10487).
 - **HEAD requests answered 405 across the whole API** — FastAPI's `@router.get` registers
   GET-only routes, so agents and link checkers that preflight with HEAD concluded every
   page was unavailable. An ASGI middleware now answers HEAD like GET without a body
-  (and without doubling the documented surface in openapi.json).
+  (and without doubling the documented surface in openapi.json) (#10487).
 - **Structured data hands agents the plot, not the branding card** — the per-implementation
   `SoftwareSourceCode` JSON-LD declared the 1200×630 og card as its `image`; it now carries
   the actual render as an `ImageObject` (full-size + 1200px thumbnail) plus the fields an
@@ -49,11 +49,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `keywords`, `author`, `isBasedOn` — previously present only in the SPA's JSON-LD, which
   no crawler executes. Spec-hub bot pages likewise show the best real render (with the
   full asset list) instead of the og collage, and their `ItemList` names each
-  implementation's render URL.
+  implementation's render URL (#10487).
 - **One version, everywhere** — `openapi.json` claimed 1.0.0 and "9 libraries", `/health`
   said 0.2.0, pyproject said 3.1.0. All surfaces now report the packaged version and a
   registry-derived library/language count, and `openapi.json` names its production server
-  so the spec is usable standalone.
+  so the spec is usable standalone (#10487).
 
 - **Deploy checks could report another project's builds** — the runbook's recipe for
   "did this actually deploy?" flagged `--region` as the easy thing to forget and treated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,44 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Added
+
+- **`llms-full.txt` — the whole catalogue in one fetch** — a new
+  `GET /llms-full.txt` lists every spec on one line (id, title, hub URL, implemented
+  libraries) under a header that documents the retrieval recipes that work for *every*
+  HTTP client: the code endpoint, the GCS render URL pattern (light/dark, responsive
+  widths, WebP), OpenAPI and the MCP endpoint. Until now an agent had to walk the 400 KB
+  sitemap or guess URL shapes; the prerendered pages that carry this information are
+  user-agent-gated, so most agents never saw them (AI-access audit 2026-08-19).
+
 ### Fixed
+
+- **The API host no longer forbids itself to AI agents** — `api.anyplot.ai/robots.txt`
+  served `Disallow: /` (only `/og/` excepted), telling every robots-compliant assistant
+  that the REST endpoints, `openapi.json` and the MCP transport were off-limits — on the
+  very host `llms.txt` advertises as the machine interface. The read API is now open;
+  only `/debug` and `/proxy` stay excluded.
+- **Non-Python code is reachable at the obvious URL** — `/specs/{id}/{library}/code`
+  defaulted its `language` parameter to `python`, so the natural URL 404'd for all seven
+  R/Julia/JavaScript libraries (28% of the catalogue) with a misleading "not found".
+  Library ids are globally unique, so the language now resolves from the registry;
+  an explicit `?language=` still wins.
+- **HEAD requests answered 405 across the whole API** — FastAPI's `@router.get` registers
+  GET-only routes, so agents and link checkers that preflight with HEAD concluded every
+  page was unavailable. An ASGI middleware now answers HEAD like GET without a body
+  (and without doubling the documented surface in openapi.json).
+- **Structured data hands agents the plot, not the branding card** — the per-implementation
+  `SoftwareSourceCode` JSON-LD declared the 1200×630 og card as its `image`; it now carries
+  the actual render as an `ImageObject` (full-size + 1200px thumbnail) plus the fields an
+  assistant checks before reusing code: `license` (MIT), `codeRepository`, `dateModified`,
+  `keywords`, `author`, `isBasedOn` — previously present only in the SPA's JSON-LD, which
+  no crawler executes. Spec-hub bot pages likewise show the best real render (with the
+  full asset list) instead of the og collage, and their `ItemList` names each
+  implementation's render URL.
+- **One version, everywhere** — `openapi.json` claimed 1.0.0 and "9 libraries", `/health`
+  said 0.2.0, pyproject said 3.1.0. All surfaces now report the packaged version and a
+  registry-derived library/language count, and `openapi.json` names its production server
+  so the spec is usable standalone.
 
 - **Deploy checks could report another project's builds** — the runbook's recipe for
   "did this actually deploy?" flagged `--region` as the easy thing to forget and treated

--- a/api/main.py
+++ b/api/main.py
@@ -45,7 +45,9 @@ from api.routers.libraries import _refresh_libraries  # noqa: E402
 from api.routers.plots import _refresh_filter_all  # noqa: E402
 from api.routers.specs import _refresh_specs_list, _refresh_specs_map  # noqa: E402
 from api.routers.stats import _refresh_stats  # noqa: E402
+from api.version import APP_VERSION  # noqa: E402
 from core.config import settings  # noqa: E402
+from core.constants import LANGUAGES_METADATA, LIBRARIES_METADATA  # noqa: E402
 from core.database import close_db, init_db, is_db_configured  # noqa: E402
 
 
@@ -119,15 +121,23 @@ async def lifespan(app: FastAPI):
     await close_db()
 
 
-# Create FastAPI application
+# Create FastAPI application. Identity fields derive from the package version
+# and the canonical registry — the hardcoded "1.0.0" / "9 libraries" pair had
+# drifted three releases and six libraries behind reality. `servers` makes the
+# spec self-contained: without it, a client handed only openapi.json has no
+# base URL to resolve the relative paths against.
 app = FastAPI(
     title="anyplot API",
-    description="Backend API for anyplot.ai - plotting gallery across 9 libraries",
-    version="1.0.0",
+    description=(
+        "Backend API for anyplot.ai — the open plot catalogue across "
+        f"{len(LIBRARIES_METADATA)} libraries in {len(LANGUAGES_METADATA)} languages."
+    ),
+    version=APP_VERSION,
     lifespan=lifespan,
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_url="/openapi.json",
+    servers=[{"url": "https://api.anyplot.ai", "description": "Production"}],
 )
 
 # Register exception handlers
@@ -243,11 +253,43 @@ class MCPTrailingSlashMiddleware:
         await self.asgi_app(scope, receive, send)
 
 
-# Wrap the FastAPI app with the middleware
+class HeadAsGetMiddleware:
+    """Answer HEAD requests with the matching GET route's headers and no body.
+
+    FastAPI's @router.get registers GET-only routes (Starlette's plain Route
+    would add HEAD itself), so every HEAD probe — link checkers, agents
+    preflighting a page before fetching it — answered 405 across the whole
+    API, including the seo-proxy pages and /health. An ASGI rewrite rather
+    than adding HEAD to route.methods: the latter would also emit a `head`
+    operation per path into openapi.json, doubling the documented surface.
+    Content-Length from the GET response is kept — that is what HEAD promises.
+    """
+
+    def __init__(self, asgi_app):
+        self.asgi_app = asgi_app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope["method"] == "HEAD":
+            scope = {**scope, "method": "GET"}
+
+            # Body chunks are emptied but their more_body sequencing is kept —
+            # forcing an early end while a streaming response keeps sending
+            # would violate the ASGI message protocol.
+            async def send_without_body(message):
+                if message["type"] == "http.response.body":
+                    message = {**message, "body": b""}
+                await send(message)
+
+            await self.asgi_app(scope, receive, send_without_body)
+            return
+        await self.asgi_app(scope, receive, send)
+
+
+# Wrap the FastAPI app with the middlewares
 # This must be done after all routers are registered
 # Keep reference to FastAPI instance for tests
 fastapi_app = app
-app = MCPTrailingSlashMiddleware(app)
+app = HeadAsGetMiddleware(MCPTrailingSlashMiddleware(app))
 
 
 if __name__ == "__main__":

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -3,6 +3,8 @@
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
+from api.version import APP_VERSION
+
 
 router = APIRouter(tags=["health"])
 
@@ -10,13 +12,15 @@ router = APIRouter(tags=["health"])
 @router.get("/")
 async def root():
     """Root endpoint."""
-    return {"message": "Welcome to anyplot API", "version": "0.2.0", "docs": "/docs", "health": "/health"}
+    return {"message": "Welcome to anyplot API", "version": APP_VERSION, "docs": "/docs", "health": "/health"}
 
 
 @router.get("/health")
 async def health_check():
     """Health check endpoint for Cloud Run."""
-    return JSONResponse(content={"status": "healthy", "service": "anyplot-api", "version": "0.2.0"}, status_code=200)
+    return JSONResponse(
+        content={"status": "healthy", "service": "anyplot-api", "version": APP_VERSION}, status_code=200
+    )
 
 
 @router.get("/hello/{name}")

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -589,14 +589,26 @@ def _build_source_code_node(spec, impl, lib_name: str, lang_name: str, page_url:
     return node
 
 
+# Canonical walk order for the tag bag — dict insertion order varies by
+# source/roundtrip, and keywords built from it would make the JSON-LD
+# non-deterministic across renders (noisy for caches and diff-consumers).
+_TAG_CATEGORY_ORDER = ("plot_type", "data_type", "domain", "features")
+
+
 def _spec_keywords(spec) -> list[str]:
-    """Flatten the spec's tag bag ({plot_type, data_type, domain, features}) into a keyword list."""
+    """Flatten the spec's tag bag into a deduplicated, deterministically ordered keyword list."""
+    tags = spec.tags or {}
+    ordered_keys = [k for k in _TAG_CATEGORY_ORDER if k in tags]
+    ordered_keys += sorted(k for k in tags if k not in _TAG_CATEGORY_ORDER)
     keywords: list[str] = []
-    for values in (spec.tags or {}).values():
-        if isinstance(values, str):
-            keywords.append(values)
-        elif isinstance(values, list):
-            keywords.extend(str(v) for v in values)
+    seen: set[str] = set()
+    for key in ordered_keys:
+        values = tags[key]
+        for value in [values] if isinstance(values, str) else values if isinstance(values, list) else []:
+            keyword = str(value)
+            if keyword not in seen:
+                seen.add(keyword)
+                keywords.append(keyword)
     return keywords
 
 

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -117,17 +117,24 @@ BOT_HTML_TEMPLATE = """<!DOCTYPE html>
     <meta charset="UTF-8" />
     <title>{title}</title>
     <meta name="description" content="{description}" />
+    <meta name="robots" content="{robots_content}" />
     <meta property="og:title" content="{title}" />
     <meta property="og:description" content="{description}" />
     <meta property="og:image" content="{image}" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="{title}" />
     <meta property="og:url" content="{og_url}" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="anyplot.ai" />
+    <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@MarkusNeusinger" />
+    <meta name="twitter:creator" content="@MarkusNeusinger" />
     <meta name="twitter:title" content="{title}" />
     <meta name="twitter:description" content="{description}" />
     <meta name="twitter:image" content="{image}" />
-    <link rel="canonical" href="{url}" />{robots}{jsonld}
+    <link rel="canonical" href="{url}" />{jsonld}
 </head>
 <body>
 {body}
@@ -304,13 +311,16 @@ def _render_bot_html(
     - ``jsonld``: raw (unescaped) values; ``json.dumps`` handles quoting and
       ``_jsonld_script`` neutralizes ``</``.
     """
+    # max-image-preview:large — without it Google Images/Discover cap the
+    # preview at thumbnail size, which for an image catalogue is on-mission
+    # traffic left on the table. Irrelevant on noindex pages.
     return BOT_HTML_TEMPLATE.format(
         title=title,
         description=description,
         image=image,
         url=url,
         og_url=og_url if og_url is not None else url,
-        robots='\n    <meta name="robots" content="noindex" />' if noindex else "",
+        robots_content="noindex" if noindex else "max-image-preview:large",
         jsonld=_jsonld_script(jsonld) if jsonld else "",
         body=f"{body or f'<h1>{title}</h1><p>{description}</p>'}\n{_BOT_NAV_HTML}",
     )
@@ -420,15 +430,32 @@ def _build_spec_hub_html(spec, image: str) -> str:
             f'<li><a href="{html.escape(impl_url, quote=True)}">'
             f"{title_esc} in {html.escape(lib_name)} ({html.escape(lang_name)})</a></li>"
         )
-        impl_list_items.append(
-            {"@type": "ListItem", "position": position, "name": f"{spec.title} — {lib_name}", "url": impl_url}
-        )
+        item = {"@type": "ListItem", "position": position, "name": f"{spec.title} — {lib_name}", "url": impl_url}
+        # Per-item render URL: one hub fetch enumerates every plot image
+        # instead of costing a follow-up request per implementation.
+        if impl.preview_url_light:
+            item["image"] = impl.preview_url_light
+        impl_list_items.append(item)
 
-    body = (
-        f"<h1>{title_esc}</h1>"
-        f"<p>{desc_esc}</p>"
-        f'<img src="{image_esc}" alt="{title_esc}" width="1200" height="630" />'
-        + (f"<h2>Implementations</h2><ul>{''.join(impl_links)}</ul>" if impl_links else "")
+    # The body shows the best actual render, not the 1200x630 og collage card:
+    # the hub is the sitemap'd, most-shared URL, and until now it was the one
+    # page type where a machine could enumerate 15 implementation links yet
+    # not reach a single plot image (AI-access audit 2026-08-19). The collage
+    # card stays the og:image — link previews are what it was made for.
+    best_impl = max(
+        (i for i in spec.impls if i.preview_url_light), key=lambda i: (i.quality_score or 0, i.library_id), default=None
+    )
+    if best_impl:
+        best_lib_name, _ = _impl_display_names(best_impl)
+        plot_img = (
+            _render_picture(best_impl, title_esc)
+            + f"<p>Preview render from the {html.escape(best_lib_name)} implementation.</p>"
+        )
+    else:
+        plot_img = f'<img src="{image_esc}" alt="{title_esc}" width="1200" height="630" />'
+
+    body = f"<h1>{title_esc}</h1><p>{desc_esc}</p>{plot_img}" + (
+        f"<h2>Implementations</h2><ul>{''.join(impl_links)}</ul>" if impl_links else ""
     )
     jsonld = {
         "@context": "https://schema.org",
@@ -464,6 +491,12 @@ def _sized_srcset(full_url: str) -> str:
     return ", ".join(f"{stem}_{w}.png {w}w" for w in (400, 800, 1200))
 
 
+def _thumb_1200(full_url: str) -> str:
+    """The 1200px derivative for a full-size render URL (the original's width
+    varies per plot, so 1200 is the largest honest fixed size)."""
+    return full_url[:-4] + "_1200.png" if full_url.endswith(".png") else full_url
+
+
 def _render_picture(impl, alt: str) -> str:
     """The actual plot render, both themes, at a size a consumer can choose.
 
@@ -473,12 +506,7 @@ def _render_picture(impl, alt: str) -> str:
     ``&amp;quot;``. ``html.escape`` defaults to ``quote=True``, so a caller that
     follows the contract is attribute-safe.
     """
-    light_default = html.escape(
-        impl.preview_url_light[:-4] + "_1200.png"
-        if impl.preview_url_light.endswith(".png")
-        else impl.preview_url_light,
-        quote=True,
-    )
+    light_default = html.escape(_thumb_1200(impl.preview_url_light), quote=True)
     source = ""
     if impl.preview_url_dark:
         dark_set = html.escape(_sized_srcset(impl.preview_url_dark), quote=True)
@@ -514,6 +542,62 @@ def _render_asset_list(impl) -> str:
         if url:
             items.append(f'<li><a href="{html.escape(url, quote=True)}">{label}</a></li>')
     return f"<h2>Renders</h2><ul>{''.join(items)}</ul>" if items else ""
+
+
+def _build_source_code_node(spec, impl, lib_name: str, lang_name: str, page_url: str, hub_url: str, image: str) -> dict:
+    """SoftwareSourceCode JSON-LD for an implementation page.
+
+    Mirrors the SPA's node in app/src/pages/SpecPage.tsx (license, author,
+    codeRepository, isBasedOn) — crawlers never execute the SPA, so a field
+    living only there is invisible to every bot. `license` in particular is
+    the one field an assistant checks before copying the code.
+
+    `image` is the actual render as an ImageObject, not the 1200x630 og card
+    the meta tags carry: in that card the plot is a thumbnail inside branding
+    chrome, and structured-data consumers were being handed the chrome while
+    the body served the real plot (AI-access audit 2026-08-19). The card
+    remains the og:image — link previews are the surface it was made for.
+    """
+    node = {
+        "@type": "SoftwareSourceCode",
+        "name": f"{spec.title} — {lib_name}",
+        "description": spec.description or DEFAULT_DESCRIPTION,
+        "programmingLanguage": lang_name,
+        "runtimePlatform": lib_name,
+        "codeSampleType": "full solution",
+        "codeRepository": "https://github.com/MarkusNeusinger/anyplot",
+        "license": "https://opensource.org/licenses/MIT",
+        "author": {"@type": "Organization", "name": "anyplot", "url": "https://anyplot.ai"},
+        "isBasedOn": hub_url,
+        "url": page_url,
+        "image": image,
+    }
+    if impl.preview_url_light:
+        node["image"] = {
+            "@type": "ImageObject",
+            "contentUrl": impl.preview_url_light,
+            "thumbnailUrl": _thumb_1200(impl.preview_url_light),
+            "encodingFormat": "image/png",
+            "caption": f"{spec.title} rendered with {lib_name}",
+            "license": "https://opensource.org/licenses/MIT",
+        }
+    if impl.updated:
+        node["dateModified"] = impl.updated.date().isoformat()
+    keywords = _spec_keywords(spec)
+    if keywords:
+        node["keywords"] = keywords
+    return node
+
+
+def _spec_keywords(spec) -> list[str]:
+    """Flatten the spec's tag bag ({plot_type, data_type, domain, features}) into a keyword list."""
+    keywords: list[str] = []
+    for values in (spec.tags or {}).values():
+        if isinstance(values, str):
+            keywords.append(values)
+        elif isinstance(values, list):
+            keywords.extend(str(v) for v in values)
+    return keywords
 
 
 def _build_impl_html(spec, impl, code: str | None, image: str) -> str:
@@ -583,16 +667,7 @@ def _build_impl_html(spec, impl, code: str | None, image: str) -> str:
                     {"@type": "ListItem", "position": 3, "name": lib_name, "item": page_url},
                 ],
             },
-            {
-                "@type": "SoftwareSourceCode",
-                "name": f"{spec.title} — {lib_name}",
-                "description": spec.description or DEFAULT_DESCRIPTION,
-                "programmingLanguage": lang_name,
-                "runtimePlatform": lib_name,
-                "codeSampleType": "full solution",
-                "url": page_url,
-                "image": image,
-            },
+            _build_source_code_node(spec, impl, lib_name, lang_name, page_url, hub_url, image),
         ],
     }
     return _render_bot_html(
@@ -609,22 +684,25 @@ def _build_impl_html(spec, impl, code: str | None, image: str) -> str:
 async def get_robots():
     """Serve robots.txt for the API backend.
 
-    The API itself should not be indexed, but `/og/` must be crawlable: every
-    prerendered page on anyplot.ai references its preview image there, and a
-    blanket Disallow made those images unreachable for anything that honours
-    robots.txt — Google Images, and the AI assistants that explicitly say they
-    comply. The image answered 200 while the host forbade fetching it, so an
-    assistant asked to show a plot could read the code and not the picture.
+    The read API is deliberately open. The previous blanket `Disallow: /`
+    (with only `/og/` excepted) told every robots-compliant agent that the
+    REST endpoints, `/openapi.json` and the MCP transport were off-limits —
+    on the very host `app/public/robots.txt` and llms.txt advertise as the
+    machine interface to the catalogue (AI-access audit 2026-08-19). The API
+    is public, read-only and cached; there is nothing to protect by
+    forbidding it, and compliant AI assistants were the only clients the
+    Disallow actually stopped.
 
-    Link-preview bots were never affected either way; they do not consult
-    robots.txt, which is why this went unnoticed.
+    Only surfaces that are useless or hazardous to crawl stay disallowed:
+    `/debug` (internal diagnostics) and `/proxy` (a parameterised fetch
+    proxy — crawling it just re-downloads GCS objects through the API).
 
-    `Allow` is placed first deliberately. A compliant crawler resolves by
-    specificity and would reach the same answer either way, but simpler
-    first-match parsers would stop at `Disallow: /` and never see the
-    exception — the same ordering rule `app/public/robots.txt` documents.
+    `Disallow` lines are placed before the `Allow: /` catch-all: first-match
+    parsers stop at the first matching rule, so the specific exclusions must
+    precede the blanket allow — the same ordering rule `app/public/robots.txt`
+    documents. Specificity-compliant crawlers reach the same answer either way.
     """
-    return Response(content="User-agent: *\nAllow: /og/\nDisallow: /\n", media_type="text/plain")
+    return Response(content="User-agent: *\nDisallow: /debug\nDisallow: /proxy\nAllow: /\n", media_type="text/plain")
 
 
 @router.get("/sitemap.xml")
@@ -646,6 +724,69 @@ async def get_sitemap(db: AsyncSession | None = Depends(optional_db)):
         cache_key("sitemap_xml"), _fetch, refresh_after=settings.cache_refresh_after, refresh_factory=_refresh_sitemap
     )
     return Response(content=xml, media_type="application/xml")
+
+
+def _build_llms_full(specs: list) -> str:
+    """Whole-catalogue index for AI agents: one line per spec, one fetch.
+
+    llms.txt names the surfaces; this is the llmstxt.org companion file that
+    makes the catalogue enumerable without walking the 400 KB sitemap or
+    fetching every hub page. The header documents the retrieval recipes that
+    work for EVERY client — the prerendered pages are user-agent-gated, these
+    URLs are not (AI-access audit 2026-08-19).
+    """
+    lines = [
+        "# anyplot — full catalogue index",
+        "#",
+        "# One line per plot specification:",
+        "# spec_id | title | hub page | implemented libraries",
+        "#",
+        "# Retrieval recipes (any HTTP client, no crawler user agent needed):",
+        "#   source code:  https://api.anyplot.ai/specs/{spec_id}/{library}/code",
+        "#   spec detail:  https://api.anyplot.ai/specs/{spec_id}",
+        "#   render (PNG): https://storage.googleapis.com/anyplot-images/plots/{spec_id}/{language}/{library}/plot-light.png",
+        "#                 dark theme: plot-dark.png; responsive widths: plot-light_400.png / _800 / _1200; WebP: plot-light.webp",
+        "#   OpenAPI: https://api.anyplot.ai/openapi.json - MCP endpoint: https://api.anyplot.ai/mcp/",
+        "",
+    ]
+    for spec in sorted((s for s in specs if s.impls), key=lambda s: s.id):
+        libraries = ",".join(sorted(i.library_id for i in spec.impls))
+        title = " ".join((spec.title or spec.id).split())
+        lines.append(f"{spec.id} | {title} | https://anyplot.ai/{spec.id} | {libraries}")
+    return "\n".join(lines) + "\n"
+
+
+async def _refresh_llms_full() -> str:
+    """Standalone factory for background llms-full refresh (creates own DB session)."""
+    async with get_db_context() as db:
+        repo = SpecRepository(db)
+        specs = await repo.get_all()
+    return _build_llms_full(specs)
+
+
+@router.get("/llms-full.txt")
+async def get_llms_full(db: AsyncSession | None = Depends(optional_db)):
+    """Serve the full catalogue index (llmstxt.org llms-full.txt convention).
+
+    nginx serves anyplot.ai/llms-full.txt from this endpoint the same way it
+    proxies the prerendered pages, so the file is reachable on the site's own
+    origin for every client.
+    """
+    if db is None:
+        return Response(content=_build_llms_full([]), media_type="text/plain; charset=utf-8")
+
+    async def _fetch() -> str:
+        repo = SpecRepository(db)
+        specs = await repo.get_all()
+        return _build_llms_full(specs)
+
+    text = await get_or_set_cache(
+        cache_key("llms_full_txt"),
+        _fetch,
+        refresh_after=settings.cache_refresh_after,
+        refresh_factory=_refresh_llms_full,
+    )
+    return Response(content=text, media_type="text/plain; charset=utf-8")
 
 
 # =============================================================================

--- a/api/routers/specs.py
+++ b/api/routers/specs.py
@@ -8,6 +8,7 @@ from api.dependencies import require_db
 from api.exceptions import raise_not_found
 from api.schemas import ImplementationResponse, SpecDetailResponse, SpecListItem, SpecMapItem
 from core.config import settings
+from core.constants import LIBRARY_LANGUAGES
 from core.database import ImplRepository, SpecRepository
 from core.database.connection import get_db_context
 from core.utils import strip_noqa_comments
@@ -204,15 +205,19 @@ async def get_spec(spec_id: str, db: AsyncSession = Depends(require_db)):
 
 
 @router.get("/specs/{spec_id}/{library}/code")
-async def get_impl_code(spec_id: str, library: str, language: str = "python", db: AsyncSession = Depends(require_db)):
-    """Get implementation code for a specific spec + library + language.
+async def get_impl_code(
+    spec_id: str, library: str, language: str | None = None, db: AsyncSession = Depends(require_db)
+):
+    """Get implementation code for a specific spec + library.
 
     Code field is deferred in the main `/specs/{id}` query so it must be
-    fetched here on-demand. `language` disambiguates when the same library_id
-    could exist for multiple languages (today ggplot2 is R and makie is Julia;
-    everything else is Python). Defaults to python for backwards compat with
-    older clients that don't send the param.
+    fetched here on-demand. Library ids are globally unique across languages
+    (core/constants.py), so the language is resolved from the registry when
+    the param is absent — the old `language="python"` default made the obvious
+    URL 404 for every R/Julia/JavaScript library. An explicit `language`
+    still wins for backwards compat with clients that send it.
     """
+    language = language or LIBRARY_LANGUAGES.get(library, "python")
 
     async def _fetch() -> dict:
         return await _build_impl_code(db, spec_id, library, language)

--- a/api/version.py
+++ b/api/version.py
@@ -1,0 +1,15 @@
+"""Single source of the running app version.
+
+The value is the installed distribution's version, i.e. pyproject.toml's
+`version` field — the one the release flow bumps. Before this module existed,
+/openapi.json said 1.0.0, /health said 0.2.0 and pyproject said 3.1.0, so no
+client could tell which build it was talking to.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+
+try:
+    APP_VERSION = version("anyplot")
+except PackageNotFoundError:  # running from a checkout without the dist installed
+    APP_VERSION = "0.0.0+unknown"

--- a/core/constants.py
+++ b/core/constants.py
@@ -265,6 +265,11 @@ LIBRARY_FILE_EXTENSION_OVERRIDES = {
 LANGUAGE_NAMES = {lang["id"]: str(lang["name"]) for lang in LANGUAGES_METADATA}
 LIBRARY_NAMES = {lib["id"]: str(lib["name"]) for lib in LIBRARIES_METADATA}
 
+# Library ids are globally unique across languages, so the language of any
+# library is derivable — callers that only know a library id (public API,
+# MCP tools) must resolve through this map instead of defaulting to python.
+LIBRARY_LANGUAGES = {lib["id"]: str(lib["language_id"]) for lib in LIBRARIES_METADATA}
+
 # Interactive libraries that generate HTML previews (not just PNG). The
 # browser-rendered JS libraries (Chart.js, D3, ECharts, Highcharts, and the
 # React MUI X entry) render in a browser; the harness emits both a static PNG

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -307,9 +307,24 @@ Returns related specs sorted by Jaccard similarity with preview thumbnails and s
 
 Returns only the code field for a single implementation. Used by the frontend to lazy-load code on demand (code is deferred in the main `/specs/{spec_id}` response).
 
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `language` | string | resolved from the library | Optional override. Library ids are globally unique, so the language is looked up in `core/constants.py` when the parameter is absent — `/specs/{id}/ggplot2/code` works without `?language=r`. |
+
 ---
 
 ## SEO endpoints
+
+### GET `/llms-full.txt`
+
+**Purpose**: Whole-catalogue index for AI agents ([llms.txt convention](https://llmstxt.org/))
+
+One line per spec (`spec_id | title | hub URL | libraries`) plus a header that
+documents the user-agent-independent retrieval recipes (code endpoint, GCS
+image URL pattern, OpenAPI, MCP). nginx serves `anyplot.ai/llms-full.txt` from
+this endpoint.
+
+---
 
 ### GET `/sitemap.xml`
 

--- a/docs/reference/seo.md
+++ b/docs/reference/seo.md
@@ -194,7 +194,7 @@ Backend endpoints that serve HTML with correct meta tags for bots.
 
 | Endpoint | Purpose | og:image |
 |----------|---------|----------|
-| `GET /seo-proxy/` | Home page | Default (`og-image.png`) |
+| `GET /seo-proxy/` | Home page | Default (`api.anyplot.ai/og/home.png`) |
 | `GET /seo-proxy/plots` | Plots page | Default |
 | `GET /seo-proxy/specs` | Specs page | Default |
 | `GET /seo-proxy/legal` | Legal page | Default |
@@ -296,7 +296,7 @@ Dynamically generated preview images with anyplot.ai branding.
 | Endpoint | Description | Dimensions |
 |----------|-------------|------------|
 | `GET /og/{spec_id}.png` | Collage of top 6 implementations | 1200x630 |
-| `GET /og/{spec_id}/{library}.png` | Single branded implementation | 1200x630 |
+| `GET /og/{spec_id}/{language}/{library}.png` | Single branded implementation | 1200x630 |
 
 ### Single implementation image
 
@@ -365,18 +365,18 @@ Dynamic endpoint at `GET /robots.txt`:
 
 ```txt
 User-agent: *
-Allow: /og/
-Disallow: /
+Disallow: /debug
+Disallow: /proxy
+Allow: /
 ```
 
-`/og/` is the exception: every prerendered page references its preview image
-there, so a blanket `Disallow` pointed crawlers at an image they were forbidden
-to fetch. `Allow` comes first for the first-match parsers described above.
-
-**Why block the API?**
-- APIs should not be indexed by search engines
-- Prevents crawling of debug endpoints, docs, and API responses
-- Social media bots (WhatsApp, Twitter, etc.) are unaffected - they fetch og:images directly
+The read API is deliberately open. The earlier blanket `Disallow: /` (with
+only `/og/` excepted) told every robots-compliant AI assistant that the REST
+endpoints, `/openapi.json` and the MCP transport were off-limits — on the very
+host `llms.txt` advertises as the machine interface to the catalogue
+(AI-access audit 2026-08-19). Only `/debug` (internal diagnostics) and
+`/proxy` (a parameterised fetch proxy) stay excluded. `Disallow` lines come
+before the `Allow: /` catch-all for the first-match parsers described above.
 
 ### AI crawler policy
 

--- a/tests/unit/api/test_main.py
+++ b/tests/unit/api/test_main.py
@@ -13,6 +13,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app, fastapi_app
+from api.version import APP_VERSION
+from core.constants import LIBRARIES_METADATA
 from core.database import get_db
 from tests.conftest import TEST_IMAGE_URL
 
@@ -86,7 +88,7 @@ class TestRootEndpoint:
 
         data = response.json()
         assert "version" in data
-        assert data["version"] == "0.2.0"
+        assert data["version"] == APP_VERSION
 
     def test_returns_docs_url(self, client: TestClient) -> None:
         """Root endpoint should return docs URL."""
@@ -131,7 +133,7 @@ class TestHealthEndpoint:
         response = client.get("/health")
 
         data = response.json()
-        assert data["version"] == "0.2.0"
+        assert data["version"] == APP_VERSION
 
 
 class TestHelloEndpoint:
@@ -237,13 +239,17 @@ class TestAppConfiguration:
         assert fastapi_app.title == "anyplot API"
 
     def test_app_version(self) -> None:
-        """App should have correct version."""
-        assert fastapi_app.version == "1.0.0"
+        """App version must be the packaged version — the one the release flow bumps."""
+        assert fastapi_app.version == APP_VERSION
 
     def test_app_description(self) -> None:
-        """App should have description."""
+        """Description derives from the registry so it can never drift again."""
         assert "anyplot" in fastapi_app.description.lower()
-        assert "plotting" in fastapi_app.description.lower()
+        assert f"{len(LIBRARIES_METADATA)} libraries" in fastapi_app.description
+
+    def test_openapi_names_its_server(self) -> None:
+        """A client handed only openapi.json needs the base URL inside it."""
+        assert {"url": "https://api.anyplot.ai", "description": "Production"} in fastapi_app.servers
 
 
 class TestSpecsEndpoint:

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -613,22 +613,43 @@ class TestSeoRouter:
     """Tests for SEO router."""
 
     def test_robots_txt(self, client: TestClient) -> None:
-        """robots.txt should block the API but expose the preview images.
+        """robots.txt must leave the read API open to compliant agents.
 
-        Every prerendered page references an image under /og/; a blanket
-        Disallow made those unfetchable for anything that honours robots.txt,
-        so an assistant could read a plot's code but not show its picture.
+        The old blanket Disallow told every robots-compliant AI assistant that
+        the REST endpoints, /openapi.json and the MCP transport were
+        off-limits — on the host llms.txt advertises as the machine interface
+        (AI-access audit 2026-08-19). Only /debug and /proxy stay excluded.
         """
         response = client.get("/robots.txt")
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/plain; charset=utf-8"
         content = response.text
         assert "User-agent: *" in content
-        assert "Disallow: /" in content
-        assert "Allow: /og/" in content
-        # Allow must come first: a first-match parser stops at Disallow: / and
-        # would never reach the exception.
-        assert content.index("Allow: /og/") < content.index("Disallow: /")
+        assert "Allow: /\n" in content
+        assert "Disallow: /debug" in content
+        assert "Disallow: /proxy" in content
+        # No blanket Disallow may survive — that was the defect.
+        assert "Disallow: /\n" not in content
+        # Specific exclusions must precede the catch-all: a first-match parser
+        # stops at Allow: / and would never reach them.
+        assert content.index("Disallow: /debug") < content.index("Allow: /")
+
+    def test_llms_full_txt_without_db(self, client: TestClient) -> None:
+        """llms-full.txt degrades to the header (retrieval recipes) without a DB."""
+        with patch(DB_CONFIG_PATCH, return_value=False):
+            response = client.get("/llms-full.txt")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/plain")
+        assert "https://api.anyplot.ai/specs/{spec_id}/{library}/code" in response.text
+
+    def test_llms_full_txt_lists_the_catalogue(self, db_client, mock_spec) -> None:
+        client, _ = db_client
+        mock_spec_repo = MagicMock()
+        mock_spec_repo.get_all = AsyncMock(return_value=[mock_spec])
+        with patch("api.routers.seo.SpecRepository", return_value=mock_spec_repo):
+            response = client.get("/llms-full.txt")
+        assert response.status_code == 200
+        assert "scatter-basic | Basic Scatter Plot | https://anyplot.ai/scatter-basic | matplotlib" in response.text
 
     def test_sitemap_structure(self, client: TestClient) -> None:
         """Sitemap should return valid XML structure."""
@@ -944,6 +965,13 @@ class TestSeoProxyRouter:
         js_impl.library = MagicMock()
         js_impl.library.language = "javascript"
         js_impl.preview_url = None
+        # Concrete values — the JSON-LD builder serializes these fields
+        js_impl.preview_url_light = None
+        js_impl.preview_url_dark = None
+        js_impl.preview_html_light = None
+        js_impl.preview_html_dark = None
+        js_impl.quality_score = None
+        js_impl.updated = None
         mock_spec.impls = [*mock_spec.impls, js_impl]
 
         mock_spec_repo = MagicMock()
@@ -989,11 +1017,19 @@ class TestSeoProxyRouter:
         mock_impl_no_preview.library_id = "seaborn"
         mock_impl_no_preview.library = mock_library
         mock_impl_no_preview.preview_url = None
+        # Concrete values — the JSON-LD builder serializes these fields
+        mock_impl_no_preview.preview_url_light = None
+        mock_impl_no_preview.preview_url_dark = None
+        mock_impl_no_preview.preview_html_light = None
+        mock_impl_no_preview.preview_html_dark = None
+        mock_impl_no_preview.quality_score = None
+        mock_impl_no_preview.updated = None
 
         mock_spec_no_preview = MagicMock()
         mock_spec_no_preview.id = "scatter-basic"
         mock_spec_no_preview.title = "Basic Scatter Plot"
         mock_spec_no_preview.description = "A basic scatter plot"
+        mock_spec_no_preview.tags = None
         mock_spec_no_preview.impls = [mock_impl_no_preview]
 
         mock_spec_repo = MagicMock()
@@ -2299,3 +2335,84 @@ class TestSpecCodeEndpoint:
             response = client.get("/specs/scatter-basic/matplotlib/code")
             assert response.status_code == 200
             assert response.json()["code"] == "cached code"
+
+    def test_code_resolves_language_from_the_library(self, client: TestClient) -> None:
+        """The obvious URL must work for every library, not only Python.
+
+        The old `language="python"` default made /specs/{id}/ggplot2/code 404
+        for all 7 non-Python libraries — 28% of the catalogue unreachable at
+        the URL an agent naturally constructs (AI-access audit 2026-08-19).
+        Library ids are globally unique, so the registry knows the language.
+        """
+        mock_impl = MagicMock()
+        mock_impl.code = "ggplot(df, aes(x, y)) + geom_point()"
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_code = AsyncMock(return_value=mock_impl)
+
+        with (
+            patch(DB_CONFIG_PATCH, return_value=True),
+            patch("api.routers.specs.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.specs.ImplRepository", return_value=mock_impl_repo),
+        ):
+            response = client.get("/specs/scatter-basic/ggplot2/code")
+            assert response.status_code == 200
+            assert response.json()["language"] == "r"
+            mock_impl_repo.get_code.assert_awaited_once_with("scatter-basic", "ggplot2", "r")
+
+    def test_code_explicit_language_param_still_wins(self, client: TestClient) -> None:
+        """Backwards compat: clients that send ?language= keep their behavior."""
+        mock_impl = MagicMock()
+        mock_impl.code = "code"
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_code = AsyncMock(return_value=mock_impl)
+
+        with (
+            patch(DB_CONFIG_PATCH, return_value=True),
+            patch("api.routers.specs.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.specs.ImplRepository", return_value=mock_impl_repo),
+        ):
+            response = client.get("/specs/scatter-basic/ggplot2/code?language=python")
+            assert response.status_code == 200
+            assert response.json()["language"] == "python"
+            mock_impl_repo.get_code.assert_awaited_once_with("scatter-basic", "ggplot2", "python")
+
+    def test_code_unknown_library_falls_back_to_python(self, client: TestClient) -> None:
+        """A library id outside the registry resolves to python and 404s cleanly."""
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_code = AsyncMock(return_value=None)
+
+        with (
+            patch(DB_CONFIG_PATCH, return_value=True),
+            patch("api.routers.specs.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.specs.ImplRepository", return_value=mock_impl_repo),
+        ):
+            response = client.get("/specs/scatter-basic/no-such-lib/code")
+            assert response.status_code == 404
+
+
+class TestHeadRequests:
+    """HEAD must answer like GET without a body (served by HeadAsGetMiddleware).
+
+    FastAPI's @router.get registers GET-only routes, so every HEAD probe —
+    link checkers, agents preflighting a page before fetching it — answered
+    405 across the whole API, including /health and the seo-proxy pages
+    (AI-access audit 2026-08-19).
+    """
+
+    def test_head_health_answers_200_with_empty_body(self, client: TestClient) -> None:
+        response = client.head("/health")
+        assert response.status_code == 200
+        assert response.text == ""
+
+    def test_head_matches_get_headers(self, client: TestClient) -> None:
+        head = client.head("/robots.txt")
+        get = client.get("/robots.txt")
+        assert head.status_code == 200
+        assert head.headers["content-type"] == get.headers["content-type"]
+        assert head.text == ""
+
+    def test_head_on_a_seo_proxy_page(self, client: TestClient) -> None:
+        with patch(DB_CONFIG_PATCH, return_value=False):
+            response = client.head("/seo-proxy/")
+        assert response.status_code == 200
+        assert response.text == ""

--- a/tests/unit/api/test_seo_helpers.py
+++ b/tests/unit/api/test_seo_helpers.py
@@ -15,6 +15,7 @@ from api.routers.seo import (
     TEMPLATE_LAST_CHANGED,
     _build_home_body,
     _build_impl_html,
+    _build_llms_full,
     _build_sitemap_xml,
     _build_spec_hub_html,
     _jsonld_script,
@@ -43,6 +44,14 @@ def _mock_impl(library_id: str, language: str, preview: str | None = "https://gc
     impl.library = MagicMock()
     impl.library.language = language
     impl.preview_url = preview
+    # Concrete values — the JSON-LD builder serializes these, and a MagicMock
+    # auto-attribute is neither JSON-serializable nor orderable.
+    impl.preview_url_light = preview
+    impl.preview_url_dark = None
+    impl.preview_html_light = None
+    impl.preview_html_dark = None
+    impl.quality_score = 90.0
+    impl.updated = None
     return impl
 
 
@@ -51,6 +60,7 @@ def _mock_spec(impls: list) -> MagicMock:
     spec.id = "scatter-basic"
     spec.title = "Basic Scatter Plot"
     spec.description = "Points on <axes> & friends"
+    spec.tags = {"plot_type": "scatter", "features": ["error-bars"]}
     spec.impls = impls
     return spec
 
@@ -282,6 +292,15 @@ class TestRenderBotHtml:
         result = _render_bot_html(title="t", description="d", image="i", url="u")
         assert "application/ld+json" not in result
 
+    def test_indexable_pages_ask_for_large_image_previews(self) -> None:
+        result = _render_bot_html(title="t", description="d", image="i", url="u")
+        assert '<meta name="robots" content="max-image-preview:large" />' in result
+
+    def test_noindex_replaces_the_robots_content(self) -> None:
+        result = _render_bot_html(title="t", description="d", image="i", url="u", noindex=True)
+        assert '<meta name="robots" content="noindex" />' in result
+        assert "max-image-preview" not in result
+
 
 class TestJsonldScript:
     """Tests for _jsonld_script."""
@@ -315,8 +334,14 @@ class TestBuildSpecHubHtml:
         # display names from core.constants, not raw ids
         assert "in Matplotlib (Python)" in page
         assert "in ggplot2 (R)" in page
-        # preview image in the body
-        assert '<img src="https://api.anyplot.ai/og/scatter-basic.png"' in page
+        # the body shows the best actual render, not the og collage card —
+        # the hub was the one page type where a machine could enumerate every
+        # implementation link yet not reach a single plot image
+        assert '<img src="https://gcs/preview_1200.png"' in page
+        assert "Preview render from the Matplotlib implementation." in page
+        assert '<img src="https://api.anyplot.ai/og/scatter-basic.png"' not in page
+        # the collage card stays the social preview
+        assert '<meta property="og:image" content="https://api.anyplot.ai/og/scatter-basic.png" />' in page
         # description is escaped
         assert "&lt;axes&gt; &amp; friends" in page
 
@@ -329,6 +354,15 @@ class TestBuildSpecHubHtml:
             "https://anyplot.ai/scatter-basic/python/matplotlib",
             "https://anyplot.ai/scatter-basic/r/ggplot2",
         ]
+        # per-item render URLs: one hub fetch enumerates every plot image
+        assert [i["image"] for i in item_list["itemListElement"]] == ["https://gcs/preview.png"] * 2
+
+    def test_hub_without_previews_falls_back_to_card(self) -> None:
+        spec = _mock_spec([_mock_impl("matplotlib", "python", preview=None)])
+        page = _build_spec_hub_html(spec, "https://api.anyplot.ai/og/scatter-basic.png")
+        assert '<img src="https://api.anyplot.ai/og/scatter-basic.png"' in page
+        item_list = _extract_jsonld(page)["@graph"][1]
+        assert "image" not in item_list["itemListElement"][0]
 
 
 class TestBuildImplHtml:
@@ -358,12 +392,56 @@ class TestBuildImplHtml:
         assert source["@type"] == "SoftwareSourceCode"
         assert source["programmingLanguage"] == "Python"
         assert source["url"] == "https://anyplot.ai/scatter-basic/python/matplotlib"
+        # fields an assistant checks before reusing the code — these lived only
+        # in the SPA's JSON-LD, which no crawler executes
+        assert source["license"] == "https://opensource.org/licenses/MIT"
+        assert source["codeRepository"] == "https://github.com/MarkusNeusinger/anyplot"
+        assert source["isBasedOn"] == "https://anyplot.ai/scatter-basic"
+        # tag bag flattens into keywords (string and list values alike)
+        assert source["keywords"] == ["scatter", "error-bars"]
+
+    def test_jsonld_image_is_the_render_not_the_card(self) -> None:
+        source = _extract_jsonld(self._page())["@graph"][1]
+        image = source["image"]
+        assert image["@type"] == "ImageObject"
+        assert image["contentUrl"] == "https://gcs/preview.png"
+        assert image["thumbnailUrl"] == "https://gcs/preview_1200.png"
+
+    def test_jsonld_without_render_keeps_card_image(self) -> None:
+        impl = _mock_impl("matplotlib", "python", preview=None)
+        spec = _mock_spec([impl])
+        page = _build_impl_html(spec, impl, "code()", "https://api.anyplot.ai/og/card.png")
+        source = _extract_jsonld(page)["@graph"][1]
+        assert source["image"] == "https://api.anyplot.ai/og/card.png"
 
     def test_no_code_no_pre_block(self) -> None:
         page = self._page(code=None)
         assert "<pre>" not in page
         # page is still enriched otherwise
         assert '<a href="https://anyplot.ai/scatter-basic">' in page
+
+
+class TestBuildLlmsFull:
+    """Tests for the llms-full.txt catalogue index."""
+
+    def test_one_line_per_spec_with_sorted_libraries(self) -> None:
+        spec = _mock_spec([_mock_impl("seaborn", "python"), _mock_impl("ggplot2", "r")])
+        text = _build_llms_full([spec])
+        assert "scatter-basic | Basic Scatter Plot | https://anyplot.ai/scatter-basic | ggplot2,seaborn" in text
+
+    def test_specs_without_impls_are_skipped(self) -> None:
+        empty = _mock_spec([])
+        empty.id = "unpublished"
+        text = _build_llms_full([empty, _mock_spec([_mock_impl("matplotlib", "python")])])
+        assert "unpublished" not in text
+        assert "scatter-basic" in text
+
+    def test_header_documents_ua_independent_retrieval(self) -> None:
+        """The header is the point: recipes that work without a crawler UA."""
+        text = _build_llms_full([])
+        assert "https://api.anyplot.ai/specs/{spec_id}/{library}/code" in text
+        assert "https://storage.googleapis.com/anyplot-images/plots/" in text
+        assert "https://api.anyplot.ai/openapi.json" in text
 
 
 class TestSpecIndex:
@@ -554,6 +632,7 @@ class TestRenderAssetList:
         impl.preview_url_dark = f"{self.BASE}/plot-dark.png"
         impl.preview_html_light = f"{self.BASE}/plot-light.html" if interactive else None
         impl.preview_html_dark = f"{self.BASE}/plot-dark.html" if interactive else None
+        impl.updated = None  # serialized into JSON-LD — must not be a MagicMock
         return impl
 
     def test_names_both_themes_explicitly(self) -> None:

--- a/tests/unit/api/test_seo_helpers.py
+++ b/tests/unit/api/test_seo_helpers.py
@@ -400,6 +400,18 @@ class TestBuildImplHtml:
         # tag bag flattens into keywords (string and list values alike)
         assert source["keywords"] == ["scatter", "error-bars"]
 
+    def test_jsonld_keywords_are_deterministic_and_deduplicated(self) -> None:
+        """Insertion order of the stored JSON must not leak into the output."""
+        impl = _mock_impl("matplotlib", "python")
+        spec = _mock_spec([impl])
+        # Deliberately scrambled insertion order + a duplicate across categories
+        spec.tags = {"features": ["basic", "scatter"], "domain": ["statistics"], "plot_type": "scatter"}
+        page = _build_impl_html(spec, impl, "code()", "https://api.anyplot.ai/og/card.png")
+        source = _extract_jsonld(page)["@graph"][1]
+        # Canonical category order (plot_type before domain before features),
+        # duplicate "scatter" kept only at its first canonical position
+        assert source["keywords"] == ["scatter", "statistics", "basic"]
+
     def test_jsonld_image_is_the_render_not_the_card(self) -> None:
         source = _extract_jsonld(self._page())["@graph"][1]
         image = source["image"]


### PR DESCRIPTION
## Summary
- Opens the read API to robots-compliant agents: `api.anyplot.ai/robots.txt` no longer serves a blanket `Disallow: /` — only `/debug` and `/proxy` stay excluded. The old policy forbade the REST endpoints, `openapi.json` and the MCP transport on the very host `llms.txt` advertises as the machine interface (AI-access audit 2026-08-19).
- Fixes the language trap: `/specs/{id}/{library}/code` resolved `language=python` by default, 404ing all 7 R/Julia/JS libraries (28% of the catalogue, 1,004 implementations) at the obvious URL. The language now derives from the library registry (`core/constants.py`, new `LIBRARY_LANGUAGES`); an explicit `?language=` still wins. The equivalent MCP-side fix lands in the upcoming dedicated MCP PR.
- Enriches the machine-facing pages: implementation JSON-LD now carries the real render as an `ImageObject` (not the 1200×630 og card) plus `license`/`codeRepository`/`dateModified`/`keywords`/`author`/`isBasedOn`; spec-hub bot pages show the best-quality real render with the full asset list instead of the og collage; second-tier meta added (`robots max-image-preview:large`, `og:locale`, `og:image` dims/alt, `twitter:site`/`creator`).
- Adds `GET /llms-full.txt`: one line per spec (id, title, hub URL, libraries) under a header documenting the UA-independent retrieval recipes (code endpoint, GCS render URL pattern, OpenAPI, MCP). The nginx mapping for `anyplot.ai/llms-full.txt` follows in the app-side PR — merge this one first.
- Answers HEAD like GET via an ASGI middleware (was: 405 on every route, including `/health` and the seo-proxy pages) without doubling the openapi surface, and unifies version identity: `openapi.json` (was 1.0.0, "9 libraries") and `/health` (was 0.2.0) now report the packaged version with a registry-derived description and a `servers` block.

## Plan
Fix order approved from the 2026-08-19 AI-access audit (5-agent live audit of anyplot.ai / api.anyplot.ai / GCS): this PR is steps 2, 3 (REST half), and 6, plus the api-side half of step 4. Bucket CORS (step 1) is already applied and verified live. App-side steps (llms.txt content, nginx UA map, noscript) follow in a separate PR; the MCP overhaul is a dedicated follow-up.

## Test plan
- [x] `ruff check` + `ruff format --check` clean; `mypy api core` clean
- [x] 1,677 unit + 67 integration tests pass (new tests: robots policy, language resolution incl. override + unknown-library fallback, HEAD semantics, llms-full builder/endpoint, JSON-LD ImageObject/license, hub render + fallback, robots-meta content)
- [x] Live smoke against a local server on the shared DB: `/health` reports 3.1.0, `HEAD /health` 200, new robots.txt served, `/llms-full.txt` lists all 324 specs, `/specs/acf-pacf/{ggplot2,makie}/code` 200 without `?language=`, hub page shows the seaborn render, impl JSON-LD carries ImageObject + MIT license
- [ ] After merge: Cloud Build deploy green, then re-verify the same URLs against api.anyplot.ai