### PR TITLE
docs(cloudflare): fix Worker deploy filename and stale redeploy callout

### DIFF
--- a/changelog.d/cloudflare-worker-deploy-filename.md
+++ b/changelog.d/cloudflare-worker-deploy-filename.md
@@ -8,10 +8,10 @@
   metadata's `main_module: "worker.js"` against that filename, not the form
   field — so the API answered `400 — Uncaught Error: No such module:
   worker.js` (observed live 2026-09-04). The example now sets
-  `filename=worker.js` explicitly, with a sentence explaining why.
+  `filename=worker.js` explicitly, with a sentence explaining why. (#11222)
 
 - **The README's "needs a redeploy" callout is replaced with the deployed
   state.** The Worker was redeployed from the current `.js` after #11221, the
   Transform Rule now covers `anyplot.ai`, `www.anyplot.ai` and
   `api.anyplot.ai`, and `/api/event` measured `off-seen` — the callout named a
-  pending step that had already happened.
+  pending step that had already happened. (#11222)

--- a/changelog.d/cloudflare-worker-deploy-filename.md
+++ b/changelog.d/cloudflare-worker-deploy-filename.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The Worker deploy recipe now uploads a module Cloudflare can find.**
+  `infra/cloudflare/README.md`'s `curl` example named the multipart part
+  `worker.js=@infra/cloudflare/anyplot-api-proxy.js;type=application/javascript+module`,
+  but curl defaults the part's `filename` to the local file's basename
+  (`anyplot-api-proxy.js`) unless told otherwise, and Cloudflare resolves the
+  metadata's `main_module: "worker.js"` against that filename, not the form
+  field — so the API answered `400 — Uncaught Error: No such module:
+  worker.js` (observed live 2026-09-04). The example now sets
+  `filename=worker.js` explicitly, with a sentence explaining why.
+
+- **The README's "needs a redeploy" callout is replaced with the deployed
+  state.** The Worker was redeployed from the current `.js` after #11221, the
+  Transform Rule now covers `anyplot.ai`, `www.anyplot.ai` and
+  `api.anyplot.ai`, and `/api/event` measured `off-seen` — the callout named a
+  pending step that had already happened.

--- a/changelog.d/cloudflare-worker-deploy-filename.md
+++ b/changelog.d/cloudflare-worker-deploy-filename.md
@@ -12,6 +12,6 @@
 
 - **The README's "needs a redeploy" callout is replaced with the deployed
   state.** The Worker was redeployed from the current `.js` after #11221, the
-  Transform Rule now covers `anyplot.ai`, `www.anyplot.ai` and
+  Transform Rule now covers `anyplot.ai`, `www.anyplot.ai`, and
   `api.anyplot.ai`, and `/api/event` measured `off-seen` — the callout named a
   pending step that had already happened. (#11222)

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -22,7 +22,7 @@ it in the dashboard and pull it back here.
 
 > **Deployed state (2026-09-04).** The Worker was redeployed from the current
 > `.js` after #11221; the Transform Rule now covers `anyplot.ai`,
-> `www.anyplot.ai` and `api.anyplot.ai`, and `/api/event` measured `off-seen`.
+> `www.anyplot.ai`, and `api.anyplot.ai`, and `/api/event` measured `off-seen`.
 > The standing rule still holds: the `.js` here mirrors the deployed bytes, so
 > the next edit to it needs its own redeploy.
 

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -20,12 +20,11 @@ verdicts, and one rollout procedure — the API's is done, the app's is
 **The `.js` is the source, not a draft.** Change it here and deploy it; change
 it in the dashboard and pull it back here.
 
-> **After this lands, the Worker needs a redeploy.** The
-> `X-Origin-Secret` lines are newer than the running script, so the repository
-> and the deployment are out of step until it is pushed. Until then the Worker
-> stamps nothing, `anyplot.ai/api/health` answers `off`, and arming the gate
-> would take that route down — which is exactly what the rollout order in the
-> pull-request description prevents.
+> **Deployed state (2026-09-04).** The Worker was redeployed from the current
+> `.js` after #11221; the Transform Rule now covers `anyplot.ai`,
+> `www.anyplot.ai` and `api.anyplot.ai`, and `/api/event` measured `off-seen`.
+> The standing rule still holds: the `.js` here mirrors the deployed bytes, so
+> the next edit to it needs its own redeploy.
 
 ## The Worker
 
@@ -131,9 +130,16 @@ json.dump({
     "https://api.cloudflare.com/client/v4/accounts/{account}/workers/scripts/anyplot-api-proxy" \
     --config <(printf 'header = "Authorization: Bearer %s"\n' "$CF_API_TOKEN") \
     -F 'metadata=<-;type=application/json' \
-    -F 'worker.js=@infra/cloudflare/anyplot-api-proxy.js;type=application/javascript+module'
+    -F 'worker.js=@infra/cloudflare/anyplot-api-proxy.js;filename=worker.js;type=application/javascript+module'
 )
 ```
+
+**The explicit `filename=worker.js` is required.** Cloudflare resolves the
+`main_module` named in the metadata (`worker.js`) against each part's
+*filename*, not its form-field name; curl otherwise defaults the filename to
+the local file's basename (`anyplot-api-proxy.js`), which does not match, and
+the API answers `400 — Uncaught Error: No such module: worker.js` (observed
+live 2026-09-04).
 
 `pipefail` so a failing `python3` cannot be masked by a succeeding `curl`;
 `--fail-with-body` so an HTTP error is a non-zero exit and still prints


### PR DESCRIPTION
## Summary
- Fix the scripted Worker deploy recipe in `infra/cloudflare/README.md`: the multipart `curl` example uploaded the module under curl's default filename (the local basename `anyplot-api-proxy.js`), which Cloudflare's `main_module: "worker.js"` never matches, so a scripted deploy answered `400 — Uncaught Error: No such module: worker.js` (observed live 2026-09-04). Add the explicit `filename=worker.js` override plus a sentence explaining why Cloudflare needs it.
- Replace the stale "After this lands, the Worker needs a redeploy" callout with a "Deployed state (2026-09-04)" note: the Worker was redeployed from the current `.js` after #11221, the Transform Rule now covers `anyplot.ai`, `www.anyplot.ai` and `api.anyplot.ai`, and `/api/event` measured `off-seen`. The standing rule (the `.js` mirrors the deployed bytes) is kept.

## Plan
N/A — docs-only fix, no spec/plan file.

## Test plan
- [x] Read the full corrected recipe and callout in `infra/cloudflare/README.md` to confirm the `filename=worker.js` attribute and the new deployed-state note read correctly in context.
- [x] `uv run python -m tools.changelog check --base origin/main` passes with the new fragment.
- [ ] No live redeploy performed by this PR (docs-only); a future scripted deploy is the real-world verification of the fixed recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEScQMZFvxxNNyNJYryfa3