### PR TITLE
infra: scale anyplot-app to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 - **`anyplot-app` scales to zero** — the frontend service ran a permanently warm
   instance for ~EUR 8.30/month while 99.56% of the paid time was idle. It is a static
   nginx image that boots in ~0.26 s, and a 7-day request trace at one-minute resolution
-  shows the longest gap between requests is 11 minutes, against Cloud Run's ~15 minute
+  shows the longest gap between requests is 11 minutes, against Cloud Run's ~15-minute
   idle window — so the instance is in practice never reclaimed and visitors keep the
   same time to first byte. `anyplot-api` keeps `min-instances=1`: its cold start is
   ~11.6 s and its traffic does leave gaps over 15 minutes. (#10812)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,12 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 ### Changed
 
 - **`anyplot-app` scales to zero** — the frontend service ran a permanently warm
-  instance for ~EUR 8.30/month while 99.56 % of the paid time was idle. It is a static
+  instance for ~EUR 8.30/month while 99.56% of the paid time was idle. It is a static
   nginx image that boots in ~0.26 s, and a 7-day request trace at one-minute resolution
   shows the longest gap between requests is 11 minutes, against Cloud Run's ~15 minute
   idle window — so the instance is in practice never reclaimed and visitors keep the
   same time to first byte. `anyplot-api` keeps `min-instances=1`: its cold start is
-  ~11.6 s and its traffic does leave gaps over 15 minutes.
+  ~11.6 s and its traffic does leave gaps over 15 minutes. (#10812)
 
 ## [3.2.0] — 2026-08-29 — Findable by assistants
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Changed
+
+- **`anyplot-app` scales to zero** — the frontend service ran a permanently warm
+  instance for ~EUR 8.30/month while 99.56 % of the paid time was idle. It is a static
+  nginx image that boots in ~0.26 s, and a 7-day request trace at one-minute resolution
+  shows the longest gap between requests is 11 minutes, against Cloud Run's ~15 minute
+  idle window — so the instance is in practice never reclaimed and visitors keep the
+  same time to first byte. `anyplot-api` keeps `min-instances=1`: its cold start is
+  ~11.6 s and its traffic does leave gaps over 15 minutes.
+
 ## [3.2.0] — 2026-08-29 — Findable by assistants
 
 anyplot 3.2 makes the catalogue findable by assistants, not only legible to them. The sister

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -53,8 +53,13 @@ steps:
       - '1'
       - '--timeout'
       - '60'
+      # Scale to zero. This service is a static nginx that boots in ~0.26 s, and
+      # measured traffic never leaves it idle long enough to be reclaimed: over
+      # 7 days the longest gap between requests was 11 min, against Cloud Run's
+      # ~15 min idle window. A warm instance cost ~EUR 8.30/month for 99.56 %
+      # idle time. The API keeps min-instances=1 — its cold start is ~11.6 s.
       - '--min-instances'
-      - '1'
+      - '0'
       - '--max-instances'
       - '3'
       - '--port'

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -53,11 +53,11 @@ steps:
       - '1'
       - '--timeout'
       - '60'
-      # Scale to zero. This service is a static nginx that boots in ~0.26 s, and
-      # measured traffic never leaves it idle long enough to be reclaimed: over
-      # 7 days the longest gap between requests was 11 min, against Cloud Run's
-      # ~15 min idle window. A warm instance cost ~EUR 8.30/month for 99.56 %
-      # idle time. The API keeps min-instances=1 — its cold start is ~11.6 s.
+      # Scale to zero: this is a static nginx that boots in a fraction of a
+      # second, and its traffic is dense enough that Cloud Run rarely reclaims
+      # the instance anyway, so a warm one bought almost nothing. The API keeps
+      # min-instances=1 — its cold start is orders of magnitude larger.
+      # Measurements behind this: #10812.
       - '--min-instances'
       - '0'
       - '--max-instances'


### PR DESCRIPTION
## What

`anyplot-app` moves from `min-instances=1` to `0`, pinned in `app/cloudbuild.yaml`. The live service was already updated in the same breath (revision `anyplot-app-00150-28q`), so this commit stops the next deploy from restoring the old value.

`anyplot-api` deliberately keeps `min-instances=1` — see below.

## Why

Came out of a cost audit across the three GCP projects. The frontend service held a permanently warm Cloud Run instance while doing almost nothing with it:

| Measured over 30 days (2026-07-30 … 08-29) | anyplot-app |
|---|---|
| Billable instance time | 2,591,653 s — one instance, around the clock |
| Of which idle | 99.56 % |
| Cold start, p50 | 258 ms (static nginx, 24.5 MB image) |
| Cost | ~EUR 8.30/month |

The warm instance bought back roughly 260 seconds of aggregate wait across an entire month, behind Cloudflare, on a service that boots in a quarter of a second.

## Why this is safe

The question is whether the service would actually go cold. A 7-day request trace at one-minute resolution says no:

| Service | Minutes with traffic | Longest gap | Gaps > 15 min |
|---|---|---|---|
| **anyplot-app** | 60.0 % | **11 min** | **0** |
| anyplot-api | 46.7 % | 20 min | 0.7/day |

Cloud Run reclaims an idle instance after roughly 15 minutes. Over a full week, `anyplot-app` never had a gap that long, so in practice the instance stays resident and time to first byte for visitors and crawlers is unchanged. Post-change spot checks on `https://anyplot.ai/` returned HTTP 200 at 95–196 ms TTFB.

This is an expectation, not a guarantee — the idle window is not a documented SLA. A follow-up check is scheduled for 2026-09-06 against the before-values above (startup latencies, request latencies, billable instance time, plus Search Console crawl response time). Rollback is one flag.

`anyplot-api` keeps its warm instance because both halves of the argument invert there: its cold start is ~11.6 s, and its traffic does leave gaps beyond 15 minutes.

## Test plan

- `app/cloudbuild.yaml` parses and the deploy step carries `--min-instances '0'`, `--max-instances '3'`, `--memory '512Mi'`
- Live service verified: `minScale` annotation absent, traffic 100 % on the new revision
- `https://anyplot.ai/` returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qccek5dba72zaizDBGK61