### PR TITLE
fix(insights): ship both theme variants for top-rated previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `/insights/dashboard` never shipped one: its `TopImpl` response model carried only the
   legacy `preview_url` (a synonym for the light render), so the top-rated grid showed
   light-styled plots on a dark page. The model now carries `preview_url_light` and
-  `preview_url_dark`, like every other themed payload in the router (#10537).
+  `preview_url_dark`, like every other themed payload in the router (#10536).
 - **The MCP server now tells the truth for the whole catalogue** — `get_implementation`
   called the repository without a language, whose `python` default made all 1,004
   R/Julia/JavaScript implementations (28% of the catalogue) answer a false "not found";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **Top-rated thumbnails follow the theme** — the stats page picks a preview per theme, but
+  `/insights/dashboard` never shipped one: its `TopImpl` response model carried only the
+  legacy `preview_url` (a synonym for the light render), so the top-rated grid showed
+  light-styled plots on a dark page. The model now carries `preview_url_light` and
+  `preview_url_dark`, like every other themed payload in the router (#10537).
 - **The MCP server now tells the truth for the whole catalogue** — `get_implementation`
   called the repository without a language, whose `python` default made all 1,004
   R/Julia/JavaScript implementations (28% of the catalogue) answer a false "not found";

--- a/api/routers/insights.py
+++ b/api/routers/insights.py
@@ -78,7 +78,13 @@ class TopImpl(BaseModel):
     library_id: str
     language: str
     quality_score: float
+    # `preview_url` is the legacy single-theme field (a synonym for the light
+    # variant). The stats page picks a thumbnail per theme, so both variants
+    # have to travel with the payload — without `preview_url_dark` the grid
+    # falls back to the light render on a dark page.
     preview_url: str | None = None
+    preview_url_light: str | None = None
+    preview_url_dark: str | None = None
 
 
 class TimelinePoint(BaseModel):
@@ -290,6 +296,8 @@ async def _build_dashboard(repo: SpecRepository, impl_repo: ImplRepository) -> D
                             language=impl.library.language if impl.library else "python",
                             quality_score=score,
                             preview_url=impl.preview_url,
+                            preview_url_light=impl.preview_url_light,
+                            preview_url_dark=impl.preview_url_dark,
                         )
                     )
 

--- a/app/src/pages/StatsPage.test.tsx
+++ b/app/src/pages/StatsPage.test.tsx
@@ -1,7 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ThemeContext, type ThemeContextValue } from 'src/hooks/useLayoutContext';
 import { StatsPage } from 'src/pages/StatsPage';
 import { render, screen, userEvent, waitFor } from 'src/test-utils';
+
+const darkThemeValue: ThemeContextValue = {
+  mode: 'dark',
+  effective: 'dark',
+  isDark: true,
+  setMode: vi.fn(),
+  cycle: vi.fn(),
+};
 
 vi.mock('react-helmet-async', () => ({
   Helmet: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -78,7 +87,9 @@ const mockDashboard = {
       library_id: 'matplotlib',
       language: 'python',
       quality_score: 95,
-      preview_url: 'https://example.com/img.png',
+      preview_url: 'https://example.com/img-light.png',
+      preview_url_light: 'https://example.com/img-light.png',
+      preview_url_dark: 'https://example.com/img-dark.png',
     },
   ],
   tag_distribution: {
@@ -230,6 +241,36 @@ describe('StatsPage', () => {
     // "matplotlib" appears in library stats and in top implementation cards
     expect(screen.getAllByText('matplotlib').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('95')).toBeInTheDocument();
+  });
+
+  it('shows the theme-matching top-rated thumbnail in light and in dark mode', async () => {
+    mockFetchSuccess();
+
+    const { unmount } = render(<StatsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Basic Scatter Plot')).toBeInTheDocument();
+    });
+    expect(screen.getByAltText('Basic Scatter Plot')).toHaveAttribute(
+      'src',
+      'https://example.com/img-light_800.png'
+    );
+    unmount();
+
+    mockFetchSuccess();
+    render(
+      <ThemeContext.Provider value={darkThemeValue}>
+        <StatsPage />
+      </ThemeContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Basic Scatter Plot')).toBeInTheDocument();
+    });
+    expect(screen.getByAltText('Basic Scatter Plot')).toHaveAttribute(
+      'src',
+      'https://example.com/img-dark_800.png'
+    );
   });
 
   it('shortens echarts/muix library labels and falls back to name for others', async () => {

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -2049,6 +2049,30 @@ class TestInsightsRouter:
             assert isinstance(data["score_distribution"], dict)
             assert isinstance(data["tag_distribution"], dict)
 
+    def test_dashboard_top_implementations_carry_themed_previews(self, client: TestClient, mock_spec) -> None:
+        """Top-rated entries must ship both theme variants so the stats grid can follow the theme."""
+        dark_url = "https://example.com/plot-dark.png"
+        mock_spec.impls[0].quality_score = 97.0  # Above the top-rated threshold
+        mock_spec.impls[0].preview_url_dark = dark_url
+        mock_spec_repo = MagicMock()
+        mock_spec_repo.get_all = AsyncMock(return_value=[mock_spec])
+        mock_impl_repo = MagicMock()
+        mock_impl_repo.get_total_code_lines = AsyncMock(return_value=500)
+        mock_impl_repo.get_loc_per_impl = AsyncMock(return_value=[("matplotlib", 50)])
+
+        with (
+            patch(DB_CONFIG_PATCH, return_value=True),
+            patch("api.routers.insights.get_or_set_cache", side_effect=_passthrough_cache),
+            patch("api.routers.insights.SpecRepository", return_value=mock_spec_repo),
+            patch("api.routers.insights.ImplRepository", return_value=mock_impl_repo),
+        ):
+            response = client.get("/insights/dashboard")
+            assert response.status_code == 200
+            top = response.json()["top_implementations"]
+            assert len(top) == 1
+            assert top[0]["preview_url_light"] == TEST_IMAGE_URL
+            assert top[0]["preview_url_dark"] == dark_url
+
     def test_potd_without_db(self, client: TestClient) -> None:
         """Plot of the day should return 503 when DB not configured."""
         with patch(DB_CONFIG_PATCH, return_value=False):


### PR DESCRIPTION
Fixes a bug reported on `/stats`: *"die Top rated halten sich nicht an light oder dark style"* — the top-rated thumbnails ignore the light/dark theme.

## Summary

- **Root cause:** `/insights/dashboard`'s `TopImpl` response model carried only the legacy `preview_url`, which is a SQLAlchemy synonym for `preview_url_light`. The stats page picks a thumbnail per theme via `selectPreviewUrl(impl, isDark)`, but with no `preview_url_dark` in the payload that helper falls through to the legacy field — so the grid rendered light-styled plots on a dark page. `TopImpl` was the last outlier in the router; plot-of-the-day and related-specs already ship both variants, and the frontend's `TopImpl` interface already declared the fields it never received.
- **Fix:** `TopImpl` now carries `preview_url_light` and `preview_url_dark`, populated from the implementation row. Two fields on an already-eager-loaded relationship — no extra query, no frontend change needed.
- **No asset work required:** the dark renders and their responsive variants are already in GCS (verified `plot-dark_800.png`, `plot-dark_400.webp`, `plot-dark_1200.webp` → 200).

## Test plan

- [x] **Reproduced against production** — `GET https://anyplot.ai/api/insights/dashboard` returns `top_implementations` entries with `preview_url` only, pointing at `plot-light.png`; the same implementations expose a `preview_url_dark` through `/api/specs/{id}`.
- [x] **End-to-end in the real page** — replayed the live payload (before / after the fix) through a local stub API and drove `/stats` in Chromium with the theme forced. Before: dark theme requested `.../plot-light_800.png`. After: `.../plot-dark_800.png`. Light theme unchanged in both runs.
- [x] **Backend regression test** — `test_dashboard_top_implementations_carry_themed_previews` asserts both variants survive into the payload; confirmed it fails without the model change.
- [x] **Frontend regression test** — `StatsPage.test.tsx` now renders the grid in light and in dark context and asserts the matching thumbnail `src`; the fixture was updated to the real payload shape.
- [x] `/verify-api` + `/verify-core`: `pytest tests/unit` (1688 passed), `ruff check`, `ruff format --check`, `mypy`.
- [x] `/verify-frontend`: `yarn test` (618 passed), `yarn lint`, `yarn type-check`, `yarn fm:check`.

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]` → `### Fixed`
- [x] Related documentation updated if behavior changed — n/a: no documented behavior, event, or workflow changes; this restores the theme-aware preview contract already described for the other endpoints.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJzPKcxY4ErCLG16BkPmff)_