### PR TITLE
docs(open-pr): watch the regional Cloud Builds, not the global list

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -183,9 +183,18 @@ When such paths merged, watch until the build succeeds — a red Cloud
 Build means production did NOT update even though the PR was green:
 
 ```bash
-gcloud builds list --limit 3
-gcloud builds log <id>   # on failure
+gcloud builds list --region=europe-west4 --limit 3 \
+  --format='table(id,status,createTime,substitutions.TRIGGER_NAME,substitutions.SHORT_SHA)'
+gcloud builds log --region=europe-west4 <id>   # on failure
 ```
+
+The `--region` flag is load-bearing: the `deploy-app` / `deploy-api`
+triggers are **regional** (europe-west4), and the global `gcloud builds
+list` answers with a handful of months-old global builds — all
+`SUCCESS`, none from today — which reads like "nothing was triggered"
+while both deploys are already done (2026-08-28, #10808 follow-through:
+a 20-minute poll on the global list never saw the builds). Match the
+`SHORT_SHA` column against the merge commit before trusting a row.
 
 ## Gotchas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,11 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Changed
 
+- **`open-pr` skill: the post-merge Cloud Build watch names the region** — `gcloud builds
+  list` without `--region=europe-west4` answers with months-old global builds (all `SUCCESS`,
+  none from today), which reads like "nothing was triggered" while both regional deploys are
+  already done; the #10808 follow-through polled that list for 20 minutes. The command now
+  carries the region and a `SHORT_SHA` column to match against the merge commit.
 - **`babysit-pipeline`'s gap-backfill guidance corrected against a completed run** — the
   section shipped in #10628 was written mid-backfill and three of its claims did not
   survive the rest of it. The halt-on-cluster threshold counted raw failed runs, but one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   list` without `--region=europe-west4` answers with months-old global builds (all `SUCCESS`,
   none from today), which reads like "nothing was triggered" while both regional deploys are
   already done; the #10808 follow-through polled that list for 20 minutes. The command now
-  carries the region and a `SHORT_SHA` column to match against the merge commit.
+  carries the region and a `SHORT_SHA` column to match against the merge commit (#10809).
 - **`babysit-pipeline`'s gap-backfill guidance corrected against a completed run** — the
   section shipped in #10628 was written mid-backfill and three of its claims did not
   survive the rest of it. The halt-on-cluster threshold counted raw failed runs, but one


### PR DESCRIPTION
## Summary
- The `open-pr` skill's §4 post-merge deploy watch ran `gcloud builds list` without `--region=europe-west4`. The `deploy-app` / `deploy-api` triggers are regional, so the global list answers with months-old builds — all `SUCCESS`, none from today — which reads like "nothing was triggered" while both deploys are already done. The #10808 follow-through polled that list for 20 minutes before noticing.
- The command now names the region, adds a `SHORT_SHA` column to match against the merge commit, and the trap is recorded next to the command. Changelog entry under Changed.

## Plan
N/A — friction found during the #10808 follow-through.

## Test plan
- [x] `gcloud builds list --region=europe-west4 --limit 3 --format=…` run as written: shows `deploy-app` and `deploy-api` for `87f78ad` (the #10808 merge), both `SUCCESS`; the global form shows three April builds
- [x] Docs-only change; no code paths touched