### PR TITLE
docs(changelog): the section describes one rollout state again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,8 +290,9 @@ aggregate instead: an italic *Catalog* line at the end of the version section an
   traffic** — `app/cloudbuild.yaml` now follows the same candidate-rollout pattern as
   `api/cloudbuild.yaml`: deploy with `--no-traffic --tag=candidate
   --revision-suffix=b$BUILD_ID`, smoke the candidate on its tag URL, then `update-traffic`
-  to exactly that revision (the chains are not identical — this one pushes `:latest` only
-  after the promotion, where the API still pushes it alongside the deploy). The service
+  to exactly that revision (the chains were not identical at the time — this one pushed
+  `:latest` only after the promotion, where the API still pushed it alongside the deploy;
+  the API caught up in #11212). The service
   carries the whole crawler path in `app/nginx.conf` — the `$is_bot` map, the `location =`
   bypasses, the `@seo_proxy` upstream — and that is the file whose breakage served every
   bot an HTTP 502 for four weeks in 2026 while humans, Plausible and CI all saw a healthy


### PR DESCRIPTION
One line of `CHANGELOG.md`, so the `[Unreleased]` section describes one rollout state instead of two.

#11207's frontend entry said:

> …then `update-traffic` to exactly that revision (the chains are not identical — this one pushes `:latest` only after the promotion, **where the API still pushes it alongside the deploy**).

#11212 is what changed that, so the sentence became false the moment it merged. Now:

> …to exactly that revision (the chains **were** not identical **at the time** — this one **pushed** `:latest` only after the promotion, where the API still **pushed** it alongside the deploy; **the API caught up in #11212**).

Past tense, and the closing PR named rather than a position: the release cut folds fragments in **above** the existing bullets, so "the entry above" would be wrong today and right after the cut, while `#11212` is true in both.

## Why `skip-changelog` rather than a fragment

This corrects an existing entry; it is not a change worth a release-notes line of its own. And it *needs* the label, because the fragment gate compares bullet **sets** — an edited bullet is indistinguishable from an added one. Measured rather than assumed, when this same edit first rode along in #11212:

```
error: CHANGELOG.md [Unreleased] gained a bullet — it belongs in a fragment:
- **The frontend deploys through a candidate revision instead of straigh…
```

That is the reason it was taken back out of #11212 and moved here.

The `skip-changelog` label did not exist in this repository — #11215 documented it as the escape hatch without creating it — so it was created for this PR (grey, "No changelog fragment needed: this PR changes nothing worth a release-notes line"). The gate's own `if:` condition now has something to match.

**Noted for later, not built here:** the gate could tell an *added* bullet from a *changed* one by treating the bold title as the bullet's identity, which would let a correction like this pass without a label. That is a sibling-pair change for both repos, deliberately out of scope tonight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEScQMZFvxxNNyNJYryfa3
