### PR TITLE
fix(impl-generate): scope the retry cap to the current campaign

### DIFF
--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -1075,11 +1075,13 @@ jobs:
             if [ "$FAILURE_COUNT" -eq 999 ]; then
               CAP_REASON="the failure counter could not be read (failed closed — auto-retry disabled)"
             else
-              # State the counted failures, not a flat "3 attempts": this run
-              # made ONE attempt, and reading the old wording as "tried three
-              # times, must be a real capability gap" is exactly how genuinely
+              # State the real total, not a flat "3 attempts": a pair capped by
+              # stale history had ONE attempt today, and reading the old wording
+              # as "tried three times, must be a capability gap" is exactly how
               # recoverable pairs got written off (2026-08-24).
-              CAP_REASON="${FAILURE_COUNT} failed attempt(s) in the last ${CAMPAIGN_WINDOW_H}h (cap: 3 per campaign)"
+              # ATTEMPT, not FAILURE_COUNT: the latter excludes the failure being
+              # handled right now, so at the cap it would under-report by one.
+              CAP_REASON="${ATTEMPT} failed attempt(s) in the last ${CAMPAIGN_WINDOW_H}h (cap: 3 per campaign)"
             fi
             echo "::warning::Marking $LIBRARY as failed: $CAP_REASON"
 

--- a/.github/workflows/impl-generate.yml
+++ b/.github/workflows/impl-generate.yml
@@ -1016,6 +1016,11 @@ jobs:
           # Pass via env (not template-interpolated into the script) so hints
           # containing quotes / $ / backticks can't break shell parsing.
           CHANGE_REQUEST: ${{ inputs.change_request }}
+          # How far back a failure marker still counts toward the 3-attempt cap.
+          # Covers a whole campaign (a generate→review→repair→merge cycle runs
+          # well under an hour) with room for a stalled tail, without letting
+          # last month's failures veto today's retries.
+          CAMPAIGN_WINDOW_H: '12'
         run: |
           echo "::notice::Handling generation failure for $LIBRARY/$SPEC_ID"
 
@@ -1035,11 +1040,25 @@ jobs:
           # (the old code broke on issues with >100 comments for this reason).
           # pipefail (Actions bash default) makes a gh failure fail the whole
           # pipeline, so the fail-closed else-branch still triggers.
+          #
+          # CAMPAIGN-SCOPED: only markers younger than CAMPAIGN_WINDOW_H count.
+          # The markers are the permanent audit trail — nothing deletes them —
+          # so counting all of them made the "3 attempts" cap per-issue-lifetime
+          # instead of per-generation-run. Any (spec, library) pair that ever
+          # failed twice then got exactly ONE attempt on every future dispatch,
+          # and a single hit of the ~9%/run "agent reports success but writes no
+          # file" flake parked it under `impl:<lib>:failed`, which nothing
+          # retries (the watchdog reports it as "needs manual attention").
+          # Measured 2026-08-24: counts of 3 and 4 on pairs that then succeeded
+          # on the very next manual dispatch, and 87 pairs parked repo-wide.
+          # A generation campaign is minutes long, so a window of hours is
+          # generous while still letting stale history age out on its own.
           MARKER="<!-- impl-fail:${SPEC_ID}:${LIBRARY} -->"
+          CAMPAIGN_CUTOFF=$(date -u -d "${CAMPAIGN_WINDOW_H} hours ago" +%Y-%m-%dT%H:%M:%SZ)
           if FAILURE_COUNT=$(gh api --paginate "repos/${{ github.repository }}/issues/${ISSUE}/comments?per_page=100" \
-            --jq "[.[] | select(.body != null and (.body | contains(\"$MARKER\")))] | length" \
+            --jq "[.[] | select(.body != null and (.body | contains(\"$MARKER\")) and .created_at > \"$CAMPAIGN_CUTOFF\")] | length" \
             | awk '{ sum += $1 } END { print sum + 0 }'); then
-            echo "::notice::Previous failures for ${LIBRARY}/${SPEC_ID}: $FAILURE_COUNT"
+            echo "::notice::Previous failures for ${LIBRARY}/${SPEC_ID} since ${CAMPAIGN_CUTOFF}: $FAILURE_COUNT"
           else
             echo "::warning::Failure-count API call failed — failing closed (treating retry cap as reached, no auto-retry)"
             FAILURE_COUNT=999
@@ -1056,7 +1075,11 @@ jobs:
             if [ "$FAILURE_COUNT" -eq 999 ]; then
               CAP_REASON="the failure counter could not be read (failed closed — auto-retry disabled)"
             else
-              CAP_REASON="3 generation attempts"
+              # State the counted failures, not a flat "3 attempts": this run
+              # made ONE attempt, and reading the old wording as "tried three
+              # times, must be a real capability gap" is exactly how genuinely
+              # recoverable pairs got written off (2026-08-24).
+              CAP_REASON="${FAILURE_COUNT} failed attempt(s) in the last ${CAMPAIGN_WINDOW_H}h (cap: 3 per campaign)"
             fi
             echo "::warning::Marking $LIBRARY as failed: $CAP_REASON"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,22 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The generation retry cap counted a library's entire failure history, not the current
+  run** — `impl-generate.yml` derives its "3 attempts" budget from hidden marker comments
+  on the spec issue, and nothing ever deletes those markers. A `(spec, library)` pair that
+  failed twice at any point in the past was therefore capped forever: every later dispatch
+  got a single attempt, and one hit of the intermittent "agent reports success but writes
+  no implementation file" failure (8 of 85 generate runs on 2026-08-24) parked it under
+  `impl:<library>:failed`, which nothing retries — the watchdog only reports it as needing
+  manual attention. Repo-wide that state had accumulated on **87 `(spec, library)` pairs**.
+  Marker counting is now scoped to a 12-hour campaign window, so stale history ages out and
+  a fresh dispatch gets its full three attempts. The fail-closed behaviour on an unreadable
+  counter (issue #1010: ~1,200 runs in 38 h) is untouched (#10554).
+- **A failed library no longer claims three attempts it never made** — the cap message read
+  `Marking <lib> as failed: 3 generation attempts` even when the run made exactly one, which
+  reads as "tried repeatedly, must be a genuine capability gap". It now names the counted
+  failures and the window. Three pairs written off under the old wording on 2026-08-24
+  succeeded on the very next dispatch (#10554).
 - **Image structured data carries the licensing fields Google recommends** — Search
   Console flagged every implementation page's `ImageObject` for missing `creator`,
   `copyrightNotice`, `creditText`, and `acquireLicensePage`. The bot-page JSON-LD now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   manual attention. Repo-wide that state had accumulated on **87 `(spec, library)` pairs**.
   Marker counting is now scoped to a 12-hour campaign window, so stale history ages out and
   a fresh dispatch gets its full three attempts. The fail-closed behaviour on an unreadable
-  counter (issue #1010: ~1,200 runs in 38 h) is untouched (#10554).
+  counter (issue #1010: ~1,200 runs in 38 h) is untouched (#10627).
 - **A failed library no longer claims three attempts it never made** — the cap message read
   `Marking <lib> as failed: 3 generation attempts` even when the run made exactly one, which
   reads as "tried repeatedly, must be a genuine capability gap". It now names the counted
   failures and the window. Three pairs written off under the old wording on 2026-08-24
-  succeeded on the very next dispatch (#10554).
+  succeeded on the very next dispatch (#10627).
 - **Image structured data carries the licensing fields Google recommends** — Search
   Console flagged every implementation page's `ImageObject` for missing `creator`,
   `copyrightNotice`, `creditText`, and `acquireLicensePage`. The bot-page JSON-LD now


### PR DESCRIPTION
## Problem

`impl-generate.yml` budgets 3 generation attempts per library, counted from hidden marker comments on the spec issue:

```bash
MARKER="<!-- impl-fail:${SPEC_ID}:${LIBRARY} -->"
FAILURE_COUNT=$(gh api --paginate ".../issues/${ISSUE}/comments" ... )
if [ "$FAILURE_COUNT" -ge 2 ]; then   # → impl:<lib>:failed, no auto-retry
```

Nothing ever deletes those markers — `grep -rn "impl-fail:"` across the repo returns exactly one hit, the read. So the count spans the **issue's entire lifetime**, not the current run, even though the surrounding code says "Attempt N/3" and clearly means one campaign.

Consequences, all observed on 2026-08-24 during the library backfill:

1. A pair that ever failed twice gets **one** attempt on every future dispatch. Observed counts: `chartjs/treemap-basic` **4**, `plotnine/wireframe-3d-basic` **4**, `ggplot2/network-force-directed` **3`.
2. Generation has an intermittent failure where the agent exits `"subtype":"success","is_error":false` but writes no file — **8 of 85** generate runs that day (~9%). With budget left, the built-in auto-retry absorbs it (`bubble-basic/highcharts`: failed 17:55, retried and succeeded 18:02, no human involved). With the budget already spent by old history, one flake is terminal.
3. Terminal means terminal: `impl:<lib>:failed` has no recovery path — watchdog case 3 fires once and thereafter logs `already retried by watchdog — needs manual attention` (seen for issues #998, #990, #810, #653).
4. Repo-wide, **87 `(spec, library)` pairs across 54 issues** carry `impl:*:failed`. That is a measurable slice of the 1,237 missing implementations, and part of it is self-inflicted rather than never-attempted.

Three of the pairs written off this way succeeded on the very next manual dispatch.

## Fix

Count only markers newer than a 12-hour campaign window:

```bash
CAMPAIGN_CUTOFF=$(date -u -d "${CAMPAIGN_WINDOW_H} hours ago" +%Y-%m-%dT%H:%M:%SZ)
--jq "[.[] | select(.body != null and (.body | contains(\"$MARKER\")) and .created_at > \"$CAMPAIGN_CUTOFF\")] | length"
```

A campaign runs well under an hour, so 12 h is generous for a stalled tail while stale history ages out on its own. Choosing a time window over deleting markers keeps the audit trail intact, needs no destructive writes to issues, and unblocks the existing 87 pairs without a migration.

The cap message now states what was actually counted — `2 failed attempt(s) in the last 12h (cap: 3 per campaign)` instead of a flat `3 generation attempts` printed after a single attempt. That wording is what led to two pairs being written off as capability gaps during the backfill before a retry proved otherwise.

**Explicitly unchanged:** the fail-closed path. An unreadable counter still sets `FAILURE_COUNT=999` and disables auto-retry — the zero-fallback loop that flooded ~1,200 runs in 38 h (#1010) stays impossible.

## Verification

- `yaml.safe_load` parses the workflow; the step's `run:` block extracted and checked with `bash -n`.
- jq filter exercised against a fixture with an old marker, a fresh marker, and a `null` body → returns `1` (the fresh one only), so neither the age filter nor the existing null-guard regressed.
- End-to-end behaviour is only observable on real pipeline runs (a documented no-verification-loop area in CLAUDE.md); the change is one filter clause plus a message.

## Follow-up (not in this PR)

The 87 parked pairs need a re-dispatch sweep to actually recover — this PR only stops the trap from re-arming. That sweep is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbZuWNDFy7kjXh9kLfA4dP