### PR TITLE
docs(legal): a privacy policy that matches the code, one retention per store

### DIFF
--- a/api/routers/seo.py
+++ b/api/routers/seo.py
@@ -1054,8 +1054,10 @@ _LEGAL_BOT_BODY = (
     '<a href="https://x.com/MarkusNeusinger">X</a>). Full legal notice with '
     'contact details on the <a href="https://anyplot.ai/legal">interactive page</a>.</p>'
     "<h2>Privacy</h2>"
-    "<p>Analytics: Plausible Analytics (EU, proxied) — no cookies, no personal data collected. "
-    "Hosting: Google Cloud Run (Netherlands).</p>"
+    "<p>Analytics: Plausible Analytics (EU), served over a path on this domain — no cookies, no "
+    "cross-site identifier, no IP address stored. Server logs are kept 30 days; a feedback entry "
+    "is kept until it is deleted by hand and is readable only by the operator. Hosting: Google "
+    "Cloud Run (Netherlands), with Cloudflare at the edge.</p>"
     "<h2>Transparency</h2>"
     "<p>The whole stack — specs, pipeline, API and frontend — is open source at "
     '<a href="https://github.com/MarkusNeusinger/anyplot">github.com/MarkusNeusinger/anyplot</a>; '

--- a/app/src/pages/LegalPage.test.tsx
+++ b/app/src/pages/LegalPage.test.tsx
@@ -77,8 +77,16 @@ describe('LegalPage', () => {
     render(<LegalPage />);
 
     // The feedback widget asks for "Name or email (optional)", so the old
-    // blanket "no personal data" was false.
-    expect(screen.getByText(/no personal data unless you type it/)).toBeInTheDocument();
+    // blanket "no personal data" was false — and so is any restatement of it:
+    // an IP address, an IP hash and the feedback session id are personal data
+    // whether or not you typed them, so the bullet promises only name/email.
+    expect(screen.getByText(/no name or email unless you type one/)).toBeInTheDocument();
+    // Everything the feedback record actually holds, so a later trim cannot
+    // quietly drop the two identifiers a reader would care about most.
+    expect(screen.getByText(/your window size/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/a random id that ties your own submissions together/)
+    ).toBeInTheDocument();
     // Plausible's real property is cookieless and identifier-free, not that
     // the script is ours — it is Plausible's, only served from our domain.
     expect(screen.getByText(/the script is theirs/)).toBeInTheDocument();

--- a/app/src/pages/LegalPage.test.tsx
+++ b/app/src/pages/LegalPage.test.tsx
@@ -50,6 +50,41 @@ describe('LegalPage', () => {
     expect(plausibleLinks.length).toBeGreaterThan(0);
   });
 
+  // The privacy section's load-bearing claims, each pinned where it is true.
+  // A shortening pass is exactly what drops a qualifier — "30 days" silently
+  // spreading over a store that has no timer, or the objection right losing
+  // the condition that makes it one.
+  it('names the legal basis, the jurisdiction and the whole set of rights', () => {
+    render(<LegalPage />);
+
+    expect(screen.getByText(/legitimate interest in protecting the site/)).toBeInTheDocument();
+    expect(screen.getByText(/swiss data protection law applies/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/object to the processing on grounds relating to your particular situation/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/complain to a supervisory authority/)).toBeInTheDocument();
+  });
+
+  it('gives each store its own retention, and no store a borrowed one', () => {
+    render(<LegalPage />);
+
+    // Cloud Logging has the 30 days; the feedback table has no timer at all.
+    expect(screen.getByText(/retained for 30 days/)).toBeInTheDocument();
+    expect(screen.getByText(/nothing deletes them on a timer/)).toBeInTheDocument();
+  });
+
+  it('does not claim more privacy than the code delivers', () => {
+    render(<LegalPage />);
+
+    // The feedback widget asks for "Name or email (optional)", so the old
+    // blanket "no personal data" was false.
+    expect(screen.getByText(/no personal data unless you type it/)).toBeInTheDocument();
+    // Plausible's real property is cookieless and identifier-free, not that
+    // the script is ours — it is Plausible's, only served from our domain.
+    expect(screen.getByText(/the script is theirs/)).toBeInTheDocument();
+    expect(screen.getByText(/Cloudflare stands in front of the site/)).toBeInTheDocument();
+  });
+
   it('renders the technology stack', () => {
     render(<LegalPage />);
 

--- a/app/src/pages/LegalPage.tsx
+++ b/app/src/pages/LegalPage.tsx
@@ -188,22 +188,26 @@ export function LegalPage() {
 
           <Box sx={{ maxWidth: 760, mx: 'auto' }}>
             <Typography sx={subheadingStyle}>data controller</Typography>
-            <Typography sx={textStyle}>Markus Neusinger (see legal notice above)</Typography>
+            <Typography sx={textStyle}>
+              Markus Neusinger (see legal notice above). the ground for all of it is an
+              operator&apos;s legitimate interest in protecting the site and knowing how often it is
+              read; swiss data protection law applies, and the GDPR on top for visitors from the EU.
+            </Typography>
 
             <Typography sx={subheadingStyle}>what we collect</Typography>
             <Typography sx={textStyle}>
-              <strong>anonymized analytics.</strong> we use{' '}
+              <strong>anonymized analytics.</strong> the counting is done by{' '}
               <Link href="https://plausible.io" target="_blank" rel="noopener" sx={proseLinkStyle}>
                 Plausible Analytics
               </Link>
-              , a privacy-focused analytics tool. it collects no personal data, uses no cookies, and
-              does not track you across websites. we track: page views, navigation patterns, code
-              copies, image downloads, search queries, filter usage, UI interactions (tab toggles,
-              theme preference, banner dismissals), and anonymized performance metrics (Core Web
-              Vitals: LCP, CLS, INP) to keep the site fast. when you share a link, we read the
-              requesting bot&apos;s user-agent to detect the platform (e.g., LinkedIn, WhatsApp) —
-              no data about the eventual viewer is collected at that step. all data is aggregated
-              and anonymous.
+              . the script is theirs, but it is served over a path on this domain: no cookies, no
+              identifier that would recognize you on other sites, no IP address kept there, and your
+              browser talks only to us. counted are page views, search queries and filter usage,
+              code copies and image downloads, theme and navigation clicks, and Core Web Vitals
+              (LCP, CLS, INP) to keep the site fast. when you share a link, we read the requesting
+              bot&apos;s user-agent to detect the platform (e.g., LinkedIn, WhatsApp) — no data
+              about the eventual viewer is collected at that step. all data is aggregated and
+              anonymous.
             </Typography>
             <Typography sx={textStyle}>
               <strong>public dashboard.</strong> our analytics are{' '}
@@ -230,16 +234,31 @@ export function LegalPage() {
               </Link>{' '}
               for security and debugging purposes.
             </Typography>
+            <Typography sx={textStyle}>
+              <strong>feedback.</strong> the feedback widget keeps what you send it: the message,
+              the reaction, anything you put in the optional contact field, the page you were on,
+              your user-agent, and a one-way hash of your IP address that limits spam. only the
+              operator can read those entries, and nothing deletes them on a timer — ask and yours
+              is gone.
+            </Typography>
+            <Typography sx={textStyle}>
+              <strong>the edge.</strong> Cloudflare stands in front of the site and processes your
+              IP address there to rate-limit, to filter bots — which can put a short check page in
+              front of a request — and to absorb DDoS attacks.
+            </Typography>
 
             <Typography sx={subheadingStyle}>what we do not collect</Typography>
             <Typography sx={textStyle}>
               • no user accounts or personal profiles
               <br />
-              • no personal data (names, emails, etc.)
+              • no personal data unless you type it — the optional contact field in the feedback
+              widget is the only one that asks for a name or an email
               <br />
-              • no cookies at all (we use localStorage for UI preferences only)
-              <br />• <strong>no ai training</strong>: your interactions are not used to train ai
-              models
+              • no cookies at all (localStorage holds UI preferences — theme, image size — and a
+              cached release number)
+              <br />• <strong>no ai training</strong>: nothing you send is used to train ai models.
+              the ai in this project writes the catalogue, at build time; it never sees a
+              visitor&apos;s request
             </Typography>
 
             <Typography sx={textStyle}>
@@ -250,7 +269,9 @@ export function LegalPage() {
 
             <Typography sx={subheadingStyle}>hosting &amp; third parties</Typography>
             <Typography sx={textStyle}>
-              all services are hosted in the EU (Netherlands, europe-west4):
+              the site, its database and its images run in the EU (Netherlands, europe-west4);
+              Cloudflare&apos;s network is global, and Plausible is a service of its own on its own
+              EU servers:
             </Typography>
             <Table sx={{ ...tableStyle, ...firstColStyle }}>
               <TableBody>
@@ -279,13 +300,14 @@ export function LegalPage() {
 
             <Typography sx={subheadingStyle}>your rights</Typography>
             <Typography sx={textStyle}>
-              you have the right to access, rectify, erase, and export your data. since we do not
-              store personal data, there is typically nothing to delete or export. for questions,
-              contact{' '}
+              you can ask what is stored about you and have it corrected, erased or its use
+              restricted, object to the processing on grounds relating to your particular situation,
+              and complain to a supervisory authority. in practice that means a feedback entry or a
+              log line; a few lines to{' '}
               <Link href="mailto:admin@anyplot.ai" sx={proseLinkStyle}>
                 admin@anyplot.ai
-              </Link>
-              .
+              </Link>{' '}
+              are enough.
             </Typography>
           </Box>
         </Box>
@@ -554,7 +576,7 @@ export function LegalPage() {
             mt: 2,
           }}
         >
-          last updated: July 2026
+          last updated: September 2026
         </Typography>
       </Box>
     </>

--- a/app/src/pages/LegalPage.tsx
+++ b/app/src/pages/LegalPage.tsx
@@ -237,9 +237,9 @@ export function LegalPage() {
             <Typography sx={textStyle}>
               <strong>feedback.</strong> the feedback widget keeps what you send it: the message,
               the reaction, anything you put in the optional contact field, the page you were on,
-              your user-agent, and a one-way hash of your IP address that limits spam. only the
-              operator can read those entries, and nothing deletes them on a timer — ask and yours
-              is gone.
+              your window size, your user-agent, a random id that ties your own submissions
+              together, and a one-way hash of your IP address that limits spam. only the operator
+              can read those entries, and nothing deletes them on a timer — ask and yours is gone.
             </Typography>
             <Typography sx={textStyle}>
               <strong>the edge.</strong> Cloudflare stands in front of the site and processes your
@@ -251,11 +251,11 @@ export function LegalPage() {
             <Typography sx={textStyle}>
               • no user accounts or personal profiles
               <br />
-              • no personal data unless you type it — the optional contact field in the feedback
-              widget is the only one that asks for a name or an email
+              • no name or email unless you type one — the optional contact field in the feedback
+              widget is the only place that asks
               <br />
-              • no cookies at all (localStorage holds UI preferences — theme, image size — and a
-              cached release number)
+              • no cookies at all (localStorage holds UI preferences — theme, image size — a cached
+              release number, and, once you use the feedback widget, the random id above)
               <br />• <strong>no ai training</strong>: nothing you send is used to train ai models.
               the ai in this project writes the catalogue, at build time; it never sees a
               visitor&apos;s request

--- a/changelog.d/legal-privacy-audit.md
+++ b/changelog.d/legal-privacy-audit.md
@@ -13,4 +13,4 @@
   Plausible's, only served from here), Cloudflare's edge processing of the IP is named, and
   the "all services in the EU" line no longer swallows a global CDN and a separate analytics
   service. The crawler body in `api/routers/seo.py` mirrored the same wrong sentence and was
-  corrected with it.
+  corrected with it (#11217).

--- a/changelog.d/legal-privacy-audit.md
+++ b/changelog.d/legal-privacy-audit.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **The privacy policy says what the code actually does, per store.** The section had drifted
+  behind a year of features: it promised "no personal data (names, emails, etc.)" while the
+  feedback widget asks for exactly that ("Name or email (optional)") and keeps it, with the
+  message, the page, the user agent and an IP hash, in a table nothing prunes on a timer. It
+  also had no legal basis, no jurisdiction, and a rights list missing restriction, objection
+  and the complaint to a supervisory authority. Each store now carries its own retention —
+  Cloud Logging's 30 days, a feedback entry until it is deleted by hand — because a single
+  blanket figure is the qualifier a shortening pass loses first. Plausible is described by the
+  property that matters (no cookies, no cross-site identifier, no IP stored, the browser
+  talking only to our domain) rather than the false one it used to claim (the script is
+  Plausible's, only served from here), Cloudflare's edge processing of the IP is named, and
+  the "all services in the EU" line no longer swallows a global CDN and a separate analytics
+  service. The crawler body in `api/routers/seo.py` mirrored the same wrong sentence and was
+  corrected with it.

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -1171,7 +1171,10 @@ class TestSeoProxyRouter:
         # the feedback widget's optional contact field made false. It now
         # carries the same per-store retention the human page does.
         assert "no personal data collected" not in response.text
+        # BOTH retentions, not only the logs' — pinning just the 30 days is how
+        # that figure silently spreads over the store it is not true for.
         assert "kept 30 days" in response.text
+        assert "until it is deleted by hand" in response.text
 
     def test_seo_mcp_tells_agents_how_to_connect(self, client: TestClient) -> None:
         """The /mcp page's audience is AI agents — the bot body must carry the

--- a/tests/unit/api/test_routers.py
+++ b/tests/unit/api/test_routers.py
@@ -1167,6 +1167,11 @@ class TestSeoProxyRouter:
         assert "Plausible Analytics" in response.text
         assert "no cookies" in response.text
         assert "Google Cloud Run" in response.text
+        # The crawler body used to promise "no personal data collected", which
+        # the feedback widget's optional contact field made false. It now
+        # carries the same per-store retention the human page does.
+        assert "no personal data collected" not in response.text
+        assert "kept 30 days" in response.text
 
     def test_seo_mcp_tells_agents_how_to_connect(self, client: TestClient) -> None:
         """The /mcp page's audience is AI agents — the bot body must carry the


### PR DESCRIPTION
## Summary

- **The privacy section now says what the code does.** It had drifted behind a year of features; every claim in it (and the services table behind it) was checked against the current code and infrastructure, and what no longer held was fixed or dropped. Same lowercase house voice, same length class — the section grew by three short paragraphs, not by an article-by-article rewrite.
- **One retention per store, none borrowed.** Server logs get Cloud Logging's 30 days; a feedback entry gets "nothing deletes them on a timer — ask and yours is gone". A single blanket figure is the qualifier a shortening pass loses first, so the tests pin both separately.
- **The crawler body in `api/routers/seo.py` carried the same wrong sentence** ("no personal data collected") and is corrected in the same commit — that string is anyplot's prerender for `/legal`, and its own comment asks for the two to stay in sync.

## What was added

| | |
|---|---|
| legal basis + jurisdiction | one sentence under `data controller`: an operator's legitimate interest in protecting the site and knowing how often it is read; Swiss data protection law, GDPR on top for EU visitors. No article numbers, no EU-representative claim. |
| feedback retention | a new `feedback.` paragraph: every field the widget stores (message, reaction, contact, page, window size, user agent, submission id, IP hash), admin-only, no timer |
| the edge | a new `the edge.` paragraph: Cloudflare processes the IP for rate limiting, bot filtering (which can show a check page) and DDoS |
| rights | access, rectification, erasure, restriction, objection **on grounds relating to your particular situation**, complaint to a supervisory authority — one sentence, no article numbers |

## What was wrong and is now fixed

Each claim with the evidence that decided it:

| Claim as it stood | Verdict | Evidence |
|---|---|---|
| "no personal data (names, emails, etc.)" | **false** → "no name or email unless you type one — the optional contact field in the feedback widget is the only place that asks" | `app/src/components/FeedbackWidget.tsx:485` placeholder is literally `Name or email (optional)`; stored at `core/database/models.py:250` (`contact`), alongside `message`, `viewport`, `user_agent`, `session_id`, `ip_hash` (`models.py:248–259`). The promise is deliberately *only* name/email: an IP address, its hash and the feedback session id are personal data whether or not anyone typed them, so any broader "no personal data" wording would be the same false claim again (Copilot review) |
| Plausible "collects no personal data … a privacy-focused analytics tool" | **wrong property** → no cookies, no cross-site identifier, no IP kept there, the browser talks only to us | the script IS Plausible's, only served from our domain: `app/nginx.conf:321–323` proxies `/js/script.js`, `:335` proxies `/api/event`; `app/index.html:143,145` |
| "all services are hosted in the EU (Netherlands, europe-west4)" | **over-broad** → the site, database and images run in europe-west4; Cloudflare's network is global; Plausible is its own EU service | `api/cloudbuild.yaml:4` `_REGION: europe-west4`, `:66` `anyplot:europe-west4:anyplot-db`; `gcloud storage buckets list` → `anyplot-images`, `anyplot-static` both `EUROPE-WEST4` |
| "we track … UI interactions (tab toggles, theme preference, **banner dismissals**)" | **stale** → list shortened to what is actually sent | the tracked event names are `copy_code, download_image, external_link, feedback_opened, feedback_submitted, internal_link, library_click, library_filter, map_*, nav_click, page_not_found, plot_rotate, report_issue, search_no_results, stats_top_impl_click, suggest_spec, tag_click, theme_toggle` — no banner event exists |
| "since we do not store personal data, there is typically nothing to delete or export" | **false**, and `export` was the wrong right | feedback entries exist; and portability applies to consent/contract processing, not to the legitimate interest this site runs on, so the export claim was dropped rather than restated |
| "no cookies at all (localStorage for UI preferences only)" | **true, but the inventory was short** | no `Set-Cookie` from `anyplot.ai` or `api.anyplot.ai` (curl, 2026-09-03). localStorage keys: `theme` (`useThemeMode.ts:3`), `imageSize` (`PlotsPage.tsx:100`), `anyplot:latest-release` (`useLatestRelease.ts:4`) and `anyplot_feedback_session` (`FeedbackWidget.tsx:25,144`). The last two are not preferences — one is a cached release number, the other a persistent random identifier — so both are named (Copilot review) |
| "no ai training: your interactions are not used to train ai models" | **true, sharpened** | Anthropic is called only from `scripts/evaluate-plot.py:500` (CI/generation time). `grep anthropic api/ core/` finds only the unused `core/config.py:79` key — nothing on a request path. The bullet now says so |
| bot body: "no personal data collected" (`api/routers/seo.py`) | **false** → same per-store wording as the human page | same evidence as row 1 |
| "last updated: July 2026" | stale → September 2026 | |

## What was checked and left alone

- **server logs, 30 days** — `gcloud logging buckets describe _Default --location=global --project=anyplot` → `retentionDays: 30`. This is the configured value (and also GCP's default), so the sentence stands as written.
- **the services table** — every row verified accurate (Cloud Run, Cloud SQL, Cloud Storage all `europe-west4`; Cloudflare global with EU data centres; Plausible EU + proxied). Only the sentence introducing it was over-broad.
- **the public Plausible dashboard** — `https://plausible.io/anyplot.ai` answers 200.
- **GitHub username credit in spec metadata** — real: `plots/*/specification.yaml` carries `suggested: <github handle>`. Paragraph kept unchanged.
- **CSP violation reports** — anyplot has **no** CSP reporting: `app/security-headers.conf:28` sets no `report-uri`/`report-to`, and the only `report-to` header on the live site is Cloudflare's own NEL endpoint, which reports to Cloudflare, not to us. Nothing was written about it, since there is nothing to write. (The sibling repo does have one; this is the asymmetry, not an omission.)
- **an in-process rate-limit counter** — anyplot has none. The only rate limit is the feedback endpoint's, and it is DB-backed via the stored `ip_hash` (`api/routers/feedback.py:96–101`), so it is covered by the feedback paragraph rather than getting one of its own.

## For Markus — please confirm

1. **The jurisdiction sentence.** "swiss data protection law applies, and the GDPR on top for visitors from the EU", with no EU representative named. That is the intended position, as agreed for kurrentschrift — say the word if anyplot should read differently.
2. **The one figure I could not verify from the repository:** the 30-day log retention comes from the live `_Default` Cloud Logging bucket, not from any file in the repo. If a sink or a bucket policy is ever changed in the console, this sentence goes stale silently — there is no test that can catch it.
3. **The feedback contact field is a genuine personal-data intake nobody had documented.** Free text plus "Name or email (optional)" is stored indefinitely and read only through the admin `/debug` routes (`api/routers/debug.py:547,560,599`, all `require_admin`). The page now says so honestly, but if you would rather the field stopped asking for an email, or entries got an automatic expiry, that is a code change and a separate PR.

## Decisions taken here

- Kept the existing skeleton (`data controller` · `what we collect` · `what we do not collect` · `hosting & third parties` · `your rights`) rather than adding sub-headings — the brief asked for a focused update, not a new page.
- Folded the legal basis into `data controller` instead of giving it its own heading; one sentence did not earn one.
- Dropped the right to data portability rather than restating it, per the reasoning in the table above.
- Named neither article numbers nor per-region service essays anywhere.

## Review round

One Copilot review, four findings, all legitimate and all applied in `6f6b610`: the feedback field list was missing the window size and the submission id; "no personal data unless you type it" was the old blanket claim in new words (an IP address, its hash and a persistent random id are personal data whether or not anyone typed them, and the page says so three paragraphs earlier); the localStorage inventory omitted `anyplot_feedback_session`; and the crawler-body test claimed to pin both retentions while asserting only the 30 days. Both threads answered and resolved.

## Test plan

- [x] `yarn type-check` (tsc + tsconfig.test.json) — clean
- [x] `yarn lint` — clean
- [x] `yarn fm:check` — clean
- [x] `yarn test` — 70 files, 626 tests pass; `LegalPage.test.tsx` grew from 9 to 12 cases, pinning the legal basis + jurisdiction, the per-store retentions, and the corrected claims (including the two feedback identifiers, so a later trim cannot drop them)
- [x] `uv run pytest -k seo_legal` — passes; the test now also asserts the old wrong sentence is gone
- [x] `uv run ruff check` + `ruff format --check` on the touched Python — clean
- [x] `uv run python -m tools.changelog check --base origin/main` — fragment well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEScQMZFvxxNNyNJYryfa3
