### PR TITLE
feat(ci): CodeQL advanced setup that skips plots/**

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,71 @@
+name: "CodeQL"
+
+# Advanced CodeQL setup, replacing the repository's default setup so the
+# generated plot implementations can be left out of scanning.
+#
+# Under default setup every push to an `implementation/*` branch and every
+# impl-* pull request triggered a full five-language scan; during the 4-slot
+# backfill of 2026-09-02 up to 23 CodeQL runs sat in the runner queue at once,
+# ahead of the pipeline's own jobs. `plots/**` holds generated, AI-reviewed
+# plot scripts that run only inside the pipeline's sandboxed render step —
+# scanning them has never produced an actionable alert, and the impl-* PRs
+# touch nothing else.
+#
+# Default setup must be switched off in the repository settings (Code
+# security → Code scanning) once this workflow lands: GitHub rejects
+# advanced-setup uploads while default setup is enabled.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'plots/**'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'plots/**'
+  schedule:
+    # Weekly, like the default setup it replaces. :23 past the hour dodges
+    # GitHub's top-of-hour scheduler overload (see daily-regen.yml).
+    - cron: '23 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # Same coverage as the default setup: `javascript-typescript` covers
+        # both JavaScript and TypeScript; `actions` scans the workflow files.
+        language: [actions, javascript-typescript, python]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          # Also keep the plot scripts out of the analysis itself, not only
+          # out of the triggers: a docs-only push would otherwise still scan
+          # the thousands of files under plots/.
+          config: |
+            paths-ignore:
+              - plots/**
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `.github/workflows/codeql.yml` keeps the same languages and weekly schedule but ignores
   `plots/**` both as a trigger and inside the analysis, so pipeline PRs no longer start
   a scan. Default setup has to be switched off in the repository settings for the
-  workflow's uploads to be accepted.
+  workflow's uploads to be accepted. (#11200)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
+### Changed
+
+- **CodeQL moves to an advanced-setup workflow that skips `plots/**`** — the default
+  setup scanned five languages on every push to an `implementation/*` branch and every
+  impl-* pull request; during the 4-slot backfill of 2026-09-02 up to 23 CodeQL runs
+  waited in the runner queue at once, ahead of the pipeline's own jobs. The new
+  `.github/workflows/codeql.yml` keeps the same languages and weekly schedule but ignores
+  `plots/**` both as a trigger and inside the analysis, so pipeline PRs no longer start
+  a scan. Default setup has to be switched off in the repository settings for the
+  workflow's uploads to be accepted.
+
 ### Fixed
 
 - **The API image installs `libraqm0`, which is what actually restores text shaping —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,17 +26,6 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ## [Unreleased]
 
-### Changed
-
-- **CodeQL moves to an advanced-setup workflow that skips `plots/**`** — the default
-  setup scanned five languages on every push to an `implementation/*` branch and every
-  impl-* pull request; during the 4-slot backfill of 2026-09-02 up to 23 CodeQL runs
-  waited in the runner queue at once, ahead of the pipeline's own jobs. The new
-  `.github/workflows/codeql.yml` keeps the same languages and weekly schedule but ignores
-  `plots/**` both as a trigger and inside the analysis, so pipeline PRs no longer start
-  a scan. Default setup has to be switched off in the repository settings for the
-  workflow's uploads to be accepted. (#11200)
-
 ### Fixed
 
 - **The watchdog now rescues a repair that crashed after a rejection** — a PR carrying
@@ -83,6 +72,14 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Changed
 
+- **CodeQL moves to an advanced-setup workflow that skips `plots/**`** — the default
+  setup scanned five languages on every push to an `implementation/*` branch and every
+  impl-* pull request; during the 4-slot backfill of 2026-09-02 up to 23 CodeQL runs
+  waited in the runner queue at once, ahead of the pipeline's own jobs. The new
+  `.github/workflows/codeql.yml` keeps the same languages and weekly schedule but ignores
+  `plots/**` both as a trigger and inside the analysis, so pipeline PRs no longer start
+  a scan. Default setup has to be switched off in the repository settings for the
+  workflow's uploads to be accepted. (#11200)
 - **The API image is built in two stages and drops two thirds of its weight** — the
   single-stage `api/Dockerfile` produced a 1.6 GB image (502 MB compressed in Artifact
   Registry) of which 277 MB compressed was ballast in two layers: `build-essential`,

--- a/docs/workflows/overview.md
+++ b/docs/workflows/overview.md
@@ -172,6 +172,7 @@ Located in `.github/workflows/`:
 | `report-validate.yml` | Validates user-submitted issue reports |
 | `sync-postgres.yml` | Syncs `plots/` filesystem state to PostgreSQL on push to main |
 | `sync-labels.yml` | Auto-syncs spec/impl labels after manual PR merges |
+| `codeql.yml` | CodeQL scanning (actions, JavaScript/TypeScript, Python) on pushes to main, PRs and a weekly cron; `plots/**` is excluded from triggers and analysis, so pipeline PRs never start a scan |
 | `ci-lint.yml` | Ruff lint check on PRs |
 | `ci-tests.yml` | Unit + integration tests on PRs |
 | `notify-deployment.yml` | Records GitHub deployment events for `app` / `api` |


### PR DESCRIPTION
## Summary
- CodeQL runs here as GitHub's default setup, which cannot exclude paths: every push to an `implementation/*` branch and every impl-* PR triggered a full five-language scan. During the 4-slot backfill of 2026-09-02 up to 23 CodeQL runs waited in the runner queue at once, ahead of the pipeline's own jobs.
- `.github/workflows/codeql.yml` is the advanced-setup equivalent: same languages (`actions`, `javascript-typescript`, `python`), weekly cron, `push`/`pull_request` on `main` with `paths-ignore: plots/**`, and the same exclusion inside the analysis config so a docs-only push does not scan thousands of generated plot files. Actions are SHA-pinned (`codeql-action` v4.37.9).
- **Follow-up in repository settings (not a code change):** default setup must be disabled (Code security → Code scanning) after this merges; GitHub rejects advanced-setup uploads while default setup is on. I will do that right after the merge and confirm the first workflow run.

## Plan
N/A

## Test plan
- [ ] The PR itself triggers the new workflow (it changes files outside `plots/**`); the three `Analyze (...)` jobs may report an upload conflict until default setup is switched off — expected.
- [ ] After the settings change: a push to `main` outside `plots/**` runs all three analyses green; the next impl-* PR starts no CodeQL run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrKzcwZBnref1sWYtdXynu