### PR TITLE
fix(watchdog): skip cron-liveness rescue when daily-regen is disabled

### DIFF
--- a/.github/workflows/watchdog-stuck-jobs.yml
+++ b/.github/workflows/watchdog-stuck-jobs.yml
@@ -312,7 +312,16 @@ jobs:
           # CEST and sits an hour earlier in local terms under CET.
           LIVENESS_HOURS=10
           HOUR=$(date -u +%-H)
-          if (( HOUR >= 17 && HOUR <= 21 )); then
+          # A manually disabled daily-regen is a deliberate pause (e.g. while a
+          # sequential backfill owns the rate limit), not a starved schedule:
+          # its cron does not tick at all, so the gap grows without bound, and
+          # `gh workflow run` on a disabled workflow fails with HTTP 422 — which
+          # under `set -e` takes the whole scan down after A and B already ran.
+          REGEN_STATE=$(gh api "repos/${GH_REPO}/actions/workflows/daily-regen.yml" \
+            --jq '.state' 2>/dev/null || echo unknown)
+          if [[ "$REGEN_STATE" != "active" ]]; then
+            echo "::notice::daily-regen liveness: workflow state is '${REGEN_STATE}', not active — rescue skipped"
+          elif (( HOUR >= 17 && HOUR <= 21 )); then
             echo "::notice::daily-regen liveness: inside/adjacent to quiet window (UTC hour $HOUR) — check skipped"
           else
             # --branch main: schedule runs (and rescue dispatches) live on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **A disabled `daily-regen` no longer fails every watchdog scan** — the watchdog's
+  cron-liveness rescue read the growing silence of a manually disabled schedule as
+  starvation and tried to dispatch it; GitHub answers `workflow_dispatch` on a disabled
+  workflow with HTTP 422, so the scan step died under `set -e` after sections A and B had
+  already run, and the run reported failure. The rescue now checks the workflow's state
+  first and skips with a notice when it is not `active` (#10540).
 - **Image structured data carries the licensing fields Google recommends** — Search
   Console flagged every implementation page's `ImageObject` for missing `creator`,
   `copyrightNotice`, `creditText`, and `acquireLicensePage`. The bot-page JSON-LD now


### PR DESCRIPTION
## Problem

`Watchdog: scan (cron)` has been failing on 4 of its last 6 runs (2026-08-22 → 2026-08-24). The failure is always the last thing the step does:

```
##[warning]daily-regen: no new run on main for 133h49m (> 10h) — schedule starved, re-dispatching
##[notice]daily-regen: cron starved (133h49m silent) → dispatching
could not create workflow dispatch event: HTTP 422: Cannot trigger a 'workflow_dispatch' on a disabled workflow
##[error]Process completed with exit code 1.
```

`daily-regen.yml` is currently `disabled_manually`. A disabled workflow has exactly the signature the section C liveness check looks for — its cron never ticks, so the gap grows without bound — but dispatching it is impossible, and the resulting non-zero `gh` exit kills the step under `set -euo pipefail`. Sections A and B had already completed their scans by then, so the actual watchdog work happened and was then reported as a failed run.

## Fix

Read the workflow's state before attempting the rescue and skip with a notice unless it is `active`:

```bash
REGEN_STATE=$(gh api "repos/${GH_REPO}/actions/workflows/daily-regen.yml" --jq '.state' 2>/dev/null || echo unknown)
if [[ "$REGEN_STATE" != "active" ]]; then
  echo "::notice::daily-regen liveness: workflow state is '${REGEN_STATE}', not active — rescue skipped"
elif (( HOUR >= 17 && HOUR <= 21 )); then
  ...
```

A deliberate pause stays paused; genuine scheduler starvation on an active workflow is still rescued exactly as before. The `|| echo unknown` fallback means an API hiccup also skips the rescue rather than failing the scan.

## Verification

- `yaml.safe_load` parses the workflow.
- The step's `run:` block extracted and checked with `bash -n`.
- Behaviour is only observable on real scheduled runs (this is one of the documented no-verification-loop areas in CLAUDE.md), so the change is deliberately minimal: one state read, one `if` → `elif`.

## Note for the reviewer

Whether `daily-regen` should be re-enabled is a separate, human decision — this PR only stops the watchdog from crashing on the answer being "no".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbZuWNDFy7kjXh9kLfA4dP