### PR TITLE
fix(security): swap script-src 'unsafe-inline' for a per-request CSP nonce

### DIFF
--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -1071,15 +1071,19 @@ Every deploy names its revision deterministically (`--revision-suffix=b$BUILD_ID
 promotes it explicitly, so earlier revisions are still there, still healthy, and one
 command away. Rolling back needs no rebuild and takes under a minute:
 
-```bash
-# 1. List recent revisions with their creation times.
-gcloud run revisions list --service anyplot-app --region europe-west4 \
-  --format='table(name, creationTimestamp, status.conditions[0].status)' --limit 10
+1. List the recent revisions with their creation times:
 
-# 2. Send all traffic to the one you want back.
-gcloud run services update-traffic anyplot-app --region europe-west4 \
-  --to-revisions=<chosen-revision>=100
-```
+   ```bash
+   gcloud run revisions list --service anyplot-app --region europe-west4 \
+     --format='table(name, creationTimestamp, status.conditions[0].status)' --limit 10
+   ```
+
+2. Send all traffic to the revision you want back:
+
+   ```bash
+   gcloud run services update-traffic anyplot-app --region europe-west4 \
+     --to-revisions=<chosen-revision>=100
+   ```
 
 Same shape for `anyplot-api`. This is the lever for anything that ships inside the image
 and only reveals itself in production.

--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -1098,7 +1098,7 @@ revision from before that PR still serves the `'unsafe-inline'` policy byte for 
 Once no such revision is left, the lever is a revert PR through the normal pipeline
 instead — slower, but by then the question has long been answered live.
 
-Deliberately NOT built for that case: a Cloud Run environment variable that flips the
+One thing is deliberately not built for that case: a Cloud Run environment variable that flips the
 policy inside a running revision. nginx cannot read the process environment from its
 configuration, so it would take a startup templating step (`envsubst` into a writable
 path — and `/etc/nginx` is read-only in the unprivileged image), which neither CI nor a

--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -1065,6 +1065,36 @@ place, and the residual is narrow: it needs the previous candidate to pass every
 well, so the worst case is promoting a revision that was believed smoked, not shipping a
 page known to be broken.
 
+### Rollback
+
+Every deploy names its revision deterministically (`--revision-suffix=b$BUILD_ID`) and
+promotes it explicitly, so the previous revision is still there, still healthy, and one
+command away. Rolling back needs no rebuild and takes under a minute:
+
+```bash
+# 1. Find the revision that served before the current one.
+gcloud run revisions list --service anyplot-app --region europe-west4 \
+  --format='table(name, creationTimestamp, status.conditions[0].status)' --limit 5
+
+# 2. Send all traffic back to it.
+gcloud run services update-traffic anyplot-app --region europe-west4 \
+  --to-revisions=<previous-revision>=100
+```
+
+Same shape for `anyplot-backend`. This is the lever for anything that ships inside the
+image and only reveals itself in production. The current example is the CSP nonce path in
+`app/security-headers.conf`: if Cloudflare ever stops stamping its edge-injected script
+with the nonce it reads from our response header, the previous revision still serves the
+`'unsafe-inline'` policy byte for byte.
+
+Deliberately NOT built for that case: a Cloud Run environment variable that flips the
+policy inside a running revision. nginx cannot read the process environment from its
+configuration, so it would take a startup templating step (`envsubst` into a writable
+path — and `/etc/nginx` is read-only in the unprivileged image), which neither CI nor a
+local checkout here can exercise. A mechanism whose failure mode is "the container does
+not start", and which nothing can test, is a worse rollback than a traffic split the
+deploy pipeline already proves on every build.
+
 ## Debugging Tips
 
 ### Database Connection Issues

--- a/agentic/docs/project-guide.md
+++ b/agentic/docs/project-guide.md
@@ -1068,24 +1068,31 @@ page known to be broken.
 ### Rollback
 
 Every deploy names its revision deterministically (`--revision-suffix=b$BUILD_ID`) and
-promotes it explicitly, so the previous revision is still there, still healthy, and one
+promotes it explicitly, so earlier revisions are still there, still healthy, and one
 command away. Rolling back needs no rebuild and takes under a minute:
 
 ```bash
-# 1. Find the revision that served before the current one.
+# 1. List recent revisions with their creation times.
 gcloud run revisions list --service anyplot-app --region europe-west4 \
-  --format='table(name, creationTimestamp, status.conditions[0].status)' --limit 5
+  --format='table(name, creationTimestamp, status.conditions[0].status)' --limit 10
 
-# 2. Send all traffic back to it.
+# 2. Send all traffic to the one you want back.
 gcloud run services update-traffic anyplot-app --region europe-west4 \
-  --to-revisions=<previous-revision>=100
+  --to-revisions=<chosen-revision>=100
 ```
 
-Same shape for `anyplot-backend`. This is the lever for anything that ships inside the
-image and only reveals itself in production. The current example is the CSP nonce path in
-`app/security-headers.conf`: if Cloudflare ever stops stamping its edge-injected script
-with the nonce it reads from our response header, the previous revision still serves the
-`'unsafe-inline'` policy byte for byte.
+Same shape for `anyplot-api`. This is the lever for anything that ships inside the image
+and only reveals itself in production.
+
+**Pick the target by what it contains, not by its position.** "The previous revision" is
+the right answer only while the change you are undoing is the most recent deploy; one more
+deploy later, the previous revision carries it too. The creation timestamps in step 1 are
+there for that — find the last revision created before the change landed. The current
+example is the CSP nonce path in `app/security-headers.conf`: if Cloudflare ever stops
+stamping its edge-injected script with the nonce it reads from our response header, any
+revision from before that PR still serves the `'unsafe-inline'` policy byte for byte.
+Once no such revision is left, the lever is a revert PR through the normal pipeline
+instead — slower, but by then the question has long been answered live.
 
 Deliberately NOT built for that case: a Cloud Run environment variable that flips the
 policy inside a running revision. nginx cannot read the process environment from its

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -158,6 +158,26 @@ steps:
         }
         # Humans get the SPA shell.
         expect "$$HUMAN" "/" '<div id="root">' "a browser did not get the SPA shell"
+        # …and every <script> tag in that shell carries the CSP nonce from its
+        # own response header. The two halves are one `$$request_id` read twice
+        # — `add_header` in security-headers.conf, `sub_filter` in nginx.conf —
+        # and losing the stamp is the silent failure this probe exists for: a
+        # precompressed shell served by `gzip_static`, a location the filter
+        # never reaches, a renamed variable. The page keeps its `<div id="root">`
+        # and looks perfectly healthy to every probe above while the browser
+        # blocks every inline script on it, because a nonce in the policy makes
+        # 'unsafe-inline' inert. Cheap to check here, four weeks of nobody
+        # noticing if it is not.
+        curl -fsS $$RETRY -A "$$HUMAN" -D head.out -o body.out "$$URL/" \
+          || { echo "candidate did not serve the shell for the nonce probe"; exit 1; }
+        NONCE=$$(grep -i '^content-security-policy:' head.out | grep -o 'nonce-[0-9a-f]*' | head -1)
+        test -n "$$NONCE" || { echo "the shell's Content-Security-Policy carries no nonce"; exit 1; }
+        grep -qF "<script nonce=\"$${NONCE#nonce-}\"" body.out \
+          || { echo "no <script> tag carries the header's $$NONCE — the sub_filter stamp did not run"; exit 1; }
+        UNSTAMPED=$$(grep -o '<script[^>]*>' body.out | grep -v 'nonce=' | wc -l)
+        test "$$UNSTAMPED" = "0" \
+          || { echo "$$UNSTAMPED <script> tag(s) in the shell carry no nonce and would be blocked"; exit 1; }
+        echo "OK: CSP nonce on every script tag of the shell"
         # Crawlers get the prerendered page through @seo_proxy. The canonical
         # link is the marker: the SPA shell carries none at all, and its value
         # names the route, so one grep proves both "the bot hop ran" and "the

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -178,8 +178,13 @@ steps:
         # docroot: plain curl saw 7 stamped tags, `curl --compressed` saw 0.
         curl -fsS $$RETRY --compressed -A "$$HUMAN" -D head.out -o body.out "$$URL/" \
           || { echo "candidate did not serve the shell for the nonce probe"; exit 1; }
-        NONCE=$$(grep -i '^content-security-policy:' head.out | grep -o 'nonce-[0-9a-f]*' | head -1)
-        test -n "$$NONCE" || { echo "the shell's Content-Security-Policy carries no nonce"; exit 1; }
+        # Exactly 32 hex digits, which is what nginx's $$request_id always is.
+        # `[0-9a-f]*` would have accepted a bare `nonce-` — and `test -n` calls
+        # that non-empty — so a policy with an empty nonce and `nonce=""` on
+        # every tag would have matched itself all the way through this probe
+        # while the browser blocked the lot (Copilot review).
+        NONCE=$$(grep -i '^content-security-policy:' head.out | grep -oE 'nonce-[0-9a-f]{32}' | head -1)
+        test -n "$$NONCE" || { echo "the shell's Content-Security-Policy carries no 32-hex-digit nonce"; exit 1; }
         # Every tag against THAT nonce, not "has some nonce": a stale or
         # mismatched value is refused by the browser exactly like a missing one,
         # and counting attributes rather than comparing them would wave it

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -168,7 +168,15 @@ steps:
         # blocks every inline script on it, because a nonce in the policy makes
         # 'unsafe-inline' inert. Cheap to check here, four weeks of nobody
         # noticing if it is not.
-        curl -fsS $$RETRY -A "$$HUMAN" -D head.out -o body.out "$$URL/" \
+        #
+        # `--compressed` is the load-bearing flag, not a courtesy. Plain curl
+        # sends no Accept-Encoding, so `gzip_static` never reaches for the
+        # `.gz` — and the single most likely way to lose the stamp is exactly a
+        # precompressed shell coming back, which this probe would then pass
+        # while every browser got the untouched file (Copilot review).
+        # Reproduced against a local nginx with an index.html.gz planted in the
+        # docroot: plain curl saw 7 stamped tags, `curl --compressed` saw 0.
+        curl -fsS $$RETRY --compressed -A "$$HUMAN" -D head.out -o body.out "$$URL/" \
           || { echo "candidate did not serve the shell for the nonce probe"; exit 1; }
         NONCE=$$(grep -i '^content-security-policy:' head.out | grep -o 'nonce-[0-9a-f]*' | head -1)
         test -n "$$NONCE" || { echo "the shell's Content-Security-Policy carries no nonce"; exit 1; }

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -172,12 +172,16 @@ steps:
           || { echo "candidate did not serve the shell for the nonce probe"; exit 1; }
         NONCE=$$(grep -i '^content-security-policy:' head.out | grep -o 'nonce-[0-9a-f]*' | head -1)
         test -n "$$NONCE" || { echo "the shell's Content-Security-Policy carries no nonce"; exit 1; }
-        grep -qF "<script nonce=\"$${NONCE#nonce-}\"" body.out \
-          || { echo "no <script> tag carries the header's $$NONCE — the sub_filter stamp did not run"; exit 1; }
-        UNSTAMPED=$$(grep -o '<script[^>]*>' body.out | grep -v 'nonce=' | wc -l)
-        test "$$UNSTAMPED" = "0" \
-          || { echo "$$UNSTAMPED <script> tag(s) in the shell carry no nonce and would be blocked"; exit 1; }
-        echo "OK: CSP nonce on every script tag of the shell"
+        # Every tag against THAT nonce, not "has some nonce": a stale or
+        # mismatched value is refused by the browser exactly like a missing one,
+        # and counting attributes rather than comparing them would wave it
+        # through (Copilot review).
+        TAGS=$$(grep -o '<script[^>]*>' body.out | wc -l)
+        MATCHING=$$(grep -o "<script nonce=\"$${NONCE#nonce-}\"" body.out | wc -l)
+        test "$$TAGS" -gt 0 || { echo "the shell served no <script> tag at all"; exit 1; }
+        test "$$MATCHING" = "$$TAGS" \
+          || { echo "$$MATCHING of $$TAGS <script> tag(s) carry the header's $$NONCE — the rest would be blocked"; exit 1; }
+        echo "OK: all $$TAGS script tags of the shell carry the header's nonce"
         # Crawlers get the prerendered page through @seo_proxy. The canonical
         # link is the marker: the SPA shell carries none at all, and its value
         # names the route, so one grep proves both "the bot hop ran" and "the

--- a/app/index.html
+++ b/app/index.html
@@ -25,9 +25,14 @@
     </script>
 
     <!-- On-device debug console (Eruda), gated behind ?debug=1 so it never
-         ships to normal users. Plain <script> (not type="module") so it runs
-         before module parse-time errors and can capture them — critical for
-         debugging mobile-only crashes where remote DevTools aren't available. -->
+         ships to normal users. A classic script element (not type="module") so
+         it runs before module parse-time errors and can capture them — critical
+         for debugging mobile-only crashes where remote DevTools aren't
+         available. The opening tag is described rather than written out: nginx
+         stamps the CSP nonce with a blunt `sub_filter` over the literal string,
+         so a comment containing it comes back to the browser with a stray
+         `nonce=` inside — harmless, but confusing in the one artefact anyone
+         debugging CSP will read. -->
     <script>
       (function () {
         try {

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -471,10 +471,20 @@ server {
     }
 
     # /:specId -> hub on main domain (no language segment; canonical is /{spec_id})
+    #
+    # `try_files /index.html =404` serves the shell as a FILE, in THIS location —
+    # no internal redirect, so `location = /index.html` and its headers are never
+    # reached. That is why the two routes below repeat the shell's Cache-Control
+    # instead of inheriting it: the shell now carries a per-request CSP nonce, and
+    # a stored copy would pair an old `nonce="…"` in the body with a fresh one in
+    # the header. Measured before the fix: these two routes answered with no
+    # Cache-Control at all while anyplot.ai/<spec> answered `no-store`.
     location ~ "^/(?<spec_id>[A-Za-z0-9][A-Za-z0-9-]*)/?$" {
         set $python_seo_uri /seo-proxy/$spec_id;
         error_page 418 = @seo_proxy_python;
         if ($is_bot) { return 418; }
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        include /etc/nginx/security-headers.conf;
         try_files /index.html =404;
     }
 
@@ -483,6 +493,8 @@ server {
         set $python_seo_uri /seo-proxy/$spec_id/python/$library;
         error_page 418 = @seo_proxy_python;
         if ($is_bot) { return 418; }
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        include /etc/nginx/security-headers.conf;
         try_files /index.html =404;
     }
 

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -165,11 +165,35 @@ server {
     # levels — see security-headers.conf).
     include /etc/nginx/security-headers.conf;
 
+    # The delivery half of the CSP nonce; the header half and the whole
+    # reasoning are in security-headers.conf. Stamp the SAME `$request_id` the
+    # policy names onto every `<script` tag of the HTML we serve. A nonce makes
+    # 'unsafe-inline' inert, so a tag that misses the stamp is a tag that stops
+    # running — and the first one in the shell is the theme resolver.
+    #
+    # Server level rather than per-location, deliberately: four locations can
+    # end up serving index.html — the exact match, the SPA fallback, and in the
+    # python server block below two regex routes whose `try_files /index.html
+    # =404` serves the file IN PLACE, without the internal redirect that would
+    # re-run location matching. A stamp missing from one of those is a blank
+    # page on exactly those routes and nowhere else.
+    #
+    # `<script` cannot match `</script>`, and sub_filter's default type list is
+    # text/html alone, so this never reaches into a .js chunk or a JSON body.
+    # It does also pass over the proxied crawler pages from @seo_proxy, which
+    # carry no executable script of ours — one JSON-LD data block, which no
+    # browser executes — and crawlers run no JS either way.
+    sub_filter '<script' '<script nonce="$request_id"';
+    sub_filter_once off;
+
     # Compression - serve pre-compressed gzip files from Vite build when available
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+    # Serves `<file>.gz` untouched when it exists, which is exactly what
+    # sub_filter cannot rewrite. index.html is therefore excluded from
+    # precompression in app/vite.config.ts — the nonce depends on it.
     gzip_static on;
 
     # Vite-fingerprinted assets — filename changes on every build, safe to cache forever
@@ -379,6 +403,13 @@ server {
     # Security headers (same include-per-add_header-location rule as the
     # main server block above).
     include /etc/nginx/security-headers.conf;
+
+    # CSP nonce, same as the main server block — and this block is the reason
+    # it sits at server level: the two spec-route regex locations below serve
+    # `/index.html` through `try_files` as a FILE, so they never reach the
+    # `location = /index.html` block and would carry no stamp at all.
+    sub_filter '<script' '<script nonce="$request_id"';
+    sub_filter_once off;
 
     gzip on;
     gzip_vary on;

--- a/app/security-headers.conf
+++ b/app/security-headers.conf
@@ -50,10 +50,11 @@
 #
 # The nonce is `$request_id`: nginx's own 16 random bytes, rendered as 32 hex
 # digits. Hex is a subset of the base64-value charset the CSP nonce grammar
-# accepts, and 128 bits is above the 128 the spec asks for. nginx stamps it on
-# every `<script` tag of the shell with `sub_filter` (app/nginx.conf), so the
-# tag and this header always carry the SAME value — they are the same variable
-# read twice in one request.
+# accepts, and 16 bytes is exactly the 128 bits of entropy CSP recommends for a
+# nonce (a recommendation in the spec, not a requirement). nginx stamps that
+# value on every `<script` tag of the shell with `sub_filter` (app/nginx.conf),
+# so the tag and this header always agree — they are the same variable read
+# twice within one request.
 #
 # Two consequences worth knowing before editing either half:
 #
@@ -70,18 +71,30 @@
 #     hand out the untouched `.gz` and `sub_filter` never sees a compressed
 #     body.
 #
-# 'strict-dynamic' is deliberately NOT here. It would drop 'self' for scripts,
-# and Vite's shell links its chunks with `<link rel="modulepreload">` — link
-# elements the stamp does not touch and 'strict-dynamic' does not cover. The
-# chunks stay on 'self'.
+# 'strict-dynamic' is deliberately NOT here, and the reason is narrower than it
+# first looks. It would drop 'self' for scripts and trust only what an
+# already-trusted script pulls in. The entry module IS a nonced <script>, so it
+# runs, and its imports are fetched by a script rather than the parser, so they
+# run too. What breaks is the layer above them: Vite's shell links every chunk
+# with `<link rel="modulepreload">`, and a link element is neither a script
+# element strict-dynamic can trust nor something the `<script` stamp touches. So
+# the hints are refused — a console full of violations and a slower first paint,
+# because each chunk then waits for the entry module to ask for it, instead of a
+# blank page. Not a catastrophe; just a cost with nothing bought, since the
+# chunks are fingerprinted files under 'self' already. Adopting the keyword
+# means widening the stamp to <link> in the same change; a test says so.
 #
-# Rolling back without a rebuild, if the edge ever stops honouring the nonce:
+# Rolling back without a rebuild, if the edge ever stops honouring the nonce —
+# pick the last revision created BEFORE this policy shipped, which is NOT
+# "the previous one" once another frontend deploy has happened (Copilot review):
+#   gcloud run revisions list --service anyplot-app --region europe-west4 \
+#     --format='table(name, creationTimestamp)' --limit 10
 #   gcloud run services update-traffic anyplot-app --region europe-west4 \
-#     --to-revisions=<previous-revision>=100
-# (`gcloud run revisions list --service anyplot-app --region europe-west4`
-# names them; every deploy gives its revision the deterministic suffix
-# `-b$BUILD_ID`, and the previous one still serves the 'unsafe-inline' policy
-# byte for byte.) agentic/docs/project-guide.md § Rollback has the long form.
+#     --to-revisions=<that-revision>=100
+# Once this has been live long enough that no pre-nonce revision is left, the
+# lever is a revert PR through the normal pipeline instead — which is fine,
+# because by then the question this policy risks has been answered.
+# agentic/docs/project-guide.md § Rollback has the long form.
 # - style-src 'unsafe-inline': MUI/emotion inject inline styles.
 # - img/font/connect storage.googleapis.com: plot previews + MonoLisa fonts on GCS.
 # - img/connect/frame api.anyplot.ai: API calls, og images, interactive-preview

--- a/app/security-headers.conf
+++ b/app/security-headers.conf
@@ -76,13 +76,19 @@
 # already-trusted script pulls in. The entry module IS a nonced <script>, so it
 # runs, and its imports are fetched by a script rather than the parser, so they
 # run too. What breaks is the layer above them: Vite's shell links every chunk
-# with `<link rel="modulepreload">`, and a link element is neither a script
-# element strict-dynamic can trust nor something the `<script` stamp touches. So
-# the hints are refused — a console full of violations and a slower first paint,
-# because each chunk then waits for the entry module to ask for it, instead of a
-# blank page. Not a catastrophe; just a cost with nothing bought, since the
-# chunks are fingerprinted files under 'self' already. Adopting the keyword
-# means widening the stamp to <link> in the same change; a test says so.
+# with `<link rel="modulepreload">`, and a link element is not something
+# strict-dynamic's trust propagation reaches. So the hints are refused — a
+# console full of violations and a slower first paint, because each chunk then
+# waits for the entry module to ask for it, instead of a blank page. Not a
+# catastrophe; just a cost with nothing bought, since the chunks are
+# fingerprinted files under 'self' already.
+#
+# The remedy, for whoever wants the keyword: widen the stamp to <link> in the
+# same change. A preload request carries its link element's nonce as
+# cryptographic nonce metadata, and a nonce-source in script-src matches it —
+# which is why React, Next.js, Vite and Rails each carry the same bug report
+# and the same fix, "put the nonce on the preload link". A test enforces the
+# pairing.
 #
 # Rolling back without a rebuild, if the edge ever stops honouring the nonce —
 # pick the last revision created BEFORE this policy shipped, which is NOT

--- a/app/security-headers.conf
+++ b/app/security-headers.conf
@@ -7,54 +7,81 @@
 # location, re-include this file there.
 #
 # CSP notes (must not break the SPA — see app/index.html and app/src):
-# - script-src 'unsafe-inline': index.html ships three executable inline
+# - script-src 'nonce-$request_id': index.html ships three executable inline
 #   scripts (theme resolver, Eruda loader, Plausible stub), and a FOURTH one
 #   arrives that this repository does not write — see the block below.
 # - script-src cdn.jsdelivr.net: on-device debug console (Eruda) behind ?debug=1.
+#   Reached through a `src`, so the host is what CSP judges, not a nonce.
 #
-# Why script-src still says 'unsafe-inline' (measured 2026-09-03)
-# ---------------------------------------------------------------
-# Replacing 'unsafe-inline' with the sha256 of each inline script is the
-# obvious hardening — index.html is static, so its scripts are fixed at build
-# time, and `yarn build` was verified to copy them through byte-for-byte. The
-# three hashes are recorded below and pinned by tests/unit/api/test_csp_policy.py
-# so they never go stale.
+# Why script-src is a NONCE and no longer 'unsafe-inline' (2026-09-04)
+# --------------------------------------------------------------------
+# The obvious hardening — replace 'unsafe-inline' with the sha256 of each
+# inline script — was built, measured and rejected on 2026-09-03 (#11213).
+# index.html is static, so its three hashes are stable, but a FOURTH inline
+# script arrives after nginx: Cloudflare JavaScript Detections injects one into
+# every HTML response at the edge, and its body carries a per-response ray id
+# and timestamp:
 #
-# They cannot be ENFORCED yet. Cloudflare JavaScript Detections injects an
-# inline script into every HTML response at the edge, after nginx, and its body
-# carries a per-response ray id and timestamp — so its hash differs on every
-# request and cannot be listed here. The whole policy was mounted over the LIVE
-# production bundle through a local proxy and loaded twice, once with each
-# script-src:
+#     window.__CF$cv$params={r:'a35d48a2bdf1be85',t:'MTc4ODUyNzk0NA=='};…
+#
+# A body that differs per response has no fixed hash, so it can never be
+# listed. Mounted over the live production bundle and loaded twice, the two
+# policies measured:
 #
 #     'unsafe-inline'  → Cloudflare's script runs (its hidden iframe appears)
 #     hashes only      → "Executing inline script violates … The action has
 #                        been blocked", no iframe, no JS-detection signal
 #
-# Exactly one script is blocked, and it is the edge's. Shipping the hash policy
-# would silently degrade bot detection on a site whose origin gate leans on the
-# edge — so it is not shipped, and 'unsafe-inline' is NOT joined by hashes
-# either: a browser ignores 'unsafe-inline' as soon as a hash is present, so the
-# two together are the same breakage wearing a stricter-looking policy.
+# Turning JavaScript Detections off is not the way out either: the Free plan
+# refuses it while Bot Fight Mode is on (the API rejects `enable_js=false`),
+# and it would be a security trade rather than a fix.
 #
-# The way out is a NONCE, not a hash. Cloudflare parses this response header
-# and stamps its own injected script with the nonce it finds there (their
-# JavaScript Detections docs say so explicitly, and recommend it over
-# 'unsafe-inline'). That needs nginx to mint one per request and rewrite
-# index.html's `<script>` tags with it — `sub_filter` plus `gzip_static off`
-# for the shell — which is a delivery change no test in this repo can prove and
-# no local nginx here can run. It is the open item; the alternative is turning
-# JavaScript Detections off in the zone, which is a security trade, not a fix.
+# A NONCE is the way out, and it is Cloudflare's own recommendation. Their
+# JavaScript Detections page (developers.cloudflare.com/bots/
+# additional-configurations/javascript-detections/, read 2026-09-04) says: "If
+# your CSP uses a `nonce` for script tags, Cloudflare will add these nonces to
+# the scripts it injects by parsing your CSP response header", and "We highly
+# discourage the use of `unsafe-inline` and instead recommend the use CSP
+# `nonces` in script tags which we parse and support in our CDN." Two
+# conditions come with it, and both hold here: the nonce must arrive in the
+# response HEADER (JavaScript Detections "is not supported with `nonce` set via
+# `<meta>` tags" — this file is the header), and `/cdn-cgi/challenge-platform/`
+# must be reachable, which `script-src 'self'` covers because it is same-origin.
 #
-# The hashes of app/index.html's three executable inline scripts, ready for the
-# day one of those two happens (JSON-LD blocks need none — a browser never
-# executes `type="application/ld+json"`, so CSP never asks):
-#   'sha256-4VdX7wfQgL9PnVFBkrDWBbPpiST1xriKljA5URM8DcM='  theme resolver
-#   'sha256-HfNBzShy4Q4W9GmmnPkcx36GlrZI5mkU15xjpyh1pmk='  Eruda loader
-#   'sha256-BiWO1y5gYRbSlOrPh1rJPXYnES50FX9PwJpfXfWJy0A='  Plausible stub
-# A hash covers the exact bytes between `<script>` and `</script>`, so a single
-# re-indent invalidates one. The test recomputes them from index.html on every
-# run, which is what keeps this block honest while it waits.
+# The nonce is `$request_id`: nginx's own 16 random bytes, rendered as 32 hex
+# digits. Hex is a subset of the base64-value charset the CSP nonce grammar
+# accepts, and 128 bits is above the 128 the spec asks for. nginx stamps it on
+# every `<script` tag of the shell with `sub_filter` (app/nginx.conf), so the
+# tag and this header always carry the SAME value — they are the same variable
+# read twice in one request.
+#
+# Two consequences worth knowing before editing either half:
+#
+#   * A nonce makes 'unsafe-inline' inert. A browser ignores 'unsafe-inline'
+#     the moment a nonce or hash appears, so the two together are not
+#     belt-and-braces — they are the nonce policy wearing a permissive label.
+#     A test forbids the combination.
+#   * A nonced response must never be replayed. `location = /index.html` sends
+#     `no-store`, and `sub_filter` additionally clears `Last-Modified` and the
+#     `ETag` (nginx does that itself whenever a body filter rewrites the
+#     response), so no client can revalidate its way into an old body under a
+#     new header. The other half of the same rule lives in app/vite.config.ts:
+#     the shell is excluded from precompression, because `gzip_static` would
+#     hand out the untouched `.gz` and `sub_filter` never sees a compressed
+#     body.
+#
+# 'strict-dynamic' is deliberately NOT here. It would drop 'self' for scripts,
+# and Vite's shell links its chunks with `<link rel="modulepreload">` — link
+# elements the stamp does not touch and 'strict-dynamic' does not cover. The
+# chunks stay on 'self'.
+#
+# Rolling back without a rebuild, if the edge ever stops honouring the nonce:
+#   gcloud run services update-traffic anyplot-app --region europe-west4 \
+#     --to-revisions=<previous-revision>=100
+# (`gcloud run revisions list --service anyplot-app --region europe-west4`
+# names them; every deploy gives its revision the deterministic suffix
+# `-b$BUILD_ID`, and the previous one still serves the 'unsafe-inline' policy
+# byte for byte.) agentic/docs/project-guide.md § Rollback has the long form.
 # - style-src 'unsafe-inline': MUI/emotion inject inline styles.
 # - img/font/connect storage.googleapis.com: plot previews + MonoLisa fonts on GCS.
 # - img/connect/frame api.anyplot.ai: API calls, og images, interactive-preview
@@ -70,4 +97,4 @@ add_header X-Frame-Options "SAMEORIGIN" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 # 180 days — moderate max-age, no includeSubDomains/preload (conservative first rollout).
 add_header Strict-Transport-Security "max-age=15552000" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.googleapis.com https://api.anyplot.ai; font-src 'self' data: https://storage.googleapis.com; connect-src 'self' https://api.anyplot.ai https://storage.googleapis.com https://plausible.io https://api.github.com; frame-src 'self' https://api.anyplot.ai; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'nonce-$request_id' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.googleapis.com https://api.anyplot.ai; font-src 'self' data: https://storage.googleapis.com; connect-src 'self' https://api.anyplot.ai https://storage.googleapis.com https://plausible.io https://api.github.com; frame-src 'self' https://api.anyplot.ai; object-src 'none'; base-uri 'self'; frame-ancestors 'self'" always;

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -21,8 +21,16 @@ export default defineConfig({
       overlay: { initialIsOpen: false },
       enableBuild: false,
     }),
-    compression({ algorithm: 'gzip', threshold: 1024 }),
-    compression({ algorithm: 'brotliCompress', threshold: 1024 }),
+    // index.html is EXCLUDED, and that is load-bearing rather than tidiness.
+    // nginx rewrites the shell per request to stamp the CSP nonce onto its
+    // <script> tags (app/nginx.conf, app/security-headers.conf), and
+    // `gzip_static on` would hand out the precompressed copy instead —
+    // untouched, unstamped, and with a policy that then blocks every inline
+    // script on the page. sub_filter only ever sees uncompressed bodies. The
+    // hashed chunks under /assets/ are what precompression is actually for,
+    // and they keep it; the shell is 11 kB and nginx still gzips it on the fly.
+    compression({ algorithm: 'gzip', threshold: 1024, exclude: [/index\.html$/] }),
+    compression({ algorithm: 'brotliCompress', threshold: 1024, exclude: [/index\.html$/] }),
   ],
   server: {
     port: 3000,

--- a/changelog.d/csp-nonce.md
+++ b/changelog.d/csp-nonce.md
@@ -18,9 +18,10 @@
 
 - **The frontend deploy smoke checks the nonce before promoting.** The
   candidate has to serve a shell whose `<script>` tags all carry the nonce from
-  that same response's header. A lost stamp leaves a page that looks healthy to
-  every other probe and runs no inline script at all, so it is worth the two
-  extra curls.
+  that same response's header, fetched with `--compressed` so a precompressed
+  shell cannot slip past. A lost stamp leaves a page that looks healthy to every
+  other probe and runs no inline script at all, so it is worth the one extra
+  curl.
 
 ### Fixed
 

--- a/changelog.d/csp-nonce.md
+++ b/changelog.d/csp-nonce.md
@@ -21,3 +21,16 @@
   that same response's header. A lost stamp leaves a page that looks healthy to
   every other probe and runs no inline script at all, so it is worth the two
   extra curls.
+
+### Fixed
+
+- **The python.anyplot.ai spec routes sent the SPA shell with no
+  `Cache-Control` at all.** `try_files /index.html =404` answers with the shell
+  as a file inside that location, so it never reaches `location =
+  /index.html` and never inherited its `no-store` — measured against a local
+  nginx while the main host answered correctly on the same path. A stale shell
+  asks for `/assets/` hashes a later deploy no longer has; with the nonce it
+  would additionally pair an old `nonce="…"` with a fresh header. Both routes
+  now send the shell's `Cache-Control` and re-include the security-header
+  snippet beside it, since an `add_header` of their own would otherwise have
+  dropped the whole inherited set.

--- a/changelog.d/csp-nonce.md
+++ b/changelog.d/csp-nonce.md
@@ -1,0 +1,23 @@
+### Security
+
+- **`script-src` drops `'unsafe-inline'` for a per-request nonce.** nginx mints
+  one from `$request_id` — 16 random bytes as 32 hex digits — sends it in the
+  policy and stamps the same value onto every `<script>` tag of the shell with
+  `sub_filter`, in both server blocks. The measurement that stopped the hash
+  version a day earlier is what makes this the right shape: Cloudflare
+  JavaScript Detections injects an inline script at the edge whose body carries
+  a per-response ray id, so it has no listable hash — but Cloudflare documents
+  that it copies a nonce out of the response header onto that script, which a
+  hash could never be. Cache safety comes from three sides: the shell is
+  `no-store`, `sub_filter` clears `ETag` and `Last-Modified` on its own, and
+  `index.html` is now excluded from build-time precompression, because
+  `gzip_static` would otherwise serve an unstamped `.gz` and quietly block
+  every inline script on the page.
+
+### Changed
+
+- **The frontend deploy smoke checks the nonce before promoting.** The
+  candidate has to serve a shell whose `<script>` tags all carry the nonce from
+  that same response's header. A lost stamp leaves a page that looks healthy to
+  every other probe and runs no inline script at all, so it is worth the two
+  extra curls.

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -231,6 +231,31 @@ def test_every_server_block_stamps_the_nonce():
     )
 
 
+_EXCLUDE_LIST = re.compile(r"exclude\s*:\s*\[([^\]]*)\]")
+_JS_REGEX_LITERAL = re.compile(r"/((?:[^/\\\n]|\\.)+)/([gimsuy]*)")
+
+
+def _js_regex_literals_after_exclude(call: str) -> list[re.Pattern[str]]:
+    """The `exclude:` regex literals of one plugin call, as Python patterns.
+
+    JavaScript and Python agree on the small subset a filename filter uses —
+    literal characters, `\\.`, `^`, `$`, character classes — so a JS literal can
+    simply be run here. Flags other than `i` have no counterpart worth
+    translating and are ignored; an unparseable literal is skipped rather than
+    crashing the suite, and skipping it can only make the test stricter.
+    """
+    listed = _EXCLUDE_LIST.search(call)
+    if not listed:
+        return []
+    patterns = []
+    for source, flags in _JS_REGEX_LITERAL.findall(listed.group(1)):
+        try:
+            patterns.append(re.compile(source, re.IGNORECASE if "i" in flags else 0))
+        except re.error:
+            continue
+    return patterns
+
+
 def test_the_shell_is_never_precompressed():
     """`gzip_static` hands out the `.gz` untouched, and sub_filter never sees it.
 
@@ -241,19 +266,21 @@ def test_the_shell_is_never_precompressed():
     on a local nginx with the `.gz` planted back: `curl --compressed` saw zero
     stamped tags where the plain shell had seven.
 
-    The pattern is matched, not merely searched for the word "index" — a first
-    version accepted `/index\\.js$/` and even `/not-index\\.html$/`, both of
-    which leave `index.html.gz` in `dist/` (Copilot review).
+    The declared pattern is RUN against the emitted name rather than read for
+    the word "index", because two rounds of review found the reading version
+    accepting patterns that exclude nothing: `/index\\.js$/`,
+    `/not-index\\.html$/`, and then `/foo/index\\.html$/`, which matches a
+    nested file while `dist/index.html` is still compressed. Whatever the next
+    plausible near-miss is, `re.search(pattern, "index.html")` answers it.
     """
     config = VITE_CONFIG.read_text(encoding="utf-8")
     calls = re.findall(r"compression\(\{[^}]*\}\)", config)
     assert calls, "app/vite.config.ts declares no compression plugin — did it move?"
-    excludes_the_shell = re.compile(r"exclude\s*:\s*\[[^\]]*(?<![\w-])index\\?\.html\$?/")
-    unguarded = [c for c in calls if not excludes_the_shell.search(c)]
+    unguarded = [c for c in calls if not any(p.search("index.html") for p in _js_regex_literals_after_exclude(c))]
     assert not unguarded, (
-        "a compression plugin in app/vite.config.ts does not exclude index.html: "
-        f"{unguarded}. The shell is rewritten per request for the CSP nonce and "
-        "must not exist as a precompressed file."
+        "a compression plugin in app/vite.config.ts declares no exclude pattern that "
+        f"actually matches the emitted shell: {unguarded}. index.html is rewritten per "
+        "request for the CSP nonce and must not exist as a precompressed file."
     )
 
 

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -267,10 +267,10 @@ def test_the_shell_is_never_stored():
     the shell is checked instead.
     """
     shells = locations_serving_the_shell_in_place()
-    assert len(shells) >= 3, (
-        f"only {len(shells)} location(s) look like they serve the shell — expected the "
-        "exact match in each server block plus the two python-host spec routes. Did the "
-        "try_files shapes change?"
+    assert len(shells) >= 4, (
+        f"only {len(shells)} location(s) look like they serve the shell — expected at "
+        "least four: the exact match in each server block plus the two python-host spec "
+        "routes. Did the try_files shapes change?"
     )
     missing = [b.strip().splitlines()[0].strip() for b in shells if "no-store" not in _without_comments(b)]
     assert not missing, (

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -77,11 +77,8 @@ def _without_comments(text: str) -> str:
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
 
 
-def locations_with_add_header() -> list[str]:
-    """Every `location …{ … }` block of app/nginx.conf that sets a header itself.
-
-    Returned as the raw block text, so the caller can check what is inside it.
-    """
+def location_blocks() -> list[str]:
+    """Every `location …{ … }` block of app/nginx.conf, as raw text."""
     conf = NGINX_CONF.read_text(encoding="utf-8")
     blocks = []
     for match in re.finditer(r"^\s*location\s[^{]*\{", conf, re.MULTILINE):
@@ -95,7 +92,40 @@ def locations_with_add_header() -> list[str]:
                 if depth == 0:
                     blocks.append(conf[start : i + 1])
                     break
-    return [b for b in blocks if _ADD_HEADER.search(_without_comments(b))]
+    return blocks
+
+
+def locations_with_add_header() -> list[str]:
+    """Every location block that sets a header itself, and so drops the rest."""
+    return [b for b in location_blocks() if _ADD_HEADER.search(_without_comments(b))]
+
+
+_TRY_FILES = re.compile(r"try_files\s+([^;]+);")
+
+
+def locations_serving_the_shell_in_place() -> list[str]:
+    """Every location that answers with index.html under its OWN headers.
+
+    Two shapes, and the difference is the whole point. `try_files … /index.html`
+    with the shell LAST is a URI fallback: nginx redirects internally and re-runs
+    location matching, so the response is built by `location = /index.html` and
+    inherits its headers. `try_files /index.html =404` has the shell as a
+    non-last argument, which is a FILE — served right here, with this location's
+    headers and no others. Both shapes exist in app/nginx.conf, the second twice
+    in the python server block, and only the first is obvious from reading it.
+    """
+    out = []
+    for block in location_blocks():
+        head = block.strip().splitlines()[0].strip()
+        if head.startswith("location = /index.html"):
+            out.append(block)
+            continue
+        for match in _TRY_FILES.finditer(_without_comments(block)):
+            arguments = match.group(1).split()
+            if "/index.html" in arguments[:-1]:
+                out.append(block)
+                break
+    return out
 
 
 def server_blocks() -> list[str]:
@@ -229,36 +259,51 @@ def test_the_shell_is_never_stored():
     `sub_filter` drops `Last-Modified` and `ETag` on its own whenever it
     rewrites a body (so nothing can be revalidated), and these locations say
     `no-store` (so nothing is kept to revalidate).
+
+    Checking only `location = /index.html` is what the first version did, and it
+    passed while python.anyplot.ai/<spec> answered with no Cache-Control at all:
+    that route serves the shell as a FILE inside its own location and never
+    reaches the exact match (Copilot review). Every location that can produce
+    the shell is checked instead.
     """
-    shells = [b for b in locations_with_add_header() if b.lstrip().startswith("location = /index.html")]
-    assert shells, "app/nginx.conf no longer has a `location = /index.html` — where does the shell get its headers?"
-    missing = [b.splitlines()[0].strip() for b in shells if "no-store" not in b]
+    shells = locations_serving_the_shell_in_place()
+    assert len(shells) >= 3, (
+        f"only {len(shells)} location(s) look like they serve the shell — expected the "
+        "exact match in each server block plus the two python-host spec routes. Did the "
+        "try_files shapes change?"
+    )
+    missing = [b.strip().splitlines()[0].strip() for b in shells if "no-store" not in _without_comments(b)]
     assert not missing, (
-        f"these shell locations do not send `no-store`: {missing}. The shell carries a "
-        "per-request CSP nonce and must not be reusable."
+        f"these locations answer with the shell but do not send `no-store`: {missing}. "
+        "The shell carries a per-request CSP nonce and must not be reusable."
     )
 
 
-def test_strict_dynamic_needs_the_stamp_to_reach_the_module_preloads():
-    """It reads as the stricter policy and would load the app from nothing.
+def test_strict_dynamic_would_have_to_widen_the_stamp_to_the_module_preloads():
+    """The keyword and the stamp are one decision, taken in two files.
 
     `'strict-dynamic'` makes a browser ignore `'self'` for scripts and trust
-    only what an already-trusted script pulls in. `yarn build` links every
-    chunk from the shell with `<link rel="modulepreload">` — a link element,
-    which trust propagation does not cover and which the `<script` stamp does
-    not touch. So adopting the keyword means widening the stamp in the same
-    breath; adopting it alone means the preloads are refused. Absent today, and
-    the reasoning is in security-headers.conf — this only has to hold whoever
-    adds it to the second half.
+    only what an already-trusted script pulls in. The entry module is a nonced
+    `<script>`, so it and the imports it fetches still run — the casualty is
+    narrower and easy to miss: `yarn build` links every chunk from the shell
+    with `<link rel="modulepreload">`, and a link element is neither something
+    trust propagation reaches nor something a `<script`-only stamp touches. The
+    hints are refused, which costs a console full of violations and a slower
+    first paint rather than a blank page (Copilot review corrected an earlier,
+    louder claim here).
+
+    So this is not a ban on the keyword. It is the requirement that whoever
+    adopts it widens the stamp in the same change instead of discovering the
+    cost in production. Nothing to check while the keyword is absent.
     """
     if "'strict-dynamic'" not in csp_directives()["script-src"]:
         return
     conf = _without_comments(NGINX_CONF.read_text(encoding="utf-8"))
     assert re.search(r"sub_filter\s+'<link", conf), (
         "script-src carries 'strict-dynamic', which drops 'self' for scripts, but "
-        "app/nginx.conf still stamps only <script> tags. Vite's <link "
-        'rel="modulepreload"> chunk hints would be blocked and the SPA would never '
-        "boot."
+        "app/nginx.conf still stamps only <script> tags — so Vite's <link "
+        'rel="modulepreload"> chunk hints are refused and every chunk waits for the '
+        "entry module to ask for it. Stamp <link> too, or drop the keyword."
     )
 
 

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -237,12 +237,19 @@ def test_the_shell_is_never_precompressed():
     The prettiest way to break this whole mechanism: leave a build artefact in
     place. nginx would serve `index.html.gz` byte for byte, the stamp would
     never run, the header would still carry its nonce, and every inline script
-    on the page would be refused — with nothing in any log to say why.
+    on the page would be refused — with nothing in any log to say why. Measured
+    on a local nginx with the `.gz` planted back: `curl --compressed` saw zero
+    stamped tags where the plain shell had seven.
+
+    The pattern is matched, not merely searched for the word "index" — a first
+    version accepted `/index\\.js$/` and even `/not-index\\.html$/`, both of
+    which leave `index.html.gz` in `dist/` (Copilot review).
     """
     config = VITE_CONFIG.read_text(encoding="utf-8")
     calls = re.findall(r"compression\(\{[^}]*\}\)", config)
     assert calls, "app/vite.config.ts declares no compression plugin — did it move?"
-    unguarded = [c for c in calls if "index" not in c.split("exclude")[-1]]
+    excludes_the_shell = re.compile(r"exclude\s*:\s*\[[^\]]*(?<![\w-])index\\?\.html\$?/")
+    unguarded = [c for c in calls if not excludes_the_shell.search(c)]
     assert not unguarded, (
         "a compression plugin in app/vite.config.ts does not exclude index.html: "
         f"{unguarded}. The shell is rewritten per request for the CSP nonce and "

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -1,16 +1,18 @@
 """The delivery-side security policy, held against the files it describes.
 
 `app/security-headers.conf` is a string in an nginx include. Nothing compiles
-it, nothing imports it, and three things in it can drift silently — each of
+it, nothing imports it, and four things around it can drift silently — each of
 which has cost someone a day somewhere:
 
-1. **The inline-script hashes.** `script-src` cannot enforce them yet —
-   Cloudflare JavaScript Detections injects a fourth inline script at the edge
-   whose body changes per response (measured 2026-09-03, the reasoning is in
-   `security-headers.conf`) — so the file records them in a comment instead,
-   ready for the day a nonce or a zone setting makes the switch possible. A
-   recorded hash that no longer matches its script is worse than none: it looks
-   like readiness. This recomputes them on every run.
+1. **The CSP nonce, which lives in two files at once.** `script-src` names
+   `'nonce-$request_id'` here; `app/nginx.conf` stamps that same `$request_id`
+   onto every `<script` tag with `sub_filter`. Nothing but agreement makes them
+   one mechanism, and disagreement is invisible: the page still arrives, the
+   header still reads as a modern policy, and every inline script on it is
+   blocked — a nonce in the policy makes `'unsafe-inline'` inert, so there is
+   no fallback left to catch the fall. The delivery half also depends on the
+   shell NOT being precompressed (`gzip_static` would hand out the untouched
+   `.gz`) and on it never being stored for replay.
 
 2. **nginx's `add_header` inheritance.** A location with any `add_header` of
    its own drops every inherited one. `app/nginx.conf` therefore re-includes
@@ -22,14 +24,21 @@ which has cost someone a day somewhere:
    nginx in front of it, so nothing there inherits anything from the website —
    and it has two exits, only one of which is a middleware.
 
+4. **The keywords a hardening pass reaches for by reflex.** `'unsafe-inline'`
+   beside a nonce, `'strict-dynamic'` over a shell that links its chunks with
+   `<link rel="modulepreload">`, a `report-to` group nobody defined: each looks
+   stricter and is quietly worse.
+
+What this file cannot see is whether Cloudflare copies the nonce onto the
+script IT injects at the edge — that is a live measurement, recorded in
+`app/security-headers.conf` next to the directive it justifies.
+
 The nginx parse is deliberately crude — a brace counter over one file we write
 ourselves, not a config parser. It only has to be right about this file.
 """
 
 from __future__ import annotations
 
-import base64
-import hashlib
 import re
 from pathlib import Path
 
@@ -39,51 +48,11 @@ from api.main import app, fastapi_app
 
 
 ROOT = Path(__file__).resolve().parents[3]
-INDEX_HTML = ROOT / "app" / "index.html"
 HEADERS_CONF = ROOT / "app" / "security-headers.conf"
 NGINX_CONF = ROOT / "app" / "nginx.conf"
+VITE_CONFIG = ROOT / "app" / "vite.config.ts"
 
 INCLUDE_LINE = "include /etc/nginx/security-headers.conf;"
-
-# Comments are stripped BEFORE the script scan. index.html documents its own
-# Eruda loader with the words `Plain <script> (not type="module")`, and a
-# regex that reads that as a tag hashes the comment prose instead of the
-# script — silently, and with a hash that looks perfectly plausible.
-_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
-# The closing tag is `</script` followed by whitespace, `/` or `>`, and then
-# anything up to the first `>` — which is what a browser accepts and what
-# CodeQL's py/bad-tag-filter insists on (`</script >`, `</script\t\n bar>`). A
-# regex that missed one of those would swallow the rest of the document into a
-# single "script body" and hash that, silently. The lookahead is what keeps
-# `</scriptfoo>` from counting as a close.
-_SCRIPT = re.compile(r"<script(?P<attrs>[^>]*)>(?P<body>.*?)</script(?=[\s/>])[^>]*>", re.DOTALL | re.IGNORECASE)
-_TYPE = re.compile(r"""type\s*=\s*["']?([^"'\s>]+)""", re.IGNORECASE)
-# An EXTERNAL script, which CSP judges by its URL and never by a hash. HTML
-# attribute names are case-insensitive and whitespace around `=` is legal, so
-# `<script SRC = "…">` is external too — a plain `"src=" in attrs` called it
-# inline and would have demanded a hash for a script with no body (Copilot
-# review). `\b` keeps it from matching a `data-src=` or an `xlink:src=`.
-_SRC = re.compile(r"\bsrc\s*=", re.IGNORECASE)
-# A <script> whose type is none of these is a DATA BLOCK (the three JSON-LD
-# blocks in index.html): the browser never executes it, and CSP never asks for
-# a hash.
-_EXECUTABLE_TYPES = {"", "module", "text/javascript", "application/javascript"}
-
-
-def inline_script_hashes(html: str) -> list[str]:
-    """`sha256-…` for every executable inline script, in document order."""
-    html = _COMMENT.sub("", html)
-    out = []
-    for match in _SCRIPT.finditer(html):
-        attrs = match.group("attrs")
-        if _SRC.search(attrs):
-            continue
-        declared = _TYPE.search(attrs)
-        if (declared.group(1).lower() if declared else "") not in _EXECUTABLE_TYPES:
-            continue
-        digest = hashlib.sha256(match.group("body").encode("utf-8")).digest()
-        out.append(f"sha256-{base64.b64encode(digest).decode('ascii')}")
-    return out
 
 
 def csp_directives() -> dict[str, list[str]]:
@@ -129,40 +98,184 @@ def locations_with_add_header() -> list[str]:
     return [b for b in blocks if _ADD_HEADER.search(_without_comments(b))]
 
 
-def recorded_hashes() -> list[str]:
-    """The `sha256-…` values app/security-headers.conf keeps in its comment."""
-    conf = HEADERS_CONF.read_text(encoding="utf-8")
-    comments = "\n".join(line for line in conf.splitlines() if line.lstrip().startswith("#"))
-    return re.findall(r"'(sha256-[A-Za-z0-9+/=]+)'", comments)
+def server_blocks() -> list[str]:
+    """Every `server { … }` block of app/nginx.conf, as raw text."""
+    conf = NGINX_CONF.read_text(encoding="utf-8")
+    blocks = []
+    for match in re.finditer(r"^server\s*\{", conf, re.MULTILINE):
+        depth = 0
+        for i in range(match.end() - 1, len(conf)):
+            if conf[i] == "{":
+                depth += 1
+            elif conf[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(conf[match.start() : i + 1])
+                    break
+    return blocks
 
 
-def test_recorded_hashes_match_the_inline_scripts_of_index_html():
-    """The hashes the conf holds in reserve still describe the scripts they name."""
-    expected = inline_script_hashes(INDEX_HTML.read_text(encoding="utf-8"))
-    assert expected, "app/index.html has no inline scripts — did the extraction break?"
-    assert sorted(recorded_hashes()) == sorted(expected), (
-        "the hashes recorded in app/security-headers.conf and app/index.html's inline "
-        "scripts disagree.\n"
-        f"  recorded: {sorted(recorded_hashes())}\n"
-        f"  computed: {sorted(expected)}\n"
-        "Recompute after ANY edit to an inline <script> — even whitespace."
+# The nonce as the stamp spells it (`nonce="$request_id"`). Its counterpart in
+# the header is read out of the parsed DIRECTIVE, never out of the raw file:
+# security-headers.conf explains itself at length and quotes `'nonce-…'` in its
+# own prose, so a regex over the whole file happily reports a nonce that the
+# policy no longer carries — which is how this very test first passed while the
+# header had none at all.
+_HEADER_NONCE = re.compile(r"^'nonce-(\$[A-Za-z_][A-Za-z0-9_]*)'$")
+_STAMP = re.compile(r"""sub_filter\s+'<script'\s+'<script nonce="(\$[A-Za-z_][A-Za-z0-9_]*)"'\s*;""")
+
+
+def header_nonce_variable() -> str | None:
+    """The nginx variable `script-src` reads its nonce from, if any."""
+    for token in csp_directives().get("script-src", []):
+        match = _HEADER_NONCE.match(token)
+        if match:
+            return match.group(1)
+    return None
+
+
+def test_the_policy_takes_its_nonce_from_a_per_request_variable():
+    """A nonce is only a nonce if it is fresh per response.
+
+    A literal would be a shared secret baked into an image and reused for the
+    lifetime of a revision — which is to say, not a secret. `$request_id` is
+    nginx's own 16 random bytes as 32 hex digits: hex is inside the CSP nonce
+    grammar's charset, and 128 bits is at the ceiling of what the spec asks
+    for.
+    """
+    script_src = csp_directives()["script-src"]
+    nonces = [t for t in script_src if t.startswith("'nonce-")]
+    assert nonces == ["'nonce-$request_id'"], (
+        f"script-src carries {nonces or 'no nonce'}; expected exactly one, "
+        "'nonce-$request_id'. A literal nonce is a constant, and a constant "
+        "nonce is 'unsafe-inline' with extra steps."
+    )
+    assert "'unsafe-inline'" not in script_src, (
+        "script-src still allows 'unsafe-inline'. With a nonce present a browser "
+        "ignores it anyway, so this only misleads the next reader."
     )
 
 
-def test_script_src_never_mixes_unsafe_inline_with_hashes():
+def test_the_header_and_the_stamp_name_the_same_variable():
+    """The one failure with no symptom until every inline script is dead.
+
+    The header promises a nonce; `sub_filter` writes one onto the tags. Nothing
+    connects them but this equality, and if it breaks the page still arrives,
+    still renders its shell, still reports a strict-looking policy — while the
+    browser refuses every script in it.
+    """
+    stamps = _STAMP.findall(NGINX_CONF.read_text(encoding="utf-8"))
+    assert stamps, (
+        "app/nginx.conf stamps no CSP nonce onto <script> tags. The policy's nonce "
+        "makes 'unsafe-inline' inert, so without the stamp NOTHING inline runs."
+    )
+    assert set(stamps) == {header_nonce_variable()}, (
+        f"the stamp writes {sorted(set(stamps))} but script-src reads "
+        f"{header_nonce_variable()!r} — the tags would carry a nonce the policy "
+        "does not allow."
+    )
+
+
+def test_every_server_block_stamps_the_nonce():
+    """Both vhosts, at server level, because four locations serve the shell.
+
+    The exact `= /index.html`, the SPA fallback, and — in the python block —
+    two regex routes whose `try_files /index.html =404` serves the file in
+    place, with no internal redirect to re-run location matching. A stamp
+    placed per-location is a stamp missing from whichever one is forgotten,
+    and it fails on those routes alone.
+    """
+    missing = [
+        block.splitlines()[0]
+        for block in server_blocks()
+        if INCLUDE_LINE in block and not _STAMP.search(_without_comments(block))
+    ]
+    assert not missing, (
+        f"these server blocks send the CSP but never stamp its nonce: {missing}. "
+        "Every <script> tag they serve would be blocked."
+    )
+    assert all("sub_filter_once off;" in block for block in server_blocks() if _STAMP.search(block)), (
+        "sub_filter replaces only the FIRST match without `sub_filter_once off` — "
+        "the shell has seven script tags and six of them would go unstamped."
+    )
+
+
+def test_the_shell_is_never_precompressed():
+    """`gzip_static` hands out the `.gz` untouched, and sub_filter never sees it.
+
+    The prettiest way to break this whole mechanism: leave a build artefact in
+    place. nginx would serve `index.html.gz` byte for byte, the stamp would
+    never run, the header would still carry its nonce, and every inline script
+    on the page would be refused — with nothing in any log to say why.
+    """
+    config = VITE_CONFIG.read_text(encoding="utf-8")
+    calls = re.findall(r"compression\(\{[^}]*\}\)", config)
+    assert calls, "app/vite.config.ts declares no compression plugin — did it move?"
+    unguarded = [c for c in calls if "index" not in c.split("exclude")[-1]]
+    assert not unguarded, (
+        "a compression plugin in app/vite.config.ts does not exclude index.html: "
+        f"{unguarded}. The shell is rewritten per request for the CSP nonce and "
+        "must not exist as a precompressed file."
+    )
+
+
+def test_the_shell_is_never_stored():
+    """A nonced response that can be replayed is a nonced response that fails.
+
+    A stored shell pairs yesterday's `nonce="…"` in the body with today's
+    header — and a 304 revalidation is worse, because HTTP says the 304's
+    headers REPLACE the stored ones, so the browser ends up holding exactly
+    that mismatch. Two things prevent it and only one of them is visible here:
+    `sub_filter` drops `Last-Modified` and `ETag` on its own whenever it
+    rewrites a body (so nothing can be revalidated), and these locations say
+    `no-store` (so nothing is kept to revalidate).
+    """
+    shells = [b for b in locations_with_add_header() if b.lstrip().startswith("location = /index.html")]
+    assert shells, "app/nginx.conf no longer has a `location = /index.html` — where does the shell get its headers?"
+    missing = [b.splitlines()[0].strip() for b in shells if "no-store" not in b]
+    assert not missing, (
+        f"these shell locations do not send `no-store`: {missing}. The shell carries a "
+        "per-request CSP nonce and must not be reusable."
+    )
+
+
+def test_strict_dynamic_needs_the_stamp_to_reach_the_module_preloads():
+    """It reads as the stricter policy and would load the app from nothing.
+
+    `'strict-dynamic'` makes a browser ignore `'self'` for scripts and trust
+    only what an already-trusted script pulls in. `yarn build` links every
+    chunk from the shell with `<link rel="modulepreload">` — a link element,
+    which trust propagation does not cover and which the `<script` stamp does
+    not touch. So adopting the keyword means widening the stamp in the same
+    breath; adopting it alone means the preloads are refused. Absent today, and
+    the reasoning is in security-headers.conf — this only has to hold whoever
+    adds it to the second half.
+    """
+    if "'strict-dynamic'" not in csp_directives()["script-src"]:
+        return
+    conf = _without_comments(NGINX_CONF.read_text(encoding="utf-8"))
+    assert re.search(r"sub_filter\s+'<link", conf), (
+        "script-src carries 'strict-dynamic', which drops 'self' for scripts, but "
+        "app/nginx.conf still stamps only <script> tags. Vite's <link "
+        'rel="modulepreload"> chunk hints would be blocked and the SPA would never '
+        "boot."
+    )
+
+
+def test_script_src_never_mixes_unsafe_inline_with_a_nonce_or_hash():
     """The two together are the trap, not the belt-and-braces pair they look like.
 
     A browser ignores `'unsafe-inline'` as soon as a hash or nonce is present.
-    So a policy carrying both is exactly as strict as the hash list alone —
-    which, while Cloudflare JavaScript Detections injects an unhashable inline
-    script, means the edge's script is blocked while the policy reads as though
-    nothing changed.
+    So a policy carrying both is exactly as strict as the nonce alone, while
+    reading as though it still has a safety net — and the day someone removes
+    the stamp because "'unsafe-inline' is still in there", the whole page goes
+    quiet.
     """
     script_src = csp_directives()["script-src"]
-    has_hash = any(t.startswith("'sha256-") for t in script_src)
-    assert not (has_hash and "'unsafe-inline'" in script_src), (
-        "script-src carries both a hash and 'unsafe-inline'. The browser ignores the "
-        "latter, so this is the hash-only policy with a misleading label. Pick one."
+    keyed = [t for t in script_src if t.startswith(("'sha256-", "'sha384-", "'sha512-", "'nonce-"))]
+    assert not (keyed and "'unsafe-inline'" in script_src), (
+        f"script-src carries both {keyed} and 'unsafe-inline'. The browser ignores the "
+        "latter, so this is the strict policy with a misleading label. Pick one."
     )
 
 

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -170,8 +170,9 @@ def test_the_policy_takes_its_nonce_from_a_per_request_variable():
     A literal would be a shared secret baked into an image and reused for the
     lifetime of a revision — which is to say, not a secret. `$request_id` is
     nginx's own 16 random bytes as 32 hex digits: hex is inside the CSP nonce
-    grammar's charset, and 128 bits is at the ceiling of what the spec asks
-    for.
+    grammar's charset, and 16 bytes meets the at-least-128-bits the spec
+    recommends (a recommendation, not a ceiling and not a requirement — the
+    same wording as security-headers.conf, deliberately).
     """
     script_src = csp_directives()["script-src"]
     nonces = [t for t in script_src if t.startswith("'nonce-")]
@@ -286,11 +287,18 @@ def test_strict_dynamic_would_have_to_widen_the_stamp_to_the_module_preloads():
     only what an already-trusted script pulls in. The entry module is a nonced
     `<script>`, so it and the imports it fetches still run — the casualty is
     narrower and easy to miss: `yarn build` links every chunk from the shell
-    with `<link rel="modulepreload">`, and a link element is neither something
-    trust propagation reaches nor something a `<script`-only stamp touches. The
-    hints are refused, which costs a console full of violations and a slower
-    first paint rather than a blank page (Copilot review corrected an earlier,
-    louder claim here).
+    with `<link rel="modulepreload">`, and a link element is not something trust
+    propagation reaches. The hints are refused, which costs a console full of
+    violations and a slower first paint rather than a blank page (a review
+    corrected an earlier, louder claim here).
+
+    Why the remedy is a WIDER stamp rather than a ban: a preload request carries
+    the link element's nonce as its cryptographic nonce metadata, and a
+    nonce-source in `script-src` matches it. That is not theory — it is why
+    React (#26781), Next.js (#64091), Vite (#9719) and Rails (#53794) all
+    carry the same bug report and the same fix, "put the nonce on the preload
+    link". A later review round suggested the opposite, that a nonce cannot
+    authorize a modulepreload; it can, and the sources are in the PR.
 
     So this is not a ban on the keyword. It is the requirement that whoever
     adopts it widens the stamp in the same change instead of discovering the

--- a/tests/unit/api/test_csp_policy.py
+++ b/tests/unit/api/test_csp_policy.py
@@ -145,6 +145,35 @@ def server_blocks() -> list[str]:
     return blocks
 
 
+def _server_level_of(block: str) -> str:
+    """One server block with every nested `location { … }` cut out.
+
+    What is left is the directives that apply to the whole vhost. A directive
+    found only inside a location governs that location alone, and for the CSP
+    stamp that difference is the whole point — so the search has to be able to
+    tell them apart.
+    """
+    out = []
+    index = 0
+    for match in re.finditer(r"^\s*location\s[^{]*\{", block, re.MULTILINE):
+        if match.start() < index:
+            continue
+        out.append(block[index : match.start()])
+        depth = 0
+        for i in range(match.end() - 1, len(block)):
+            if block[i] == "{":
+                depth += 1
+            elif block[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    index = i + 1
+                    break
+        else:
+            index = len(block)
+    out.append(block[index:])
+    return _without_comments("".join(out))
+
+
 # The nonce as the stamp spells it (`nonce="$request_id"`). Its counterpart in
 # the header is read out of the parsed DIRECTIVE, never out of the raw file:
 # security-headers.conf explains itself at length and quotes `'nonce-…'` in its
@@ -207,25 +236,30 @@ def test_the_header_and_the_stamp_name_the_same_variable():
     )
 
 
-def test_every_server_block_stamps_the_nonce():
-    """Both vhosts, at server level, because four locations serve the shell.
+def test_every_server_block_stamps_the_nonce_at_server_level():
+    """Both vhosts, at SERVER level, because four locations serve the shell.
 
     The exact `= /index.html`, the SPA fallback, and — in the python block —
     two regex routes whose `try_files /index.html =404` serves the file in
     place, with no internal redirect to re-run location matching. A stamp
     placed per-location is a stamp missing from whichever one is forgotten,
-    and it fails on those routes alone.
+    and it fails on those routes alone — which the deploy smoke would not
+    notice either, since it probes `/` on the main host.
+
+    Hence `_server_level_of`: searching the whole block would be satisfied by a
+    stamp buried in one `location`, which is exactly the regression this guard
+    exists to refuse (Copilot review).
     """
+    servers = [(b, _server_level_of(b)) for b in server_blocks()]
     missing = [
-        block.splitlines()[0]
-        for block in server_blocks()
-        if INCLUDE_LINE in block and not _STAMP.search(_without_comments(block))
+        block.strip().splitlines()[0] for block, top in servers if INCLUDE_LINE in block and not _STAMP.search(top)
     ]
     assert not missing, (
-        f"these server blocks send the CSP but never stamp its nonce: {missing}. "
-        "Every <script> tag they serve would be blocked."
+        f"these server blocks do not stamp the CSP nonce at server level: {missing}. "
+        "A stamp inside one location leaves every other route that serves the shell "
+        "unstamped, and each of its <script> tags would be blocked."
     )
-    assert all("sub_filter_once off;" in block for block in server_blocks() if _STAMP.search(block)), (
+    assert all("sub_filter_once off;" in top for _, top in servers if _STAMP.search(top)), (
         "sub_filter replaces only the FIRST match without `sub_filter_once off` — "
         "the shell has seven script tags and six of them would go unstamped."
     )


### PR DESCRIPTION
The open item #11213 left behind, closed the way that PR said it had to be: a nonce, not a hash.

## Why a nonce is the only thing that can work here

`app/index.html` ships three executable inline scripts. A FOURTH arrives after nginx — Cloudflare **JavaScript Detections** injects one into every HTML response at the edge, and its body carries a per-response ray id and timestamp:

```js
window.__CF$cv$params={r:'a35d48a2bdf1be85',t:'MTc4ODUyNzk0NA=='};…
```

A body that differs per response has no hash to list, which is what #11213 measured and why the hash policy was not shipped. Turning JavaScript Detections off is not available either: the Free plan rejects `enable_js=false` while Bot Fight Mode is on.

**Verified against Cloudflare's current docs** ([JavaScript Detections](https://developers.cloudflare.com/bots/additional-configurations/javascript-detections/), read 2026-09-04, and the [bots reference page](https://developers.cloudflare.com/bots/reference/javascript-detections/), last updated 2026-08-26):

> "If your CSP uses a `nonce` for script tags, Cloudflare will add these nonces to the scripts it injects by parsing your CSP response header."

> "We highly discourage the use of `unsafe-inline` and instead recommend the use CSP `nonces` in script tags which we parse and support in our CDN."

Two conditions come with it and both hold here: the nonce must arrive in the **response header** ("JavaScript Detections is not supported with `nonce` set via `<meta>` tags"), and `/cdn-cgi/challenge-platform/` must be reachable — `script-src 'self'` covers it, same-origin. Two side effects the docs name are already true of this setup: JSD strips `ETag` from injected responses (we clear it anyway, below), and it skips injection entirely on `Cache-Control: no-transform`, which we do not send.

## The mechanism

`$request_id` — nginx's own 16 random bytes rendered as 32 hex digits. Hex is a subset of the `base64-value` charset the CSP nonce grammar accepts, and 128 bits is at the ceiling of what the spec asks for.

- **Header** (`app/security-headers.conf`): `script-src 'self' 'nonce-$request_id' https://cdn.jsdelivr.net`. `'unsafe-inline'` is gone, not kept beside it — a browser ignores it the moment a nonce appears, so the pair is the strict policy wearing a permissive label.
- **Stamp** (`app/nginx.conf`): `sub_filter '<script' '<script nonce="$request_id"'` with `sub_filter_once off`, at **server level in both server blocks**. Not per-location, because four locations can end up serving the shell — the exact `= /index.html`, the SPA fallback, and in the `python.anyplot.ai` block two regex routes whose `try_files /index.html =404` serves the file *in place*, with no internal redirect to re-run location matching. A per-location stamp is a stamp missing from whichever one is forgotten, failing on those routes alone.
- **Not precompressed** (`app/vite.config.ts`): `index.html` is excluded from both compression plugins. `gzip_static on` would hand out `index.html.gz` byte for byte and `sub_filter` — which only ever sees uncompressed bodies — would silently skip the stamp while the header still demanded it. The hashed chunks keep their `.gz`/`.br`; the shell is 11 kB and nginx gzips it on the fly.
- **Never replayed**: every location that answers with the shell sends `no-store` — the exact `= /index.html` in each server block *and* the two python-host spec routes, which the review caught serving a nonced shell with no `Cache-Control` at all (see below) — and `sub_filter` clears `Last-Modified` and `ETag` on its own whenever it rewrites a body. Without that, a 304 would replace the stored headers with a fresh nonce while the stored body still carried the old one — the classic nonce-plus-cache failure. Verified below: neither validator is present.

`'strict-dynamic'` is deliberately **not** adopted. The reason is narrower than it first looks, and the review sharpened it: the keyword makes the browser ignore `'self'` for scripts, but the entry module is itself a nonced `<script>`, so it runs and the imports it fetches run with it. What breaks is one layer up — `yarn build` links every chunk from the shell with `<link rel="modulepreload">`, and a link element is neither something trust propagation reaches nor something a `<script`-only stamp touches. Those hints are refused, which costs a console full of violations and a slower first paint, not a blank page. A cost with nothing bought, since the chunks are fingerprinted files under `'self'` already. So the chunks stay on `'self'`, and a test requires the stamp to be widened to `<link>` by whoever adopts the keyword.

## Local verification, behind the real config

nginx 1.24 with `http_sub_module`, running `app/nginx.conf` itself (only the include path, docroot and port rewritten) over a real `yarn build`:

```
req1 header nonce: nonce-0dc9d1209b7ed536aca2366495392bf0
req2 header nonce: nonce-c608aa902ce6cbe622e659f901c6f326   ← different per request

script tags total: 7, without a nonce: 0
distinct nonces in one response: 1; length: 32
header nonce == tag nonce:  MATCH

stamped tags, SPA fallback deep route: 7
stamped tags, exact /index.html:       7
stamped tags, vhost spec route:        7    ← the try_files-in-place path
stamped tags, vhost spec/library:      7
stamped tags, vhost reserved route:    7

/assets/index-*.js  content-encoding: gzip, nonce occurrences: 0   ← precompressed, untouched
shell with Accept-Encoding: gzip → still 7 stamped tags
etag/last-modified present: 0
index.html.gz / index.html.br in dist: absent; assets/*.gz: present
```

`sub_filter` comes from `ngx_http_sub_module`, which is not compiled in by default, so it is worth having checked rather than assumed: `nginxinc/nginx-unprivileged:alpine` installs the prebuilt nginx package from nginx.org's Alpine repository, and that binary's own configure line carries `--with-http_sub_module` (unpacked `nginx-1.31.5-r1.apk` and read the string out of `usr/sbin/nginx`). Had it been missing, nginx would have refused to start on "unknown directive" — caught by the candidate, but only there.

The one cosmetic finding on the way: `sub_filter` is a literal string match, so the HTML comment that documented the Eruda loader with the words `Plain <script>` came back carrying a stray `nonce=` inside a comment. Harmless, but confusing in exactly the artefact anyone debugging CSP reads, so the comment now describes the tag instead of spelling it.

## Guards, so this cannot rot quietly

`tests/unit/api/test_csp_policy.py` — the hash test is retired with the hashes (they guarded a reserve that no longer exists), and six checks take its place. Every one was **mutation-checked**: each mutation below was applied to a copy and the named test was confirmed to fail.

| Mutation | Caught by |
|---|---|
| stamp renamed to `$connection` | `test_the_header_and_the_stamp_name_the_same_variable` |
| `sub_filter` removed from the python server block | `test_every_server_block_stamps_the_nonce` |
| `sub_filter_once off` dropped | same |
| the vite `exclude` removed | `test_the_shell_is_never_precompressed` |
| `'unsafe-inline'` put back beside the nonce | `test_script_src_never_mixes_unsafe_inline_with_a_nonce_or_hash` |
| nonce frozen to a literal | `test_the_policy_takes_its_nonce_from_a_per_request_variable` |
| nonce dropped from the header | that one **and** the same-variable test |
| `'strict-dynamic'` added without widening the stamp | `test_strict_dynamic_would_have_to_widen_the_stamp_to_the_module_preloads` |
| `no-store` removed from the exact `= /index.html` | `test_the_shell_is_never_stored` |
| `no-store` removed from ONE python-host spec route | same |
| a python-host spec route reverted to a bare `try_files` | same |

That exercise found a real defect in the first draft: `header_nonce_variable()` read the nonce with a regex over the whole conf file, and `security-headers.conf` quotes `'nonce-…'` in its own prose — so with the nonce deleted from the actual directive the test still "found" one and passed. It now reads the parsed directive.

**And the deploy smoke refuses to promote without it.** `app/cloudbuild.yaml` now fetches the candidate's shell, pulls the nonce out of its `Content-Security-Policy` header, and requires that **every** `<script>` tag carries that exact value. This is the failure with no other symptom: the page still arrives, still has its `<div id="root">`, still passes every existing probe — and runs no inline script at all.

That probe was run four ways against local nginx, using the step's own bash with Cloud Build's `$$` resolved. Against the config in this PR:

```
OK: all 7 script tags of the shell carry the header's nonce      exit 0
```

against the same config with the two `sub_filter` directives deleted:

```
0 of 7 <script> tag(s) carry the header's nonce-0cfb5ee4…        exit 1
```

against a config that stamps a *different* variable than the header — the case review round one showed the probe waving through, because it counted `nonce=` attributes instead of comparing them:

```
0 of 7 <script> tag(s) carry the header's nonce-2a28032d…        exit 1
```

and with an `index.html.gz` planted back into the docroot, which is round two's finding and the one that mattered most: plain `curl` sends no `Accept-Encoding`, so `gzip_static` never reaches for the `.gz` and the probe was blind to the exact regression it exists for.

```
plain curl         7 stamped tags   → passed
curl --compressed  0 stamped tags   → what a browser gets
```

With `--compressed` on that fetch it fails on the planted file (`0 of 7 … nonce-ffb48a58…`, exit 1) and passes once the `.gz` is gone.

## Rollback

Under a minute, no rebuild, back to today's policy byte for byte:

```bash
gcloud run revisions list --service anyplot-app --region europe-west4 \
  --format='table(name, creationTimestamp, status.conditions[0].status)' --limit 10

gcloud run services update-traffic anyplot-app --region europe-west4 \
  --to-revisions=<chosen-revision>=100
```

Pick the target by creation time, not by position — "the previous revision" is the pre-nonce one only until the next frontend deploy, which the review flagged. Once no pre-nonce revision is left, the lever is a revert PR through the normal pipeline; acceptable, because by then the live question has long been answered. Written down in `agentic/docs/project-guide.md` § Rollback and, in short form, at the directive it protects in `app/security-headers.conf`.

**A Cloud Run env var switch was considered and deliberately not built**, and that is a deviation from the brief worth stating plainly. nginx cannot read the process environment from its configuration, so an env-var switch needs a startup templating step — `envsubst` into a writable path, and `/etc/nginx` is read-only in `nginxinc/nginx-unprivileged` (checked: no `chown`/`chmod g+w` on it, final `USER 101`), so the image's own `NGINX_ENVSUBST_OUTPUT_DIR` mechanism bails out with "not writable" and renders nothing. The alternative is a hand-rolled entrypoint writing config into `/tmp`. Either way its failure mode is "the container does not start", and there is no Docker in this environment and no CI job that builds this image, so nothing could exercise it before it mattered. The traffic split has the same latency, needs no new machinery, and the deploy pipeline proves the previous revision healthy on every build.

## What must still be measured in production, and what it would mean

Whether Cloudflare actually stamps the nonce is not observable from here — it depends on the CSP header the **edge** sees from the origin, so a local proxy cannot fake it. After merge and deploy, on `https://anyplot.ai` in a real browser: the JSD script present and carrying the nonce, zero CSP violations on the landing page and a plot page, Plausible events still firing, Bot Fight Mode still active.

One thing to look for specifically. The injected script creates a hidden `about:blank` iframe and inserts a second inline script *into that document*:

```js
var d=b.createElement('script');
d.innerHTML="window.__CF$cv$params={…};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';…";
```

An `about:blank` document inherits its embedder's CSP, so that inner script needs the nonce too — and there is an [open Cloudflare community report](https://community.cloudflare.com/t/javascript-detections-jsd-api-js-creates-srcdoc-iframe-without-csp-nonce-violat/920831) that JSD does not propagate the nonce into that frame. If the outer script is nonced and only the inner one is refused, that is an upstream gap in a defence-in-depth signal and not a site regression; if the outer script is refused too, Cloudflare is not honouring the nonce at all, and the rollback above is the answer.

## Review rounds

Six rounds. Twelve findings taken, one rejected with sources, the last round clean (0 comments, 0 open threads).

- **Round 1** (5): the `no-store` gap below; the smoke counting `nonce=` instead of comparing it; the rollback's positional "previous revision"; `anyplot-backend` → `anyplot-api`; and the 128-bit overstatement.
- **Round 2** (2): the deploy probe did not ask for compression, so `gzip_static` never reached for a `.gz` and it could not see the precompressed-shell regression it exists for — the sharpest catch of the six, reproduced above. Plus the rollback as a numbered procedure per the repository's Google style.
- **Round 3** (1 taken, 1 rejected): the entropy wording repeated in the test. Rejected, with sources: that a nonce cannot authorize a `<link rel="modulepreload">` — see the comment thread; four frameworks ship precisely that fix.
- **Round 4** (2): `nonce-[0-9a-f]*` accepted a bare `nonce-` that `test -n` calls non-empty, so an empty nonce would have agreed with `nonce=""` tags all the way through; and the precompression guard now RUNS the declared pattern against `index.html` instead of reading it for the word "index", after three near-misses in two rounds showed the reading approach was the wrong shape.
- **Round 5** (2): `test_every_server_block_stamps_the_nonce` searched the whole block, nested locations included — so moving the stamp into `location = /index.html` would have satisfied the guard that exists to refuse exactly that, and the smoke wouldn't have caught it either since it probes `/` on the main host. It now cuts nested locations out first. Plus "two extra curls" where the probe adds one.
- **Round 6**: clean.

The one worth naming in full is round one's, a genuine hole the local probes had walked straight past: `python.anyplot.ai/<spec>` and `/<spec>/<library>` serve the shell through `try_files /index.html =404`, which treats the shell as a FILE and answers **inside that location** — no internal redirect, so `location = /index.html` and its `no-store` are never reached. Measured before the fix:

```
$ curl -sI -H "Host: python.anyplot.ai" .../scatter-basic | grep -i cache-control
(nothing)
$ curl -sI .../scatter-basic | grep -i cache-control
Cache-Control: no-cache, no-store, must-revalidate
```

A nonced shell a client may keep. Both routes now send the shell's `Cache-Control` and re-include `security-headers.conf` beside it (an `add_header` of their own would otherwise have dropped the entire inherited set — verified CSP, HSTS and X-Frame-Options are still on those responses). And the test no longer looks for `location = /index.html` by name: it derives the shell locations from the `try_files` argument positions, finds all four, and fails if any one loses `no-store`.

Verification: `pytest tests/unit tests/integration` — 1974 passed. `ruff check`, `ruff format --check`, `mypy api core` clean. `yarn type-check`, `yarn lint`, `yarn fm:check` clean, `yarn test` — 626 passed in 70 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEScQMZFvxxNNyNJYryfa3
