### PR TITLE
fix(seo): add recommended licensing fields to ImageObject JSON-LD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **Image structured data carries the licensing fields Google recommends** — Search
+  Console flagged every implementation page's `ImageObject` for missing `creator`,
+  `copyrightNotice`, `creditText`, and `acquireLicensePage`. The bot-page JSON-LD now
+  ships all four (creator/credit: anyplot; MIT copyright notice; `/legal` as the
+  license page), completing the image-metadata rich result beside the existing
+  `license` field.
 - **Top-rated thumbnails follow the theme** — the stats page picks a preview per theme, but
   `/insights/dashboard` never shipped one: its `TopImpl` response model carried only the
   legacy `preview_url` (a synonym for the light render), so the top-rated grid showed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `copyrightNotice`, `creditText`, and `acquireLicensePage`. The bot-page JSON-LD now
   ships all four (creator/credit: anyplot; MIT copyright notice; `/legal` as the
   license page), completing the image-metadata rich result beside the existing
-  `license` field.
+  `license` field (#10537).
 - **Top-rated thumbnails follow the theme** — the stats page picks a preview per theme, but
   `/insights/dashboard` never shipped one: its `TopImpl` response model carried only the
   legacy `preview_url` (a synonym for the light render), so the top-rated grid showed

--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -583,6 +583,13 @@ def _build_source_code_node(spec, impl, lib_name: str, lang_name: str, page_url:
             "encodingFormat": "image/png",
             "caption": f"{spec.title} rendered with {lib_name}",
             "license": "https://opensource.org/licenses/MIT",
+            # Google's image-metadata rich result recommends these four beside
+            # `license`; Search Console flags each absence per page. /legal is
+            # the page that states the MIT terms the renders are offered under.
+            "acquireLicensePage": "https://anyplot.ai/legal",
+            "creator": {"@type": "Organization", "name": "anyplot", "url": "https://anyplot.ai"},
+            "creditText": "anyplot.ai",
+            "copyrightNotice": "© anyplot.ai — MIT License",
         }
     if impl.updated:
         node["dateModified"] = impl.updated.date().isoformat()

--- a/tests/unit/api/test_seo_helpers.py
+++ b/tests/unit/api/test_seo_helpers.py
@@ -420,6 +420,16 @@ class TestBuildImplHtml:
         assert image["contentUrl"] == "https://gcs/preview.png"
         assert image["thumbnailUrl"] == "https://gcs/preview_1200.png"
 
+    def test_jsonld_image_carries_licensing_metadata(self) -> None:
+        """Google's image-metadata rich result recommends these beside `license`;
+        Search Console flags each missing one per page (2026-08 notice)."""
+        image = _extract_jsonld(self._page())["@graph"][1]["image"]
+        assert image["license"] == "https://opensource.org/licenses/MIT"
+        assert image["acquireLicensePage"] == "https://anyplot.ai/legal"
+        assert image["creator"] == {"@type": "Organization", "name": "anyplot", "url": "https://anyplot.ai"}
+        assert image["creditText"] == "anyplot.ai"
+        assert image["copyrightNotice"] == "© anyplot.ai — MIT License"
+
     def test_jsonld_without_render_keeps_card_image(self) -> None:
         impl = _mock_impl("matplotlib", "python", preview=None)
         spec = _mock_spec([impl])


### PR DESCRIPTION
Fixes the 4 Image Metadata structured data issues Search Console reported for anyplot.ai (missing `creator`, `copyrightNotice`, `creditText`, `acquireLicensePage`).

## Summary

- The flagged markup is the `ImageObject` inside the `SoftwareSourceCode` JSON-LD that `api/routers/seo.py` renders on every bot-facing implementation page (the only `ImageObject` the site emits — the four Search Console issues map one-to-one to its four missing recommended fields).
- The node now carries all four beside the existing `license`: `creator` (the same anyplot Organization node the graph already uses for `author`), `creditText` (`anyplot.ai`), `copyrightNotice` (`© anyplot.ai — MIT License`), and `acquireLicensePage` pointing to `https://anyplot.ai/legal`, the page that states the MIT terms the renders are offered under.
- Added a regression test asserting the licensing fields on the JSON-LD image node.

## Test plan

- [x] `/verify-core` gates on the touched files: `pytest tests/unit/api/test_seo_helpers.py` (62 passed, including the new `test_jsonld_image_carries_licensing_metadata`), `ruff check`, `ruff format --check`, `mypy api/routers/seo.py` — all clean.
- [x] After deploy: validate an implementation page (e.g. `/scatter-basic/python/matplotlib`) with Google's Rich Results Test as a bot user agent, then use "Validate fix" in Search Console.

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]` → `### Fixed`
- [ ] Related documentation updated — n/a: no documented behavior, event, or workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzepMnRdGbhmH7kdUyMukG)_