### PR TITLE
Fix the red API deploy, halve the image, and smoke-test before traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The API image installs `libraqm0`, which is what actually restores text shaping —
+  and unblocks a deploy pipeline that has been red since 2026-08-30** — #10813 added a
+  build-time assertion on `features.check('raqm')` on the understanding that the locked
+  Pillow 12.3.0 manylinux wheel bundles libraqm. It does not: the wheel `dlopen()`s
+  libraqm at runtime, so in a bare `python:3.13-slim` the check is `False` and both
+  HarfBuzz and FriBiDi report no version at all. The assertion therefore failed every
+  build of this image, and the `deploy-api` trigger has been failing since that merge —
+  the serving revision is still the one built on 2026-08-28, so nothing merged since has
+  shipped. Installing the Debian `libraqm0` package (32 KB plus its HarfBuzz/FriBiDi
+  dependencies) turns the check `True`, verified in the built image. The assertion also
+  moves to the runtime stage, where it checks the image that actually serves: in the
+  builder stage it would pass on a venv whose runtime never got the library, which is
+  exactly the false green the guard exists to prevent. (#10813)
 - **OG cards render without MonoLisa's italic swashes in production** — the live
   `api.anyplot.ai/og/home.png` is pixel-identical to a render forced onto Pillow's
   BASIC layout engine, which means the deployed container's Pillow has no libraqm:
@@ -39,6 +52,25 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Changed
 
+- **The API image is built in two stages and drops two thirds of its weight** — the
+  single-stage `api/Dockerfile` produced a 1.6 GB image (502 MB compressed in Artifact
+  Registry) of which 277 MB compressed was ballast in two layers: `build-essential`,
+  which never compiled anything because all 108 packages this image installs ship
+  wheels, and a `chown -R appuser:appuser /app` that ran after the venv was in place
+  and so rewrote the whole environment into a second layer. The build now installs into
+  a builder stage and copies only the finished venv across with `COPY --chown`, which
+  sets ownership as the layer is written. Measured: 1.62 GB to 693 MB. Less Artifact
+  Registry growth per deploy and a shorter deploy rollout; `min-instances 1` already
+  covers the user-facing cold start.
+- **The API deploy smoke-tests a candidate revision before it takes traffic** — the
+  pipeline deployed straight onto live traffic, so a broken image served users until
+  someone noticed. It now deploys with `--no-traffic --tag=candidate` and a
+  deterministic `--revision-suffix`, probes that revision on its tag URL (`/health`,
+  `/libraries`, `/languages`, `/plots/filter` for the database path, and `/debug/status`
+  for the fail-closed admin gate), and only then shifts traffic to exactly the revision
+  it smoked — never `--to-latest`, which could promote a concurrent build's unsmoked
+  revision. Adopted verbatim from the sibling repo kurrentschrift, which has had this
+  net since its first deploy.
 - **`anyplot-app` scales to zero** — the frontend service ran a permanently warm
   instance for ~EUR 8.30/month while 99.56% of the paid time was idle. It is a static
   nginx image that boots in ~0.26 s, and a 7-day request trace at one-minute resolution

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,45 +1,80 @@
-# Dockerfile for anyplot FastAPI backend on Cloud Run
-FROM python:3.13-slim
+# Multi-stage Dockerfile for the anyplot FastAPI backend on Cloud Run.
+#
+# Same shape as app/Dockerfile: a builder stage that installs, and a clean
+# runtime stage that only receives the finished artefacts. The single-stage
+# version this replaces carried 276.6 MB of ballast in a 502.0 MB image (55 %),
+# in two layers that each had a named cause — see the comments at the apt and
+# the COPY --chown lines below. The sibling repo kurrentschrift has the same
+# fix; keep the two Dockerfiles in the same shape.
+#
+# Both stages MUST use the same base image: `uv venv` records the interpreter
+# path in .venv/pyvenv.cfg and writes /app/.venv/bin shebangs, so the runtime
+# stage has to offer the same interpreter at the same path (hence WORKDIR /app
+# on both sides too).
 
-# Set working directory
+FROM python:3.13-slim AS builder
+
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
+# No build-essential: the image's actual install set is 108 packages and every
+# one of them ships a wheel, so nothing is ever compiled here. (The two
+# sdist-only entries in uv.lock, esprima and matplotlib-venn, belong to the
+# `plotting` extra, which this image does not install.) The toolchain was
+# ~110 MB that only ever sat there. If a future dependency arrives sdist-only,
+# the build fails loudly at this step — the right place to notice.
+RUN pip install --no-cache-dir uv
+
+# Copy requirements first for better caching.
+COPY pyproject.toml uv.lock README.md ./
+
+# `--frozen` honors uv.lock instead of re-resolving from pyproject.toml —
+# without it, uv picked up greenlet 3.5.0, which only ships macOS/Windows
+# wheels and breaks the linux/amd64 Cloud Build image.
+RUN uv venv && uv sync --frozen
+
+
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# curl serves the HEALTHCHECK below. libraqm0 is what actually turns Pillow's
+# text shaping on: the manylinux wheel does NOT vendor Raqm, it dlopen()s
+# libraqm at runtime, so in a bare python:3.13-slim `features.check('raqm')` is
+# False and HarfBuzz/FriBiDi report no version at all. That is the whole of
+# #10813's regression — and why the guard it added has failed every build of
+# this image since (the deploy-api trigger has been red since 2026-08-30).
+# The Debian package is 32 KB plus its HarfBuzz/FriBiDi dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    libraqm0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements first for better caching
-COPY pyproject.toml .
-COPY uv.lock .
-COPY README.md .
+# Create the non-root user BEFORE the copies, so `COPY --chown` can name it.
+RUN useradd -m -u 1000 appuser
 
-# Install uv and create venv. `--frozen` honors uv.lock instead of re-resolving
-# from pyproject.toml — without it, uv picked up greenlet 3.5.0, which only
-# ships macOS/Windows wheels and breaks the linux/amd64 Cloud Build image.
-RUN pip install --no-cache-dir uv && \
-    uv venv && \
-    uv sync --frozen
+# `COPY --chown` sets ownership as the layer is written. The old
+# `RUN chown -R appuser:appuser /app` did it afterwards, which rewrites every
+# touched file into a fresh layer and so duplicated the entire venv: 156.0 MB
+# for a permission bit. The venv's executables keep their modes across COPY,
+# so the `chmod -R 755 .venv/bin` that used to ride along is gone too.
+COPY --from=builder --chown=appuser:appuser /app/.venv ./.venv
 
-# Fail the build if Pillow lands without libraqm. Without text shaping Pillow
-# falls back to its BASIC layout engine: the OG cards lose MonoLisa's italic
-# `ss02` swashes and all kerning, and nothing in the response signals it — the
-# only symptom is an off-brand PNG. Better a red build than a silent regression.
+# Copy application code
+COPY --chown=appuser:appuser api/ ./api/
+COPY --chown=appuser:appuser core/ ./core/
+COPY --chown=appuser:appuser plots/ ./plots/
+
+# Fail the build if Pillow cannot shape text. Without it Pillow falls back to
+# its BASIC layout engine: the OG cards lose MonoLisa's italic `ss02` swashes
+# and all kerning, and nothing in the response signals it — the only symptom is
+# an off-brand PNG (#10813). This runs in the RUNTIME stage on purpose: the
+# check is only meaningful against the image that actually serves. In the
+# builder stage it would pass on a venv whose runtime never got libraqm0, which
+# is precisely the false green this guard exists to prevent.
 RUN .venv/bin/python -c "\
 from PIL import features; \
 assert features.check('raqm'), \
-'Pillow was installed without libraqm — OG image text shaping would be disabled. Use a Pillow wheel that bundles libraqm (or install libraqm before building it from source).'"
-
-# Copy application code
-COPY api/ ./api/
-COPY core/ ./core/
-COPY plots/ ./plots/
-
-# Create non-root user and set permissions AFTER everything is installed
-RUN useradd -m -u 1000 appuser && \
-    chown -R appuser:appuser /app && \
-    chmod -R 755 /app/.venv/bin
+'Pillow cannot shape text — OG image text shaping would be disabled. The manylinux wheel dlopen()s libraqm at runtime, so the runtime stage must install libraqm0.'"
 
 # Switch to non-root user
 USER appuser

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -75,8 +75,74 @@ steps:
       - "--cpu-throttling"
       - "--concurrency=15"
       - "--timeout=600"
+      # Deploy WITHOUT routing traffic: the smoke step probes this revision on
+      # its tag URL first, and only the promote step below shifts traffic — so a
+      # bad image never serves users, not even between deploy and a failing
+      # smoke. Mirrors kurrentschrift's api/cloudbuild.yaml, which had this net
+      # while this pipeline deployed straight onto live traffic. The `candidate`
+      # tag moves to each new revision, and the deterministic revision suffix
+      # lets promote target EXACTLY the revision this build smoked (never a
+      # concurrent build's newer one).
+      # `b` prefix: Cloud Run requires the suffix to start with a lowercase
+      # letter, and $BUILD_ID is a UUID that usually starts with a digit.
+      - "--no-traffic"
+      - "--tag=candidate"
+      - "--revision-suffix=b$BUILD_ID"
     id: "deploy"
     waitFor: ["push-image"]
+
+  # Pre-traffic smoke against the CANDIDATE revision (tag URL, serving no
+  # traffic yet): a bad image that still answers /health can 500 on the real
+  # read paths — probe what the public site depends on, plus the fail-closed
+  # admin gate. Retries cover the candidate's own cold start.
+  - name: "gcr.io/cloud-builders/gcloud"
+    entrypoint: "bash"
+    args:
+      - "-ceu"
+      - |
+        # Resolve the candidate tag's URL AND assert it still points at THIS
+        # build's revision (deterministic --revision-suffix) — a concurrent
+        # build re-tagging `candidate` must fail this build, not get smoked
+        # on its behalf.
+        read -r URL REV <<< "$$(gcloud run services describe ${_SERVICE_NAME} --region=${_REGION} --platform=managed --format=json \
+          | python3 -c "import json,sys; t=json.load(sys.stdin)['status']['traffic']; c=next(x for x in t if x.get('tag')=='candidate'); print(c['url'], c['revisionName'])")"
+        test "$$REV" = "${_SERVICE_NAME}-b$BUILD_ID" || { echo "candidate tag moved to $$REV (expected ${_SERVICE_NAME}-b$BUILD_ID)"; exit 1; }
+        echo "smoke against candidate $$URL ($$REV)"
+        # Retry EVERY probe: a freshly deployed candidate starts cold whatever
+        # _MIN_INSTANCES says, so the first call that touches the DB may be the
+        # first real DB request of that container's life and can fail once.
+        RETRY="--retry 5 --retry-delay 5 --retry-all-errors"
+        curl -fsS $$RETRY "$$URL/health" | grep -q '"healthy"'
+        # /libraries and /languages fall back to static metadata when the DB is
+        # unreachable (optional_db), so they prove the app serves but not the
+        # database. /plots/filter takes require_db — it is the probe that fails
+        # when the Cloud SQL connection is broken.
+        curl -fsS $$RETRY "$$URL/libraries" | grep -q '"libraries"'
+        curl -fsS $$RETRY "$$URL/languages" | grep -q '"languages"'
+        curl -fsS $$RETRY "$$URL/plots/filter" >/dev/null
+        # Fail-closed admin gate. 401 is the answer with ADMIN_TOKEN present and
+        # no header sent; a 503 here would mean the secret never arrived, which
+        # is exactly the misconfiguration worth failing the build over.
+        code=$$(curl -s $$RETRY -o /dev/null -w '%{http_code}' "$$URL/debug/status")
+        test "$$code" = "401" || { echo "admin gate expected 401, got $$code"; exit 1; }
+        echo "smoke OK"
+    id: "smoke"
+    waitFor: ["deploy"]
+
+  # Smoke passed — route 100% of traffic to EXACTLY the revision this build
+  # deployed and smoked (deterministic name via --revision-suffix), never
+  # `--to-latest`, which could promote a concurrent build's unsmoked revision.
+  - name: "gcr.io/cloud-builders/gcloud"
+    args:
+      - "run"
+      - "services"
+      - "update-traffic"
+      - "${_SERVICE_NAME}"
+      - "--region=${_REGION}"
+      - "--platform=managed"
+      - "--to-revisions=${_SERVICE_NAME}-b$BUILD_ID=100"
+    id: "promote"
+    waitFor: ["smoke"]
 
   # Report deployed URL
   - name: "gcr.io/cloud-builders/gcloud"
@@ -89,7 +155,7 @@ steps:
       - "--platform=managed"
       - "--format=value(status.url)"
     id: "get-url"
-    waitFor: ["deploy"]
+    waitFor: ["promote"]
 
 # Store image in Artifact Registry
 images:


### PR DESCRIPTION
## Summary

Three things in the API's build and deploy path. The first one is urgent.

### 1. The API deploy has been failing since 2026-08-30

#10813 added a build-time assertion on `features.check('raqm')`, on the understanding that the locked Pillow 12.3.0 manylinux wheel bundles libraqm. **It does not** — the wheel `dlopen()`s libraqm at runtime. In a bare `python:3.13-slim`:

```
pillow 12.3.0
raqm      : False
freetype2 : True
harfbuzz    version: None
fribidi     version: None
```

So the assertion has failed every build of this image since it landed. The `deploy-api` trigger build `1c2c5b92` of **2026-08-30 21:31 died on exactly that line**, and `anyplot-api:latest` is still the image built on 2026-08-28 — nothing merged since has shipped.

Installing the Debian `libraqm0` package (32 KB plus its HarfBuzz/FriBiDi dependencies) turns the check `True`, verified in the built image. That does not just unblock the build: it makes #10813's actual regression go away, rather than merely guarding against it.

The assertion also **moves to the runtime stage**, where it checks the image that actually serves. In the builder stage it would pass on a venv whose runtime never received the library — precisely the false green the guard exists to prevent.

### 2. The image is built in two stages

The single-stage version produced a **1.62 GB** image (502 MB compressed). Two layers were ballast: `build-essential`, which never compiled anything because all 108 packages this image installs ship wheels (the two sdist-only entries in `uv.lock`, `esprima` and `matplotlib-venn`, belong to the `plotting` extra, which this image does not install), and a `chown -R appuser:appuser /app` after the venv was in place, which rewrites every touched file into a fresh layer and so duplicated the whole environment.

| | uncompressed |
|---|---|
| old (single-stage, currently serving) | 1.62 GB |
| new (multi-stage) | **693 MB** |

### 3. The deploy smoke-tests a candidate revision before it takes traffic

Until now this pipeline deployed straight onto live traffic, so a bad image served users until someone noticed. It now deploys with `--no-traffic --tag=candidate` and a deterministic `--revision-suffix`, probes that revision on its tag URL, and only then shifts traffic to exactly the revision it smoked — never `--to-latest`, which could promote a concurrent build's unsmoked revision.

Probes: `/health`, `/libraries`, `/languages`, `/plots/filter` (the one that takes `require_db`, so it fails when Cloud SQL is unreachable — `/libraries` and `/languages` fall back to static metadata via `optional_db` and would not notice), and `/debug/status`, which must answer 401 from the fail-closed admin gate.

Adopted from the sibling repo kurrentschrift, which has had this net from the start. Its step chain and this one are now identical apart from kurrentschrift's `migrate` job.

## Test plan

- [x] Built in Cloud Build (`e60104fe`) — succeeds without `build-essential`.
- [x] `features.check('raqm')` → **True** in the built image.
- [x] Root cause isolated in a standalone probe (`47f8bf05`): the same wheel gives `raqm: False` in bare `python:3.13-slim` and `raqm: True` with `libraqm0` installed.
- [x] Regression pinned to the old Dockerfile, not to this change: trigger build `1c2c5b92` (30.08., single-stage) fails on the identical line.
- [x] In the built image: heavy wheels import, `api.main` imports, `uvicorn` runs, the user is `appuser`, `plots/` and `core/` are present.
- [x] `api/cloudbuild.yaml` parses; step chain `build → push → deploy → smoke → promote → get-url`.
- [ ] The smoke step itself first runs on merge — it cannot be exercised from a branch, since it probes a deployed candidate revision.

## Notes

The size change affects Artifact Registry growth per deploy and rollout time, not user-facing latency — `min-instances 1` already covers the cold start.

CI note: this diff touches no Python, so `CI: Lint` and `CI: Tests` skip themselves by design. Cloud Build is the only real gate, which is part of why the smoke step is in here.