### PR TITLE
fix(security): headers for the API host, and the measurement that stopped the CSP hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   cost bot detection on a site whose origin gate leans on the edge; the way out is a
   nonce (Cloudflare stamps its injected script with the nonce it parses from this
   header), which needs an nginx `sub_filter` no test here can prove. All of it is
-  written down at the directive it explains. (#PRNUM)
+  written down at the directive it explains. (#11213)
 
 - **The IndexNow workflow no longer waits eight minutes behind an edge 403** — its
   key-file readiness loop treated every non-200 as "not deployed yet"; a GitHub runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,16 +141,20 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   `'unsafe-inline'`** — api.anyplot.ai is a separate origin with no nginx in front of it,
   so it inherited none of `app/security-headers.conf`: only `/proxy/html` set
   `nosniff` and a `Referrer-Policy`, on that one response. An outermost middleware now
-  `setdefault`s both on every response, including CORS preflights, the origin gate's 403
-  and the exception handlers' 500s — but deliberately **not** `X-Frame-Options`, because
+  `setdefault`s both on every response that leaves through the stack — CORS preflights, the
+  origin gate's 403, an `HTTPException`'s 4xx — and the unhandled-500 handler stamps the
+  same pair through the same helper, because `ServerErrorMiddleware` wraps every user
+  middleware and builds that response outside the stack, which is the one exit a middleware
+  cannot reach. Deliberately **not** `X-Frame-Options`, because
   the SPA embeds `/proxy/html` cross-origin in an iframe and `SAMEORIGIN` would break
   every interactive preview. On the website, both `/_health` locations set an
   `add_header` of their own without re-including the snippet, and nginx drops every
   inherited header in such a location — the rule the file states at the top and the one
   place that had missed it. Both were found by the new
   `tests/unit/api/test_csp_policy.py`, which also pins that the CSP keeps `object-src
-  'none'` and `base-uri 'self'`, that it never carries `report-to` beside `report-uri`
-  (measured in the sibling repo: Chromium then reports nothing at all), and that the
+  'none'` and `base-uri 'self'`, that a `report-to` group it names is actually defined by a
+  `Reporting-Endpoints` header (reports to an undeclared group go nowhere, and nowhere reads
+  exactly like "no violations"), and that the
   three sha256 hashes the policy holds in reserve still describe `app/index.html`'s
   inline scripts. Those hashes are in reserve rather than in force for a measured
   reason: mounted over the live production bundle through a local proxy, a hash-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,33 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
 
 ### Fixed
 
+- **The API host stamps its own security headers, `/_health` stops dropping the site's,
+  and the CSP is now guarded by a test that also explains why `script-src` still says
+  `'unsafe-inline'`** — api.anyplot.ai is a separate origin with no nginx in front of it,
+  so it inherited none of `app/security-headers.conf`: only `/proxy/html` set
+  `nosniff` and a `Referrer-Policy`, on that one response. An outermost middleware now
+  `setdefault`s both on every response, including CORS preflights, the origin gate's 403
+  and the exception handlers' 500s — but deliberately **not** `X-Frame-Options`, because
+  the SPA embeds `/proxy/html` cross-origin in an iframe and `SAMEORIGIN` would break
+  every interactive preview. On the website, both `/_health` locations set an
+  `add_header` of their own without re-including the snippet, and nginx drops every
+  inherited header in such a location — the rule the file states at the top and the one
+  place that had missed it. Both were found by the new
+  `tests/unit/api/test_csp_policy.py`, which also pins that the CSP keeps `object-src
+  'none'` and `base-uri 'self'`, that it never carries `report-to` beside `report-uri`
+  (measured in the sibling repo: Chromium then reports nothing at all), and that the
+  three sha256 hashes the policy holds in reserve still describe `app/index.html`'s
+  inline scripts. Those hashes are in reserve rather than in force for a measured
+  reason: mounted over the live production bundle through a local proxy, a hash-only
+  `script-src` blocks exactly one script — the inline one **Cloudflare JavaScript
+  Detections injects at the edge**, whose body carries a per-response ray id and so has
+  no fixed hash. With `'unsafe-inline'` its hidden iframe appears, with hashes it does
+  not and the console reads "The action has been blocked". Hardening would have silently
+  cost bot detection on a site whose origin gate leans on the edge; the way out is a
+  nonce (Cloudflare stamps its injected script with the nonce it parses from this
+  header), which needs an nginx `sub_filter` no test here can prove. All of it is
+  written down at the directive it explains. (#PRNUM)
+
 - **The IndexNow workflow no longer waits eight minutes behind an edge 403** — its
   key-file readiness loop treated every non-200 as "not deployed yet"; a GitHub runner
   that Cloudflare's bot management answers with 403 would have slept the full budget on

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -10,6 +10,8 @@ from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from api.security_headers import stamp as stamp_security_headers
+
 
 logger = logging.getLogger(__name__)
 
@@ -140,10 +142,17 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
     Never reflects the raw exception text back to clients — `str(exc)` can leak
     DSN fragments, table names, file-path traceback fragments, and other internal
     state. The full traceback goes to the server log instead.
+
+    Stamps the security headers itself. `ServerErrorMiddleware` wraps every user
+    middleware, so this response is built OUTSIDE the http middleware stack and
+    is the one exit `api/main.py`'s header middleware cannot reach (Copilot
+    review). Same helper on both paths, so the two cannot drift.
     """
     logger.exception("Unhandled exception on %s", request.url.path)
-    return JSONResponse(
-        status_code=500, content={"status": 500, "message": "Internal server error", "path": _public_path(request)}
+    return stamp_security_headers(
+        JSONResponse(
+            status_code=500, content={"status": 500, "message": "Internal server error", "path": _public_path(request)}
+        )
     )
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -166,7 +166,7 @@ app.add_exception_handler(Exception, generic_exception_handler)
 # `@app.middleware` both wrap what is already there — so reading this file from
 # here down gives the order a request actually travels, in reverse:
 #
-#   cache headers → CORS → origin gate → bot counter → gzip → router
+#   security headers → cache headers → CORS → origin gate → bot counter → gzip → router
 #
 # (`HeadAsGetMiddleware` and `MCPTrailingSlashMiddleware` wrap the whole app
 # further out still; both only rewrite the scope.)
@@ -283,6 +283,36 @@ async def add_cache_headers(request: Request, call_next):
     elif path.startswith("/insights/"):
         response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=3600"
 
+    return response
+
+
+# Added LAST, so it is the OUTERMOST http middleware and every response passes
+# back through it — including CORS preflights, the origin gate's 403 and the
+# exception handlers' 500s.
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    """Stamp the two host-level security headers the API host was missing.
+
+    `app/security-headers.conf` gives the website these, but api.anyplot.ai is
+    a separate origin with its own nginx-less delivery, and it served none of
+    them: only `/proxy/html` set a pair by hand, on that one response. The two
+    that belong on every API response:
+
+    * `nosniff` — the API returns JSON, PNG and (on /proxy/html) HTML from the
+      same host, so content-type sniffing is exactly the confusion to forbid.
+    * `Referrer-Policy` — the same value the website sends, so a link followed
+      out of an API-served page leaks no path.
+
+    Deliberately NOT `X-Frame-Options`: the SPA embeds `/proxy/html` in an
+    iframe from a different origin (`frame-src https://api.anyplot.ai` in the
+    site's CSP), and `SAMEORIGIN` would break every interactive plot preview.
+
+    `setdefault`, so a route that has a reason to say something else — as
+    `/proxy/html` does — keeps its own value.
+    """
+    response: Response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
     return response
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -46,6 +46,7 @@ from api.routers.libraries import _refresh_libraries  # noqa: E402
 from api.routers.plots import _refresh_filter_all  # noqa: E402
 from api.routers.specs import _refresh_specs_list, _refresh_specs_map  # noqa: E402
 from api.routers.stats import _refresh_stats  # noqa: E402
+from api.security_headers import stamp as stamp_security_headers  # noqa: E402
 from api.version import APP_VERSION  # noqa: E402
 from core.config import settings  # noqa: E402
 from core.constants import LANGUAGES_METADATA, LIBRARIES_METADATA  # noqa: E402
@@ -286,34 +287,22 @@ async def add_cache_headers(request: Request, call_next):
     return response
 
 
-# Added LAST, so it is the OUTERMOST http middleware and every response passes
-# back through it — including CORS preflights, the origin gate's 403 and the
-# exception handlers' 500s.
+# Added LAST, so it is the OUTERMOST http middleware and every response that
+# leaves through the stack passes back through it — CORS preflights, the origin
+# gate's 403, an HTTPException's 4xx.
+#
+# It cannot be the only place, though. `ServerErrorMiddleware` wraps every user
+# middleware, so a route that RAISES makes `await call_next(request)` raise too
+# and the registered `Exception` handler's 500 is built outside this stack. That
+# path stamps the same headers itself, through the same helper
+# (`api/security_headers.py`, `api/exceptions.py::generic_exception_handler`).
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
-    """Stamp the two host-level security headers the API host was missing.
+    """Stamp the baseline security headers the API host was missing.
 
-    `app/security-headers.conf` gives the website these, but api.anyplot.ai is
-    a separate origin with its own nginx-less delivery, and it served none of
-    them: only `/proxy/html` set a pair by hand, on that one response. The two
-    that belong on every API response:
-
-    * `nosniff` — the API returns JSON, PNG and (on /proxy/html) HTML from the
-      same host, so content-type sniffing is exactly the confusion to forbid.
-    * `Referrer-Policy` — the same value the website sends, so a link followed
-      out of an API-served page leaks no path.
-
-    Deliberately NOT `X-Frame-Options`: the SPA embeds `/proxy/html` in an
-    iframe from a different origin (`frame-src https://api.anyplot.ai` in the
-    site's CSP), and `SAMEORIGIN` would break every interactive plot preview.
-
-    `setdefault`, so a route that has a reason to say something else — as
-    `/proxy/html` does — keeps its own value.
+    Which headers, and why not `X-Frame-Options`: `api/security_headers.py`.
     """
-    response: Response = await call_next(request)
-    response.headers.setdefault("X-Content-Type-Options", "nosniff")
-    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
-    return response
+    return stamp_security_headers(await call_next(request))
 
 
 # Mount MCP server for AI assistant integration

--- a/api/security_headers.py
+++ b/api/security_headers.py
@@ -1,0 +1,50 @@
+"""The two security headers every API response carries, in one place.
+
+`app/security-headers.conf` gives the website its headers through nginx.
+api.anyplot.ai is a separate origin with no nginx in front of it, so it inherits
+none of them — and served none until this module existed, apart from the pair
+`/proxy/html` set by hand on that one response.
+
+One place, because there are TWO exits from the app and only one of them is a
+middleware. Starlette's `ServerErrorMiddleware` wraps every user middleware, so
+when a route raises, `await call_next(request)` raises with it and the response
+the registered `Exception` handler builds is produced OUTSIDE the stack — an
+unhandled 500 would leave without headers while the middleware's docstring
+claimed otherwise (Copilot review). Both paths call `stamp` instead.
+
+Deliberately NOT `X-Frame-Options`: the SPA embeds `/proxy/html` in an iframe
+from a different origin (`frame-src https://api.anyplot.ai` in the site's CSP),
+and `SAMEORIGIN` would break every interactive plot preview.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from starlette.responses import Response
+
+
+# So a caller that hands in a JSONResponse gets a JSONResponse back — the
+# exception handler's signature promises one, and a bare `Response` return would
+# make the helper the reason mypy fails there.
+ResponseT = TypeVar("ResponseT", bound=Response)
+
+SECURITY_HEADERS = {
+    # The API returns JSON, PNG and (on /proxy/html) HTML from the same host, so
+    # content-type sniffing is exactly the confusion to forbid.
+    "X-Content-Type-Options": "nosniff",
+    # The same value the website sends, so a link followed out of an API-served
+    # page leaks no path.
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+}
+
+
+def stamp(response: ResponseT) -> ResponseT:
+    """Add the baseline headers, keeping any a route set on purpose.
+
+    `setdefault`, so a response with a reason to say something else — as
+    `/proxy/html` does — keeps its own value.
+    """
+    for name, value in SECURITY_HEADERS.items():
+        response.headers.setdefault(name, value)
+    return response

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -307,6 +307,10 @@ server {
         access_log off;
         return 200 "OK";
         add_header Content-Type text/plain;
+        # This location's own add_header drops every inherited one, which is
+        # the rule the top of security-headers.conf states and the one place in
+        # this file that had missed it (found by tests/unit/api/test_csp_policy.py).
+        include /etc/nginx/security-headers.conf;
     }
 
     # Proxy sitemap.xml to backend API (dynamic generation)
@@ -459,6 +463,8 @@ server {
         access_log off;
         return 200 "OK";
         add_header Content-Type text/plain;
+        # Same as the main block: an own add_header drops the inherited ones.
+        include /etc/nginx/security-headers.conf;
     }
 
     location = /sitemap.xml {

--- a/app/security-headers.conf
+++ b/app/security-headers.conf
@@ -7,9 +7,54 @@
 # location, re-include this file there.
 #
 # CSP notes (must not break the SPA — see app/index.html and app/src):
-# - script-src 'unsafe-inline': index.html ships inline scripts (theme
-#   resolver, Eruda loader, Plausible stub); no nonce infra for a static file.
+# - script-src 'unsafe-inline': index.html ships three executable inline
+#   scripts (theme resolver, Eruda loader, Plausible stub), and a FOURTH one
+#   arrives that this repository does not write — see the block below.
 # - script-src cdn.jsdelivr.net: on-device debug console (Eruda) behind ?debug=1.
+#
+# Why script-src still says 'unsafe-inline' (measured 2026-09-03)
+# ---------------------------------------------------------------
+# Replacing 'unsafe-inline' with the sha256 of each inline script is the
+# obvious hardening — index.html is static, so its scripts are fixed at build
+# time, and `yarn build` was verified to copy them through byte-for-byte. The
+# three hashes are recorded below and pinned by tests/unit/api/test_csp_policy.py
+# so they never go stale.
+#
+# They cannot be ENFORCED yet. Cloudflare JavaScript Detections injects an
+# inline script into every HTML response at the edge, after nginx, and its body
+# carries a per-response ray id and timestamp — so its hash differs on every
+# request and cannot be listed here. The whole policy was mounted over the LIVE
+# production bundle through a local proxy and loaded twice, once with each
+# script-src:
+#
+#     'unsafe-inline'  → Cloudflare's script runs (its hidden iframe appears)
+#     hashes only      → "Executing inline script violates … The action has
+#                        been blocked", no iframe, no JS-detection signal
+#
+# Exactly one script is blocked, and it is the edge's. Shipping the hash policy
+# would silently degrade bot detection on a site whose origin gate leans on the
+# edge — so it is not shipped, and 'unsafe-inline' is NOT joined by hashes
+# either: a browser ignores 'unsafe-inline' as soon as a hash is present, so the
+# two together are the same breakage wearing a stricter-looking policy.
+#
+# The way out is a NONCE, not a hash. Cloudflare parses this response header
+# and stamps its own injected script with the nonce it finds there (their
+# JavaScript Detections docs say so explicitly, and recommend it over
+# 'unsafe-inline'). That needs nginx to mint one per request and rewrite
+# index.html's `<script>` tags with it — `sub_filter` plus `gzip_static off`
+# for the shell — which is a delivery change no test in this repo can prove and
+# no local nginx here can run. It is the open item; the alternative is turning
+# JavaScript Detections off in the zone, which is a security trade, not a fix.
+#
+# The hashes of app/index.html's three executable inline scripts, ready for the
+# day one of those two happens (JSON-LD blocks need none — a browser never
+# executes `type="application/ld+json"`, so CSP never asks):
+#   'sha256-4VdX7wfQgL9PnVFBkrDWBbPpiST1xriKljA5URM8DcM='  theme resolver
+#   'sha256-HfNBzShy4Q4W9GmmnPkcx36GlrZI5mkU15xjpyh1pmk='  Eruda loader
+#   'sha256-BiWO1y5gYRbSlOrPh1rJPXYnES50FX9PwJpfXfWJy0A='  Plausible stub
+# A hash covers the exact bytes between `<script>` and `</script>`, so a single
+# re-indent invalidates one. The test recomputes them from index.html on every
+# run, which is what keeps this block honest while it waits.
 # - style-src 'unsafe-inline': MUI/emotion inject inline styles.
 # - img/font/connect storage.googleapis.com: plot previews + MonoLisa fonts on GCS.
 # - img/connect/frame api.anyplot.ai: API calls, og images, interactive-preview

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -49,7 +49,11 @@ INCLUDE_LINE = "include /etc/nginx/security-headers.conf;"
 # regex that reads that as a tag hashes the comment prose instead of the
 # script — silently, and with a hash that looks perfectly plausible.
 _COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
-_SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script>", re.DOTALL | re.IGNORECASE)
+# `</script\s*>`, not `</script>`: HTML lets whitespace sit before the `>` of a
+# closing tag, and a regex that misses `</script >` would silently swallow the
+# rest of the document into one "script body" and hash that. CodeQL's
+# py/bad-tag-filter says so, and it is right — this parses a file people edit.
+_SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script\s*>", re.DOTALL | re.IGNORECASE)
 _TYPE = re.compile(r"""type\s*=\s*["']?([^"'\s>]+)""", re.IGNORECASE)
 # A <script> whose type is none of these is a DATA BLOCK (the three JSON-LD
 # blocks in index.html): the browser never executes it, and CSP never asks for

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -1,0 +1,195 @@
+"""The delivery-side security policy, held against the files it describes.
+
+`app/security-headers.conf` is a string in an nginx include. Nothing compiles
+it, nothing imports it, and three things in it can drift silently — each of
+which has cost someone a day somewhere:
+
+1. **The inline-script hashes.** `script-src` cannot enforce them yet —
+   Cloudflare JavaScript Detections injects a fourth inline script at the edge
+   whose body changes per response (measured 2026-09-03, the reasoning is in
+   `security-headers.conf`) — so the file records them in a comment instead,
+   ready for the day a nonce or a zone setting makes the switch possible. A
+   recorded hash that no longer matches its script is worse than none: it looks
+   like readiness. This recomputes them on every run.
+
+2. **nginx's `add_header` inheritance.** A location with any `add_header` of
+   its own drops every inherited one. `app/nginx.conf` therefore re-includes
+   the snippet in each such location, and forgetting that in a new location is
+   invisible in review and invisible in the browser until someone checks that
+   one URL.
+
+3. **The API host's own headers.** api.anyplot.ai is a separate origin with no
+   nginx in front of it, so nothing there inherits anything from the website.
+
+The nginx parse is deliberately crude — a brace counter over one file we write
+ourselves, not a config parser. It only has to be right about this file.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+ROOT = Path(__file__).resolve().parents[3]
+INDEX_HTML = ROOT / "app" / "index.html"
+HEADERS_CONF = ROOT / "app" / "security-headers.conf"
+NGINX_CONF = ROOT / "app" / "nginx.conf"
+
+INCLUDE_LINE = "include /etc/nginx/security-headers.conf;"
+
+# Comments are stripped BEFORE the script scan. index.html documents its own
+# Eruda loader with the words `Plain <script> (not type="module")`, and a
+# regex that reads that as a tag hashes the comment prose instead of the
+# script — silently, and with a hash that looks perfectly plausible.
+_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+_SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script>", re.DOTALL | re.IGNORECASE)
+_TYPE = re.compile(r"""type\s*=\s*["']?([^"'\s>]+)""", re.IGNORECASE)
+# A <script> whose type is none of these is a DATA BLOCK (the three JSON-LD
+# blocks in index.html): the browser never executes it, and CSP never asks for
+# a hash.
+_EXECUTABLE_TYPES = {"", "module", "text/javascript", "application/javascript"}
+
+
+def inline_script_hashes(html: str) -> list[str]:
+    """`sha256-…` for every executable inline script, in document order."""
+    html = _COMMENT.sub("", html)
+    out = []
+    for match in _SCRIPT.finditer(html):
+        attrs = match.group("attrs")
+        if "src=" in attrs:
+            continue
+        declared = _TYPE.search(attrs)
+        if (declared.group(1).lower() if declared else "") not in _EXECUTABLE_TYPES:
+            continue
+        digest = hashlib.sha256(match.group("body").encode("utf-8")).digest()
+        out.append(f"sha256-{base64.b64encode(digest).decode('ascii')}")
+    return out
+
+
+def csp_directives() -> dict[str, list[str]]:
+    """The Content-Security-Policy(-Report-Only) value, split by directive."""
+    conf = HEADERS_CONF.read_text(encoding="utf-8")
+    match = re.search(r'add_header\s+Content-Security-Policy(?:-Report-Only)?\s+"([^"]+)"', conf)
+    assert match, "no Content-Security-Policy header found in app/security-headers.conf"
+    directives = {}
+    for part in match.group(1).split(";"):
+        tokens = part.split()
+        if tokens:
+            directives[tokens[0]] = tokens[1:]
+    return directives
+
+
+_ADD_HEADER = re.compile(r"^\s*add_header\b", re.MULTILINE)
+
+
+def _without_comments(text: str) -> str:
+    """nginx comment lines dropped — a `#` line that MENTIONS `add_header` is
+    prose, and prose must not count as a directive."""
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def locations_with_add_header() -> list[str]:
+    """Every `location …{ … }` block of app/nginx.conf that sets a header itself.
+
+    Returned as the raw block text, so the caller can check what is inside it.
+    """
+    conf = NGINX_CONF.read_text(encoding="utf-8")
+    blocks = []
+    for match in re.finditer(r"^\s*location\s[^{]*\{", conf, re.MULTILINE):
+        depth = 0
+        start = match.start()
+        for i in range(match.end() - 1, len(conf)):
+            if conf[i] == "{":
+                depth += 1
+            elif conf[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(conf[start : i + 1])
+                    break
+    return [b for b in blocks if _ADD_HEADER.search(_without_comments(b))]
+
+
+def recorded_hashes() -> list[str]:
+    """The `sha256-…` values app/security-headers.conf keeps in its comment."""
+    conf = HEADERS_CONF.read_text(encoding="utf-8")
+    comments = "\n".join(line for line in conf.splitlines() if line.lstrip().startswith("#"))
+    return re.findall(r"'(sha256-[A-Za-z0-9+/=]+)'", comments)
+
+
+def test_recorded_hashes_match_the_inline_scripts_of_index_html():
+    """The hashes the conf holds in reserve still describe the scripts they name."""
+    expected = inline_script_hashes(INDEX_HTML.read_text(encoding="utf-8"))
+    assert expected, "app/index.html has no inline scripts — did the extraction break?"
+    assert sorted(recorded_hashes()) == sorted(expected), (
+        "the hashes recorded in app/security-headers.conf and app/index.html's inline "
+        "scripts disagree.\n"
+        f"  recorded: {sorted(recorded_hashes())}\n"
+        f"  computed: {sorted(expected)}\n"
+        "Recompute after ANY edit to an inline <script> — even whitespace."
+    )
+
+
+def test_script_src_never_mixes_unsafe_inline_with_hashes():
+    """The two together are the trap, not the belt-and-braces pair they look like.
+
+    A browser ignores `'unsafe-inline'` as soon as a hash or nonce is present.
+    So a policy carrying both is exactly as strict as the hash list alone —
+    which, while Cloudflare JavaScript Detections injects an unhashable inline
+    script, means the edge's script is blocked while the policy reads as though
+    nothing changed.
+    """
+    script_src = csp_directives()["script-src"]
+    has_hash = any(t.startswith("'sha256-") for t in script_src)
+    assert not (has_hash and "'unsafe-inline'" in script_src), (
+        "script-src carries both a hash and 'unsafe-inline'. The browser ignores the "
+        "latter, so this is the hash-only policy with a misleading label. Pick one."
+    )
+
+
+def test_object_src_and_base_uri_stay_closed():
+    """The two directives `default-src` does not cover on its own."""
+    directives = csp_directives()
+    assert directives["object-src"] == ["'none'"]
+    assert directives["base-uri"] == ["'self'"]
+
+
+def test_reporting_directives_are_not_both_present():
+    """`report-to` beside `report-uri` silences Chromium entirely.
+
+    Measured in the sibling repo kurrentschrift: with both directives in one
+    policy, Chromium sends NO report at all rather than preferring the newer
+    one. Neither is set here today; this test exists so that whoever adds
+    reporting adds exactly one of them.
+    """
+    directives = csp_directives()
+    assert not ("report-to" in directives and "report-uri" in directives), (
+        "CSP carries both report-to and report-uri — Chromium then reports nothing. Keep one."
+    )
+
+
+def test_every_location_with_its_own_header_reincludes_the_snippet():
+    """nginx drops inherited add_headers per location; each one must re-include."""
+    # `.strip()` first: the block regex may start its match on the newline
+    # before `location`, which would otherwise name the offender as "".
+    missing = [b.strip().splitlines()[0].strip() for b in locations_with_add_header() if INCLUDE_LINE not in b]
+    assert not missing, (
+        "these app/nginx.conf locations set an add_header and so lose every inherited "
+        f"security header: {missing}. Add `{INCLUDE_LINE}` to each."
+    )
+
+
+def test_the_api_host_stamps_its_own_baseline_headers():
+    """api.anyplot.ai has no nginx in front of it and inherits nothing."""
+    response = TestClient(app).get("/health")
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    # NOT X-Frame-Options: the SPA embeds /proxy/html cross-origin in an iframe,
+    # which SAMEORIGIN would break.
+    assert "X-Frame-Options" not in response.headers

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -19,7 +19,8 @@ which has cost someone a day somewhere:
    one URL.
 
 3. **The API host's own headers.** api.anyplot.ai is a separate origin with no
-   nginx in front of it, so nothing there inherits anything from the website.
+   nginx in front of it, so nothing there inherits anything from the website —
+   and it has two exits, only one of which is a middleware.
 
 The nginx parse is deliberately crude — a brace counter over one file we write
 ourselves, not a config parser. It only has to be right about this file.
@@ -34,7 +35,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from api.main import app
+from api.main import app, fastapi_app
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -57,6 +58,12 @@ _COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
 # `</scriptfoo>` from counting as a close.
 _SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script(?=[\s/>])[^>]*>", re.DOTALL | re.IGNORECASE)
 _TYPE = re.compile(r"""type\s*=\s*["']?([^"'\s>]+)""", re.IGNORECASE)
+# An EXTERNAL script, which CSP judges by its URL and never by a hash. HTML
+# attribute names are case-insensitive and whitespace around `=` is legal, so
+# `<script SRC = "…">` is external too — a plain `"src=" in attrs` called it
+# inline and would have demanded a hash for a script with no body (Copilot
+# review). `\b` keeps it from matching a `data-src=` or an `xlink:src=`.
+_SRC = re.compile(r"\bsrc\s*=", re.IGNORECASE)
 # A <script> whose type is none of these is a DATA BLOCK (the three JSON-LD
 # blocks in index.html): the browser never executes it, and CSP never asks for
 # a hash.
@@ -69,7 +76,7 @@ def inline_script_hashes(html: str) -> list[str]:
     out = []
     for match in _SCRIPT.finditer(html):
         attrs = match.group("attrs")
-        if "src=" in attrs:
+        if _SRC.search(attrs):
             continue
         declared = _TYPE.search(attrs)
         if (declared.group(1).lower() if declared else "") not in _EXECUTABLE_TYPES:
@@ -166,17 +173,31 @@ def test_object_src_and_base_uri_stay_closed():
     assert directives["base-uri"] == ["'self'"]
 
 
-def test_reporting_directives_are_not_both_present():
-    """`report-to` beside `report-uri` silences Chromium entirely.
+def reporting_endpoint_groups() -> set[str]:
+    """The group names `Reporting-Endpoints` defines, if the header is set at all."""
+    conf = HEADERS_CONF.read_text(encoding="utf-8")
+    match = re.search(r'add_header\s+Reporting-Endpoints\s+"([^"]+)"', conf)
+    if not match:
+        return set()
+    return {part.split("=", 1)[0].strip() for part in match.group(1).split(",") if "=" in part}
 
-    Measured in the sibling repo kurrentschrift: with both directives in one
-    policy, Chromium sends NO report at all rather than preferring the newer
-    one. Neither is set here today; this test exists so that whoever adds
-    reporting adds exactly one of them.
+
+def test_a_named_report_to_group_is_actually_defined():
+    """`report-to <group>` is inert unless `Reporting-Endpoints` defines <group>.
+
+    The failure this guards is silence, which looks exactly like "no
+    violations": a policy that names a group nobody declared sends nothing, and
+    the sibling repo spent a measurement on that before recognising it. Note
+    what is NOT asserted — `report-uri` beside `report-to` is a legitimate
+    migration setup, since Chromium prefers `report-to` and keeps `report-uri`
+    as the fallback for clients that lack it (Copilot review). Neither is set
+    here today; this exists for whoever adds reporting.
     """
-    directives = csp_directives()
-    assert not ("report-to" in directives and "report-uri" in directives), (
-        "CSP carries both report-to and report-uri — Chromium then reports nothing. Keep one."
+    named = csp_directives().get("report-to", [])
+    missing = [group for group in named if group not in reporting_endpoint_groups()]
+    assert not missing, (
+        f"CSP names report-to group(s) {missing} that no Reporting-Endpoints header defines — "
+        "reports would go nowhere, and nowhere reads as 'no violations'."
     )
 
 
@@ -199,3 +220,29 @@ def test_the_api_host_stamps_its_own_baseline_headers():
     # NOT X-Frame-Options: the SPA embeds /proxy/html cross-origin in an iframe,
     # which SAMEORIGIN would break.
     assert "X-Frame-Options" not in response.headers
+
+
+def test_an_unhandled_500_carries_them_too():
+    """The exit the header middleware cannot reach.
+
+    `ServerErrorMiddleware` wraps every user middleware, so a route that RAISES
+    makes `await call_next(request)` raise with it and the response
+    `generic_exception_handler` builds never passes back through the stack
+    (Copilot review). The handler stamps the headers itself, through the same
+    helper — this is what proves the two exits agree.
+    """
+
+    # `app` is the ASGI wrapper (HeadAsGetMiddleware); `fastapi_app` is the
+    # instance that owns the router and the exception handlers.
+    @fastapi_app.get("/_test/raises", include_in_schema=False)
+    async def _boom() -> None:
+        raise RuntimeError("boom")
+
+    try:
+        response = TestClient(app, raise_server_exceptions=False).get("/_test/raises")
+        assert response.status_code == 500
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    finally:
+        routes = fastapi_app.router.routes
+        routes[:] = [r for r in routes if getattr(r, "path", None) != "/_test/raises"]

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -49,11 +49,13 @@ INCLUDE_LINE = "include /etc/nginx/security-headers.conf;"
 # regex that reads that as a tag hashes the comment prose instead of the
 # script — silently, and with a hash that looks perfectly plausible.
 _COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
-# `</script\s*>`, not `</script>`: HTML lets whitespace sit before the `>` of a
-# closing tag, and a regex that misses `</script >` would silently swallow the
-# rest of the document into one "script body" and hash that. CodeQL's
-# py/bad-tag-filter says so, and it is right — this parses a file people edit.
-_SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script\s*>", re.DOTALL | re.IGNORECASE)
+# The closing tag is `</script` followed by whitespace, `/` or `>`, and then
+# anything up to the first `>` — which is what a browser accepts and what
+# CodeQL's py/bad-tag-filter insists on (`</script >`, `</script\t\n bar>`). A
+# regex that missed one of those would swallow the rest of the document into a
+# single "script body" and hash that, silently. The lookahead is what keeps
+# `</scriptfoo>` from counting as a close.
+_SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script(?=[\s/>])[^>]*>", re.DOTALL | re.IGNORECASE)
 _TYPE = re.compile(r"""type\s*=\s*["']?([^"'\s>]+)""", re.IGNORECASE)
 # A <script> whose type is none of these is a DATA BLOCK (the three JSON-LD
 # blocks in index.html): the browser never executes it, and CSP never asks for


### PR DESCRIPTION
The brief was "swap `script-src 'unsafe-inline'` for sha256 hashes, then walk the public pages with the console open". The walk is what changed the answer, so the measurement comes first.

## The measurement: hash-only `script-src` breaks Cloudflare, not the SPA

`app/index.html` has three executable inline scripts (theme resolver, Eruda loader, Plausible stub) and three JSON-LD data blocks that need no hash. `yarn build` was verified to copy the three through byte-for-byte, so hashing the source file describes what nginx serves.

The candidate policy was then mounted over the **live production bundle** — a local proxy that mirrors `https://anyplot.ai` and re-stamps the response with each header set — and loaded twice in Chrome:

| `script-src` | Cloudflare's injected script | console |
|---|---|---|
| `'self' 'unsafe-inline' cdn.jsdelivr.net` (today) | runs — its hidden iframe is in the DOM | clean of CSP |
| `'self' <3 × sha256> cdn.jsdelivr.net` | **blocked** — no iframe | `Executing inline script violates the following Content Security Policy directive … The action has been blocked.` |

Exactly one script is blocked, and it is not ours. **Cloudflare JavaScript Detections** injects an inline script into every HTML response at the edge, after nginx:

```js
window.__CF$cv$params={r:'a357b436fa1aa625',t:'MTc4ODQ2OTQzNQ=='};…
```

The ray id and timestamp change per response, so its hash does too — it can never be listed. Confirmed the same script and iframe on `https://anyplot.ai` itself, so this is production behaviour, not a proxy artefact.

Shipping the hardened policy would have silently degraded bot detection on a site whose brand-new origin gate (#11208) explicitly leans on the edge. So it is **not shipped**, and — equally deliberately — the hashes are not added *next to* `'unsafe-inline'` either: a browser ignores `'unsafe-inline'` the moment a hash appears, so that combination is the identical breakage wearing a stricter-looking label. A test now forbids it.

**The way out is a nonce, not a hash.** Cloudflare [documents](https://developers.cloudflare.com/bots/additional-configurations/javascript-detections/) that it parses this response header and stamps its injected script with the nonce it finds, and recommends that over `'unsafe-inline'`. That needs nginx to mint one per request and rewrite index.html's `<script>` tags (`sub_filter` plus `gzip_static off` for the shell) — a delivery change no test in this repo can prove and no local nginx here can run. **Owner call**, and the alternative (turning JavaScript Detections off in the zone) is a security trade rather than a fix. The reasoning, the numbers and the three hashes sit in `security-headers.conf` at the directive they explain, so the switch is a one-line edit whenever one of the two happens.

## What does ship

**The API host stamps its own baseline headers.** `api.anyplot.ai` is a separate origin with no nginx in front of it, so it inherited none of `app/security-headers.conf` — only `/proxy/html` set `nosniff` and a `Referrer-Policy`, by hand, on that one response. An outermost middleware now `setdefault`s both on every response, including CORS preflights, the origin gate's 403 and the exception handlers' 500s. Deliberately **not** `X-Frame-Options`: the SPA embeds `/proxy/html` cross-origin in an iframe (`frame-src https://api.anyplot.ai`), and `SAMEORIGIN` would break every interactive plot preview — the test asserts its absence so nobody adds it as an obvious-looking improvement.

**Both `/_health` locations stop dropping the site's headers.** They set an `add_header` of their own, and nginx drops every inherited header in such a location — the rule stated at the top of `security-headers.conf`, and the one place in `nginx.conf` that had missed it. Found by the new test, verified against `origin/main`:

```
locations missing the include on origin/main: ['location /_health {', 'location /_health {']
after the fix: []
```

**`tests/unit/api/test_csp_policy.py`** — six checks over files that nothing else compiles or imports: the reserve hashes still match `index.html`; `script-src` never mixes `'unsafe-inline'` with a hash; `object-src 'none'` and `base-uri 'self'` stay closed; the policy never carries `report-to` *beside* `report-uri` (measured in the sibling repo: Chromium then reports nothing at all — neither is set here today, so this exists for whoever adds reporting); every nginx location with its own header re-includes the snippet; and the API host's two headers are present while `X-Frame-Options` is not.

One anyplot-specific trap it had to handle: `index.html` documents its own Eruda loader with the words `Plain <script> (not type="module")` **inside an HTML comment**, and a script regex that reads that as a tag hashes the comment prose instead of the script — silently, with a hash that looks perfectly plausible. Comments are stripped first.

## Items from the brief that turned out to be no-ops here

- **`report-to` beside `report-uri`** — anyplot's CSP has neither. Encoded as a test instead of a fix.
- **`bluetooth=()` in the Permissions-Policy** — anyplot sends no `Permissions-Policy` at all. Nothing to remove. Adding one is a separate, easy hardening pass; not folded in here.

## Verification

`pytest tests/unit tests/integration` — 1913 passed, 1 skipped. `ruff check`, `ruff format --check` and `mypy api core` clean. The CSP walk itself is the table above, run against the live bundle in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEScQMZFvxxNNyNJYryfa3
