### PR TITLE
fix(impl-merge): clear stale failed labels on merge

### DIFF
--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -379,17 +379,23 @@ jobs:
           # otherwise keep reporting the pair as "already retried — needs manual
           # attention" on every scan.
           #
-          # One `gh issue edit` per label, each tolerated: `gh` resolves label
-          # names against the REPO's label list before it edits, and a single
-          # unknown name (`impl:<lib>:pending` is only created on demand and
-          # `generate:<lib>` may never have existed for this issue) fails the
-          # whole comma-separated call. The previous single-call form did just
-          # that, and its fallback only added :done — so issues #3343 and #3650
-          # kept `impl:<lib>:failed` next to `impl:<lib>:done` after the
-          # rescued implementations merged (2026-09-02).
+          # Only the labels the issue actually carries are removed, one
+          # `gh issue edit` each: `gh` resolves every name against the REPO's
+          # label list before it edits, and a single unknown name
+          # (`impl:<lib>:pending` is only created on demand, `generate:<lib>`
+          # may never have existed) fails a whole comma-separated call. The
+          # previous single-call form did just that, and its fallback only
+          # added :done — so issues #3343 and #3650 kept `impl:<lib>:failed`
+          # next to `impl:<lib>:done` after the rescued implementations merged
+          # (2026-09-02). A removal that fails anyway is reported, not hidden:
+          # the stale label is exactly the state this step exists to clear.
+          PRESENT=$(gh issue view "$ISSUE" --json labels -q '.labels[].name' 2>/dev/null || echo "")
           for stale in "generate:${LIBRARY}" "impl:${LIBRARY}:pending" \
                        "impl:${LIBRARY}:failed" "watchdog:retried-${LIBRARY}"; do
-            gh issue edit "$ISSUE" --remove-label "$stale" 2>/dev/null || true
+            if echo "$PRESENT" | grep -qx "$stale"; then
+              gh issue edit "$ISSUE" --remove-label "$stale" \
+                || echo "::warning::Could not remove stale label '$stale' from issue #$ISSUE"
+            fi
           done
 
       - name: Post success to issue

--- a/.github/workflows/impl-merge.yml
+++ b/.github/workflows/impl-merge.yml
@@ -368,17 +368,29 @@ jobs:
           # Create labels if they don't exist
           gh label create "impl:${LIBRARY}:done" --color "0e8a16" --description "${LIBRARY} implementation merged" 2>/dev/null || true
 
-          # Remove trigger, pending, and any stale failed label from earlier attempts,
-          # then add done. The :failed label is added by impl-generate.yml when an
-          # attempt errors out (e.g. environment setup failure); a later successful
-          # retry merges via this workflow but historically didn't clean up :failed,
-          # leaving the issue with both :done and :failed for the same library.
-          # Single API call (comma-separated) — matches the pattern in
-          # impl-generate.yml and avoids the partial-update window of separate edits.
-          gh issue edit "$ISSUE" \
-            --remove-label "generate:${LIBRARY},impl:${LIBRARY}:pending,impl:${LIBRARY}:failed" \
-            --add-label "impl:${LIBRARY}:done" 2>/dev/null || \
-            gh issue edit "$ISSUE" --add-label "impl:${LIBRARY}:done"
+          # Add done first — it is the completion signal everything else reads
+          # (the 15/15 auto-close below, monitor_spec.sh, the label sync).
+          gh issue edit "$ISSUE" --add-label "impl:${LIBRARY}:done"
+
+          # Then clear every label that says this library is still pending or
+          # broken: the generate trigger, the pending marker, the :failed label
+          # impl-generate.yml sets at its retry cap, and the watchdog's
+          # per-library retry marker (`watchdog:retried-<lib>`), which would
+          # otherwise keep reporting the pair as "already retried — needs manual
+          # attention" on every scan.
+          #
+          # One `gh issue edit` per label, each tolerated: `gh` resolves label
+          # names against the REPO's label list before it edits, and a single
+          # unknown name (`impl:<lib>:pending` is only created on demand and
+          # `generate:<lib>` may never have existed for this issue) fails the
+          # whole comma-separated call. The previous single-call form did just
+          # that, and its fallback only added :done — so issues #3343 and #3650
+          # kept `impl:<lib>:failed` next to `impl:<lib>:done` after the
+          # rescued implementations merged (2026-09-02).
+          for stale in "generate:${LIBRARY}" "impl:${LIBRARY}:pending" \
+                       "impl:${LIBRARY}:failed" "watchdog:retried-${LIBRARY}"; do
+            gh issue edit "$ISSUE" --remove-label "$stale" 2>/dev/null || true
+          done
 
       - name: Post success to issue
         if: steps.check.outputs.should_run == 'true' && steps.issue.outputs.number != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   the 2026-09-02 outage rescue with both labels for the same libraries, and every
   watchdog scan since reported those pairs as "already retried — needs manual
   attention". The labels are now removed one at a time, each call tolerated, and
-  `watchdog:retried-<lib>` goes with them.
+  `watchdog:retried-<lib>` goes with them. (#11197)
 - **The API image installs `libraqm0`, which is what actually restores text shaping —
   and unblocks a deploy pipeline that has been red since 2026-08-30** — #10813 added a
   build-time assertion on `features.check('raqm')` on the understanding that the locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **A merged implementation now clears its `impl:<lib>:failed` label and the watchdog's
+  retry marker** — impl-merge removed the stale labels in one comma-separated
+  `gh issue edit`, and `gh` rejects the whole call when any name in the list is not a
+  repository label (`impl:<lib>:pending` only exists on demand), so the fallback added
+  `impl:<lib>:done` and left `impl:<lib>:failed` in place. Issues #3343 and #3650 ended
+  the 2026-09-02 outage rescue with both labels for the same libraries, and every
+  watchdog scan since reported those pairs as "already retried — needs manual
+  attention". The labels are now removed one at a time, each call tolerated, and
+  `watchdog:retried-<lib>` goes with them.
 - **The API image installs `libraqm0`, which is what actually restores text shaping —
   and unblocks a deploy pipeline that has been red since 2026-08-30** — #10813 added a
   build-time assertion on `features.check('raqm')` on the understanding that the locked


### PR DESCRIPTION
## Summary
- `impl-merge.yml` removed `generate:<lib>`, `impl:<lib>:pending` and `impl:<lib>:failed` in one comma-separated `gh issue edit`; `gh` resolves each name against the repository's label list first and rejects the whole call when one is unknown (`impl:<lib>:pending` is created on demand), so the fallback only added `impl:<lib>:done`.
- Issues #3343 and #3650 therefore carry `impl:<lib>:failed` next to `impl:<lib>:done` since the 2026-09-02 outage rescue, and every watchdog scan reports those pairs as "already retried — needs manual attention".
- The labels are now removed one at a time, each call tolerated, and the watchdog's `watchdog:retried-<lib>` marker is cleared with them.

## Plan
N/A

## Test plan
- [ ] Workflow change has no local verification loop (CLAUDE.md known gap): the run script parses as YAML and passes `bash -n`.
- [ ] After merge, the next `impl-merge` run on an issue that carries `impl:<lib>:failed` (e.g. a rescue of #3069's muix) leaves only `impl:<lib>:done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrKzcwZBnref1sWYtdXynu